### PR TITLE
Borrow pip from host python if available

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.tox
+.*_cache
+*.egg-info
+Dockerfile
+build
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ coverage.xml
 tests/integration/
 .integration-sources
 .tox
+Dockerfile

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     toml
     importlib-metadata;python_version < "3.8"
     typing;python_version<"3"
-    virtualenv;python_version < "3" and platform_python_implementation == 'PyPy'
+    virtualenv>=20.0.35;python_version < "3"
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 package_dir =
     =src

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     toml
     importlib-metadata;python_version < "3.8"
     typing;python_version<"3"
+    virtualenv;python_version < "3" and platform_python_implementation == 'PyPy'
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 package_dir =
     =src

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -8,8 +8,8 @@ import warnings
 
 from typing import List, Optional, TextIO, Type
 
-from . import BuildBackendException, BuildException, ConfigSettings, ProjectBuilder
-from .env import IsolatedEnvironment
+from build import BuildBackendException, BuildException, ConfigSettings, ProjectBuilder
+from build.env import IsolatedEnvironment
 
 
 __all__ = ['build', 'main', 'main_parser']

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -232,7 +232,13 @@ class IsolatedEnvironment(object):
     def _create_isolated_env(self):  # type: () -> None
         is_py2 = sys.version_info[0] == 2
         if is_py2:
-            self._create_env_pythonhome()
+            if platform.python_implementation() == 'PyPy':
+                from virtualenv import cli_run
+
+                result = cli_run([str(self.path), '--without-pip', '--activators', ''])
+                self._executable = str(result.creator.exe)
+            else:
+                self._create_env_pythonhome()
         else:
             self._create_env_venv()
 

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -6,7 +6,8 @@ import sys
 import sysconfig
 import tempfile
 import types
-from typing import Dict, Iterable, List, Optional, Sequence, Type, cast
+import typing
+from typing import Dict, Iterable, List, Optional, Sequence, Type
 
 if sys.version_info[0] == 2:
     FileExistsError = OSError
@@ -223,7 +224,7 @@ class IsolatedEnvironment(object):
             req_file.write(os.linesep.join(requirements))
             req_file.close()
             cmd = [
-                cast(str, self._pip_executable),
+                typing.cast(str, self._pip_executable),
                 # on python2 if isolation is achieved via environment variables, we need to ignore those while calling
                 # host python (otherwise pip would not be available within it)
                 '-{}m'.format('E' if self._pip_executable == self._executable and sys.version_info[0] == 2 else ''),

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -285,14 +285,15 @@ class IsolatedEnvironment(object):
             req_file.close()
             cmd = [
                 cast(str, self._pip_executable),
-                '-m',
+                # on python2 if isolation is achieved via environment variables, we need to ignore those while calling
+                # host python (otherwise pip would not be available within it)
+                '-{}m'.format('E' if self._pip_executable == self._executable and sys.version_info[0] == 2 else ''),
                 'pip',
                 'install',
                 '--prefix',
                 self.path,
                 '--ignore-installed',
                 '--no-warn-script-location',
-                '--disable-pip-version-check',
                 '-r',
                 os.path.abspath(req_file.name),
             ]

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -176,11 +176,6 @@ class IsolatedEnvironment(object):
         if env_scripts is None:  # pragma: no cover
             raise RuntimeError('Missing scripts directory in sysconfig')
 
-        exe_path = [env_scripts]
-        if 'PATH' in os.environ:
-            exe_path.append(os.environ['PATH'])
-
-        self._replace_env('PATH', os.pathsep.join(exe_path))
         self._replace_env('PYTHONPATH', os.pathsep.join(sys_path))
 
         # Point the Python interpreter to our environment

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,8 @@ _setup()
 
 
 def pytest_addoption(parser):
+    os.environ['PYTHONWARNINGS'] = 'ignore:DEPRECATION::pip._internal.cli.base_command'  # for when not run within tox
+    os.environ['PIP_DISABLE_PIP_VERSION_CHECK'] = '1'  # do not pollute stderr with upgrade advisory
     parser.addoption('--run-integration', action='store_true', help='run the integration tests')
     parser.addoption('--only-integration', action='store_true', help='only run the integration tests')
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -87,14 +87,13 @@ def test_isolated_environment_install(mocker):
         args = subprocess.check_call.call_args[0][0][:-1]
         assert args == [
             env._pip_executable,
-            '-m',
+            '-{}m'.format('E' if env._pip_executable == env._executable and sys.version_info[0] == 2 else ''),
             'pip',
             'install',
             '--prefix',
             env.path,
             '--ignore-installed',
             '--no-warn-script-location',
-            '--disable-pip-version-check',
             '-r',
         ]
 
@@ -108,7 +107,7 @@ def test_uninitialised_isolated_environment():
 
 def test_create_isolated_build_host_with_no_pip(tmp_path, capfd, mocker):
     mocker.patch.object(build.env, 'pip', None)
-    expected = {'pip', 'greenlet', 'readline', 'cffi'} if platform.python_implementation() == "PyPy" else {'pip'}
+    expected = {'pip', 'greenlet', 'readline', 'cffi'} if platform.python_implementation() == 'PyPy' else {'pip'}
 
     with build.env.IsolatedEnvironment.for_current() as isolated_env:
         cmd = [isolated_env.executable, '-m', 'pip', 'list', '--format', 'json']

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -14,10 +14,7 @@ import build.env
 
 @pytest.mark.skipif(sys.version_info[0] != 2, reason='Custom isolated environment only available on Python 2')
 def test_isolated_environment_setup():
-    old_path = os.environ['PATH']
     with build.env.IsolatedEnvironment.for_current() as env:
-        if os.name != 'nt':
-            assert os.environ['PATH'] == os.pathsep.join([os.path.join(env.path, 'bin'), old_path])
         assert os.environ['PYTHONHOME'] == env.path
 
         python_path = map(os.path.normpath, os.environ['PYTHONPATH'].split(os.pathsep))

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -56,10 +56,6 @@ def test_isolated_environment_setup():
             assert os.path.exists(path)
 
 
-@pytest.mark.skipif(
-    platform.python_implementation() == 'PyPy' and sys.version_info[0] == 2,
-    reason='PyPy 2 does not honor PYTHONHOME - switch to virtualenv',
-)
 @pytest.mark.isolated
 def test_isolation():
     subprocess.check_call([sys.executable, '-c', 'import build.env'])

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
     fix
-    {py39, py38, py37, py36, py35, py27, pypy3, pypy2}{, -path, -sdist, -wheel}
     type
     docs
+    {py39, py38, py37, py36, py35, py27, pypy3, pypy2}{, -path, -sdist, -wheel}
 isolated_build = true
 skip_missing_interpreters = true
 minversion = 3.14
@@ -16,17 +16,17 @@ description =
     path: via PYTHONPATH
     sdist: via source distribution
     wheel: via wheel
+passenv =
+    LC_ALL
+    PIP_*
+    PYTEST_*
 setenv =
-    COVERAGE_FILE = {envtmpdir}/.coverage
-    {py27,pypy2}: PYTHONWARNINGS = ignore:DEPRECATION::pip._internal.cli.base_command
+    COVERAGE_FILE = {toxworkdir}/.coverage.{envname}
     path: TEST_MODE = path
     sdist: TEST_MODE = sdist
     wheel: TEST_MODE = wheel
-passenv =
-    PYTEST_*
-    PIP_*
-    LC_ALL
-skip_install = path,sdist,wheel: false
+    {py27,pypy2}: PYTHONWARNINGS = ignore:DEPRECATION::pip._internal.cli.base_command
+skip_install = false
 deps =
     path,sdist,wheel: -rrequirements-dev.txt
 extras =
@@ -66,3 +66,34 @@ deps =
 commands =
     sphinx-build -n -W docs/source {envtmpdir}
     python -c 'print("Documentation available under file://{envtmpdir}/index.html")'
+
+[testenv:dev]
+description = generate a DEV environment
+usedevelop = true
+deps =
+    virtualenv>=20.0.34
+extras =
+    doc
+    test
+commands =
+    python -m pip list --format=columns
+    python -c 'import sys; print(sys.executable)'
+
+[testenv:coverage]
+description = combine coverage from test environments
+passenv =
+    DIFF_AGAINST
+setenv =
+    COVERAGE_FILE = {toxworkdir}/.coverage
+skip_install = true
+deps =
+    coverage>=5.1
+    diff_cover>=3
+parallel_show_output = true
+commands =
+    coverage combine
+    coverage report --skip-covered --show-missing -i
+    coverage xml -o {toxworkdir}/coverage.xml -i
+    coverage html -d {toxworkdir}/htmlcov -i
+    python -m diff_cover.diff_cover_tool --compare-branch {env:DIFF_AGAINST:origin/main} {toxworkdir}/coverage.xml
+depends = {py39, py38, py37, py36, py35, py27, pypy3, pypy2}{, -path, -sdist, -wheel}

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ description =
     wheel: via wheel
 setenv =
     COVERAGE_FILE = {envtmpdir}/.coverage
-    {py27, pypy2}: PYTHONWARNINGS = ignore:DEPRECATION::pip._internal.cli.base_command
+    {py27,pypy2}: PYTHONWARNINGS = ignore:DEPRECATION::pip._internal.cli.base_command
     path: TEST_MODE = path
     sdist: TEST_MODE = sdist
     wheel: TEST_MODE = wheel

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ setenv =
 passenv =
     PYTEST_*
     PIP_*
+    LC_ALL
 skip_install = path,sdist,wheel: false
 deps =
     path,sdist,wheel: -rrequirements-dev.txt


### PR DESCRIPTION
Instead of provisioning via ensurepip. This speeds up isolated build environment creation.

While implementing this I had to also address https://github.com/pypa/build/issues/120 to make the CI pass. They're separate commits though. 

Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>