### PR TITLE
Refactor to simplify the env package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -78,6 +78,12 @@ omit =
     *bin/pyproject-build
     *bin\pyproject-build.exe
 
+[coverage:report]
+exclude_lines =
+    \#\s*pragma: no cover
+    ^\s*raise NotImplementedError\b
+    ^if __name__ == ['"]__main__['"]:$
+
 [coverage:paths]
 source =
     src

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,9 @@ test =
     pytest
     pytest-cov
     pytest-mock
+typing =
+    mypy==0.790
+    typing-extensions>=3.7.4.3
 
 [options.packages.find]
 where = src
@@ -82,7 +85,6 @@ omit =
 exclude_lines =
     \#\s*pragma: no cover
     ^\s*raise NotImplementedError\b
-    ^if __name__ == ['"]__main__['"]:$
 
 [coverage:paths]
 source =

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ project_urls =
 packages = find:
 install_requires =
     packaging
-    pep517
+    pep517>=0.9.1
     toml
     importlib-metadata;python_version < "3.8"
     typing;python_version<"3"

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -117,6 +117,7 @@ def _working_directory(path):  # type: (str) -> Iterator[None]
 
 class ProjectBuilder(object):
     def __init__(self, srcdir='.', config_settings=None, python_executable=sys.executable):
+        # type: (str, Optional[ConfigSettings], str) -> None
         """
         Create a project builder.
 
@@ -124,7 +125,6 @@ class ProjectBuilder(object):
         :param config_settings: config settings for the build backend
         :param python_executable: the python executable where the backend lives
         """
-        # type: (str, Optional[ConfigSettings], str) -> None
         self.srcdir = os.path.abspath(srcdir)
         self.config_settings = config_settings if config_settings else {}
 

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -116,11 +116,15 @@ def _working_directory(path):  # type: (str) -> Iterator[None]
 
 
 class ProjectBuilder(object):
-    def __init__(self, srcdir='.', config_settings=None, executable=sys.executable):
+    def __init__(self, srcdir='.', config_settings=None, python_executable=sys.executable):
+        """
+        Create a project builder.
+
+        :param srcdir: the source directory
+        :param config_settings: config settings for the build backend
+        :param python_executable: the python executable where the backend lives
+        """
         # type: (str, Optional[ConfigSettings], str) -> None
-        """
-        :param srcdir: Source directory
-        """
         self.srcdir = os.path.abspath(srcdir)
         self.config_settings = config_settings if config_settings else {}
 
@@ -151,7 +155,10 @@ class ProjectBuilder(object):
         self._backend = self._build_system['build-backend']
 
         self.hook = pep517.wrappers.Pep517HookCaller(
-            self.srcdir, self._backend, backend_path=self._build_system.get('backend-path'), python_executable=executable
+            self.srcdir,
+            self._backend,
+            backend_path=self._build_system.get('backend-path'),
+            python_executable=python_executable,
         )
 
     @property
@@ -189,7 +196,6 @@ class ProjectBuilder(object):
 
         :param distribution: Distribution to build (sdist or wheel)
         :param outdir: Output directory
-        :param executable: executable
         """
         build = getattr(self.hook, 'build_{}'.format(distribution))
         outdir = os.path.abspath(outdir)

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -10,13 +10,11 @@ import difflib
 import os
 import sys
 import warnings
-
 from typing import Dict, Iterator, List, Mapping, Optional, Set, Union
 
 import pep517.wrappers
 import toml
 import toml.decoder
-
 
 if sys.version_info < (3,):
     FileNotFoundError = IOError
@@ -118,7 +116,8 @@ def _working_directory(path):  # type: (str) -> Iterator[None]
 
 
 class ProjectBuilder(object):
-    def __init__(self, srcdir='.', config_settings=None):  # type: (str, Optional[ConfigSettings]) -> None
+    def __init__(self, srcdir='.', config_settings=None, executable=sys.executable):
+        # type: (str, Optional[ConfigSettings], str) -> None
         """
         :param srcdir: Source directory
         """
@@ -152,7 +151,7 @@ class ProjectBuilder(object):
         self._backend = self._build_system['build-backend']
 
         self.hook = pep517.wrappers.Pep517HookCaller(
-            self.srcdir, self._backend, backend_path=self._build_system.get('backend-path')
+            self.srcdir, self._backend, backend_path=self._build_system.get('backend-path'), python_executable=executable
         )
 
     @property
@@ -190,6 +189,7 @@ class ProjectBuilder(object):
 
         :param distribution: Distribution to build (sdist or wheel)
         :param outdir: Output directory
+        :param executable: executable
         """
         build = getattr(self.hook, 'build_{}'.format(distribution))
         outdir = os.path.abspath(outdir)

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -9,7 +9,7 @@ import warnings
 from typing import List, Optional, TextIO, Type, Union
 
 from build import BuildBackendException, BuildException, ConfigSettings, ProjectBuilder
-from build.env import IsolatedEnvironment
+from build.env import IsolatedEnvBuilder
 
 __all__ = ['build', 'main', 'main_parser']
 
@@ -41,7 +41,7 @@ def _error(msg, code=1):  # type: (str, int) -> None  # pragma: no cover
 
 def _build_in_isolated_env(builder, outdir, distributions):
     # type: (ProjectBuilder, str, List[str]) -> None
-    with IsolatedEnvironment.for_current() as env:
+    with IsolatedEnvBuilder() as env:
         builder.hook.python_executable = env.executable
         env.install(builder.build_dependencies)
         for distribution in distributions:

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -9,8 +9,7 @@ import warnings
 from typing import List, Optional, TextIO, Type, Union
 
 from build import BuildBackendException, BuildException, ConfigSettings, ProjectBuilder
-from build.env import isolated_env
-
+from build.env import IsolatedEnvironment
 
 __all__ = ['build', 'main', 'main_parser']
 
@@ -40,8 +39,10 @@ def _error(msg, code=1):  # type: (str, int) -> None  # pragma: no cover
     exit(code)
 
 
-def _build_in_isolated_env(builder, outdir, distributions):  # type: (ProjectBuilder, str, List[str]) -> None
-    with isolated_env() as env:
+def _build_in_isolated_env(builder, outdir, distributions):
+    # type: (ProjectBuilder, str, List[str]) -> None
+    with IsolatedEnvironment.for_current() as env:
+        builder.hook.python_executable = env.executable
         env.install(builder.build_dependencies)
         for distribution in distributions:
             builder.build(distribution, outdir)
@@ -75,7 +76,6 @@ def build(srcdir, outdir, distributions, config_settings=None, isolation=True, s
 
     try:
         builder = ProjectBuilder(srcdir, config_settings)
-
         if isolation:
             _build_in_isolated_env(builder, outdir, distributions)
         else:

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -9,7 +9,7 @@ import warnings
 from typing import List, Optional, TextIO, Type, Union
 
 from build import BuildBackendException, BuildException, ConfigSettings, ProjectBuilder
-from build.env import IsolatedEnvironment
+from build.env import isolated_env
 
 
 __all__ = ['build', 'main', 'main_parser']
@@ -41,7 +41,7 @@ def _error(msg, code=1):  # type: (str, int) -> None  # pragma: no cover
 
 
 def _build_in_isolated_env(builder, outdir, distributions):  # type: (ProjectBuilder, str, List[str]) -> None
-    with IsolatedEnvironment.for_current() as env:
+    with isolated_env() as env:
         env.install(builder.build_dependencies)
         for distribution in distributions:
             builder.build(distribution, outdir)

--- a/src/build/_compat.py
+++ b/src/build/_compat.py
@@ -1,0 +1,42 @@
+import abc
+import sys
+from typing import Callable, TypeVar
+
+_T = TypeVar('_T')
+
+
+def add_metaclass(metaclass):  # type: (type) -> Callable[[_T], _T]
+    """Class decorator for creating a class with a metaclass (borrowed from six code)."""
+
+    def wrapper(cls):  # type: (_T) -> _T
+        orig_vars = cls.__dict__.copy()
+        slots = orig_vars.get('__slots__')
+        if slots is not None:
+            if isinstance(slots, str):  # pragma: no cover
+                slots = [slots]  # pragma: no cover
+            for slots_var in slots:  # pragma: no cover
+                orig_vars.pop(slots_var)  # pragma: no cover
+        orig_vars.pop('__dict__', None)
+        orig_vars.pop('__weakref__', None)
+        if hasattr(cls, '__qualname__'):
+            orig_vars['__qualname__'] = cls.__qualname__  # type: ignore
+        return metaclass(cls.__name__, cls.__bases__, orig_vars)  # type: ignore
+
+    return wrapper
+
+
+if sys.version_info[0] == 2:
+    abstractproperty = abc.abstractproperty
+else:
+    from typing import Any, cast
+
+    F = TypeVar('F', bound=Callable[..., Any])
+
+    def abstractproperty(func):  # type: (F) -> F
+        return cast(F, property(abc.abstractmethod(func)))
+
+
+__all__ = (
+    'abstractproperty',
+    'add_metaclass',
+)

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -12,20 +12,19 @@ import tempfile
 from types import TracebackType
 from typing import Iterable, Optional, Tuple, Type
 
+from ._compat import abstractproperty, add_metaclass
+
 try:
     import pip
 except ImportError:  # pragma: no cover
     pip = None  # pragma: no cover
 
 
-ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()})  # Python 2/3 compatible ABC
-
-
-class IsolatedEnvironment(ABC):
+@add_metaclass(abc.ABCMeta)
+class IsolatedEnv(object):
     """Abstract base of isolated build environments, as required by the build project."""
 
-    @property
-    @abc.abstractmethod
+    @abstractproperty
     def executable(self):  # type: () -> str
         """Return the executable of the isolated build environment."""
         raise NotImplementedError
@@ -41,11 +40,11 @@ class IsolatedEnvironment(ABC):
 
 
 class IsolatedEnvBuilder(object):
-    def __init__(self):
+    def __init__(self):  # type: () -> None
         """Builder object for isolated environment."""
         self._path = None  # type: Optional[str]
 
-    def __enter__(self):  # type: () -> IsolatedEnvironment
+    def __enter__(self):  # type: () -> IsolatedEnv
         """
         Creates an isolated build environment.
 
@@ -55,7 +54,7 @@ class IsolatedEnvBuilder(object):
         try:
             executable, pip_executable = _create_isolated_env(self._path)
             return _IsolatedEnvVenvPip(path=self._path, python_executable=executable, pip_executable=pip_executable)
-        except Exception:  # cleanup if creation fails
+        except Exception:  # cleanup folder if creation fails
             self.__exit__(*sys.exc_info())
             raise
 
@@ -72,7 +71,7 @@ class IsolatedEnvBuilder(object):
             shutil.rmtree(self._path)
 
 
-class _IsolatedEnvVenvPip(IsolatedEnvironment):
+class _IsolatedEnvVenvPip(IsolatedEnv):
     """
     Isolated build environment context manager
 
@@ -212,5 +211,5 @@ else:
 
 __all__ = (
     'IsolatedEnvBuilder',
-    'IsolatedEnvironment',
+    'IsolatedEnv',
 )

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -1,3 +1,7 @@
+"""
+Creates and manages isolated build environments.
+"""
+import contextlib
 import os
 import platform
 import shutil
@@ -5,43 +9,118 @@ import subprocess
 import sys
 import sysconfig
 import tempfile
-import types
-import typing
-from typing import Dict, Iterable, List, Optional, Sequence, Type
-
-if sys.version_info[0] == 2:
-    FileExistsError = OSError
+from typing import Generator, Iterable, Tuple
 
 try:
     import pip
 except ImportError:  # pragma: no cover
     pip = None  # pragma: no cover
 
-_HAS_SYMLINK = None  # type: Optional[bool]
+
+@contextlib.contextmanager
+def isolated_env():  # type: () -> Generator[IsolatedEnvironment, None, None]
+    """
+    Create an isolated build environment.
+    """
+    path = tempfile.mkdtemp(prefix='build-env-')
+    try:
+        executable, pip_executable = _create_isolated_env(path)
+        env = IsolatedEnvironment(path, executable, pip_executable)
+        with _patch_sys_executable(executable):
+            yield env
+    finally:
+        if os.path.exists(path):  # in case the user already deleted skip remove
+            shutil.rmtree(path)
 
 
-def _fs_supports_symlink():  # type: () -> bool
-    if not hasattr(os, 'symlink'):
-        return False
+@contextlib.contextmanager
+def _patch_sys_executable(executable):  # type: (str) -> Generator[None, None, None]
+    """
+    Address https://github.com/pypa/pep517/pull/93, that always uses sys.executable to run pep517 hooks in.
 
-    if sys.platform.startswith(('aix', 'darwin', 'freebsd', 'linux')):
-        return True
-    else:
-        with tempfile.NamedTemporaryFile(prefix='TmP') as tmp_file:
-            temp_dir = os.path.dirname(tmp_file.name)
-            dest = os.path.join(temp_dir, '{}-{}'.format(tmp_file.name, 'b'))
+    :param executable: the new sys.executable
+    """
+
+    old_executable = sys.executable
+    sys.executable = executable
+    try:
+        yield
+    finally:
+        sys.executable = old_executable
+
+
+if sys.version_info[0] == 2:  # noqa: C901 # disable if too complex
+
+    def _create_isolated_env(path):  # type: (str) -> Tuple[str, str]
+        """
+        On Python 2 we use the virtualenv package to provision a virtual environment.
+
+        :param path: the folder where to create the isolated build environment
+        :return: the isolated build environment executable, and the pip to use to install packages into it
+        """
+        from virtualenv import cli_run
+
+        cmd = [str(path), '--no-setuptools', '--no-wheel', '--activators', '']
+        if pip is not None:
+            cmd.append('--no-pip')
+        result = cli_run(cmd, setup_logging=False)
+        executable = str(result.creator.exe)
+        pip_executable = executable if pip is None else sys.executable
+        return executable, pip_executable
+
+
+else:
+
+    def _create_isolated_env(path):  # type: (str) -> Tuple[str, str]
+        """
+        On Python 3 we use the venv package from the standard library, and if host python has no pip the ensurepip
+        package to provision one into the created virtual environment.
+
+        :param path: the folder where to create the isolated build environment
+        :return: the isolated build environment executable, and the pip to use to install packages into it
+        """
+        import venv
+
+        venv.EnvBuilder(with_pip=False).create(path)
+        executable = _find_executable(path)
+
+        # Scenario 1: pip is available (either installed or via pth file) within the python executable alongside
+        # this projects environment: in this case we should be able to import it
+        if pip is not None:
+            pip_executable = sys.executable
+        else:
+            # Scenario 2: this project is installed into a virtual environment that has no pip, but the system has
+            # Scenario 3: there's a pip executable on PATH
+            # Scenario 4: no pip can be found, we might be able to provision one into the build env via ensurepip
+            cmd = [executable, '-Im', 'ensurepip', '--upgrade', '--default-pip']
             try:
-                os.symlink(tmp_file.name, dest)
-                return True
-            except (OSError, NotImplementedError):
-                return False
+                subprocess.check_call(cmd, cwd=path)
+            except subprocess.CalledProcessError:  # pragma: no cover
+                pass  # pragma: no cover
+            # avoid the setuptools from ensurepip to break the isolation
+            subprocess.check_call([executable, '-Im', 'pip', 'uninstall', 'setuptools', '-y'])
+            pip_executable = executable
+        return executable, pip_executable
 
+    def _find_executable(path):  # type: (str) -> str
+        """
+        Detect the executable within a virtual environment.
 
-def fs_supports_symlink():  # type: () -> bool
-    global _HAS_SYMLINK
-    if _HAS_SYMLINK is None:
-        _HAS_SYMLINK = _fs_supports_symlink()
-    return _HAS_SYMLINK
+        :param path: the location of the virtual environment
+        :return: the python executable
+        """
+        config_vars = sysconfig.get_config_vars()
+        config_vars['base'] = path
+        env_scripts = sysconfig.get_path('scripts', vars=config_vars)
+        if not env_scripts:
+            raise RuntimeError("Couldn't get environment scripts path")
+        exe = 'pypy3' if platform.python_implementation() == 'PyPy' else 'python'
+        if os.name == 'nt':
+            exe = '{}.exe'.format(exe)
+        executable = os.path.join(path, env_scripts, exe)
+        if not os.path.exists(executable):
+            raise RuntimeError('Virtual environment creation failed, executable {} missing'.format(executable))
+        return executable
 
 
 class IsolatedEnvironment(object):
@@ -51,171 +130,29 @@ class IsolatedEnvironment(object):
     Non-standard paths injected directly to sys.path still be passed to the environment.
     """
 
-    _MANIPULATE_PATHS = ('purelib', 'platlib')
-
-    def __init__(self, remove_paths, _executable=sys.executable):  # type: (Sequence[str], str) -> None
-        """
-        :param remove_paths: Import paths that should be removed from the environment
-        """
-        self._env = {}  # type: Dict[str, Optional[str]]
-        self._env_vars = {}  # type: Dict[str, str]
-        self._path = None  # type: Optional[str]
-        self._remove_paths = []  # type: List[str]
-        self._executable = _executable
-        self._old_executable = None  # type: Optional[str]
-        self._pip_executable = None  # type: Optional[str]
-
-        # normalize paths so that we can compare them -- required on case insensitive systems
-        for path in remove_paths:
-            self._remove_paths.append(os.path.normcase(path))
+    def __init__(self, path, executable, pip_executable):  # type: (str, str, str) -> None
+        self._path = path
+        self._pip_executable = pip_executable
+        self._executable = executable
 
     @property
     def path(self):  # type: () -> str
-        if not self._path:
-            raise RuntimeError("{} context environment hasn't been entered yet".format(self.__class__.__name__))
-
+        """:return: the location of the isolated build environment"""
         return self._path
 
     @property
     def executable(self):  # type: () -> str
+        """:return: the python executable of the isolated build environment"""
         return self._executable
-
-    @classmethod
-    def for_current(cls):  # type: () -> IsolatedEnvironment
-        """
-        Creates an isolated environment for the current interpreter
-        """
-        remove_paths = os.environ.get('PYTHONPATH', '').split(os.pathsep)
-        # also remove the pth file adding this project (when installed via --develop install)
-        for path in sys.path:
-            if os.path.exists(os.path.join(path, 'build.egg-info')):
-                remove_paths.append(path)  # pragma: no cover
-
-        return cls(remove_paths)
-
-    def _replace_env(self, key, new):  # type: (str, Optional[str]) -> None
-        """
-        Replaces an environment variable
-        """
-        if not new:  # pragma: no cover
-            return
-
-        self._env[key] = os.environ.get(key, None)
-        os.environ[key] = new
-
-    def _pop_env(self, key):  # type: (str) -> None
-        """
-        Removes an environment variable
-        """
-        self._env[key] = os.environ.pop(key, None)
-
-    def _restore_env(self):  # type: () -> None
-        """
-        Restores the initial environment variables
-        """
-        for key, val in self._env.items():
-            if val is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = val
-
-    def _get_env_path(self, path):  # type: (str) -> Optional[str]
-        """
-        Returns sysconfig path from our environment
-        """
-        return sysconfig.get_path(path, vars=self._env_vars)
-
-    def _create_env_venv(self):  # type: () -> None
-        import venv
-
-        venv.EnvBuilder(with_pip=False).create(self.path)
-
-        env_scripts = self._get_env_path('scripts')
-        if not env_scripts:
-            raise RuntimeError("Couldn't get environment scripts path")
-        exe = 'pypy3' if platform.python_implementation() == 'PyPy' else 'python'
-        if os.name == 'nt':
-            exe = '{}.exe'.format(exe)
-
-        self._executable = os.path.join(self.path, env_scripts, exe)
-        if not os.path.exists(self._executable):
-            raise RuntimeError('Virtual environment creation failed, executable {} missing'.format(self._executable))
-
-        # Scenario 1: pip is available (either installed or via pth file) within the python executable alongside
-        # this projects environment: in this case we should be able to import it
-        if pip is not None:
-            self._pip_executable = sys.executable
-            return
-        # Scenario 2: this project is installed into a virtual environment that has no pip, but the matching system has
-        # Scenario 3: there's a pip executable on PATH
-        # Scenario 4: no pip can be found, we might be able to provision one into the isolated build env via ensurepip
-        cmd = [self.executable, '-Im', 'ensurepip', '--upgrade', '--default-pip']
-        try:
-            subprocess.check_call(cmd, cwd=self.path)
-        except subprocess.CalledProcessError:  # pragma: no cover
-            pass  # pragma: no cover
-        # avoid the setuptools from ensurepip to break the isolation
-        subprocess.check_call([self.executable, '-Im', 'pip', 'uninstall', 'setuptools', '-y'])
-        self._pip_executable = self.executable
-
-    def _create_env_virtualenv(self):  # type: () -> None
-        from virtualenv import cli_run
-
-        cmd = [str(self.path), '--no-setuptools', '--no-wheel', '--activators', '']
-        if pip is not None:
-            cmd.append('--no-pip')
-        result = cli_run(cmd, setup_logging=False)
-        self._executable = str(result.creator.exe)
-        self._pip_executable = self._executable
-        if pip is not None:
-            self._pip_executable = sys.executable
-
-    def _create_isolated_env(self):  # type: () -> None
-        if sys.version_info[0] == 2:
-            self._create_env_virtualenv()
-
-        else:
-            self._create_env_venv()
-
-    def __enter__(self):  # type: () -> IsolatedEnvironment
-        """
-        Set up the environment
-
-        The environment path should be empty
-        """
-        self._path = tempfile.mkdtemp(prefix='build-env-')
-        self._env_vars = {
-            'base': self.path,
-            'platbase': self.path,
-        }
-
-        self._create_isolated_env()
-
-        self._pop_env('PIP_REQUIRE_VIRTUALENV')
-        # address https://github.com/pypa/pep517/pull/93
-        self._old_executable, sys.executable = sys.executable, self._executable
-
-        return self
-
-    def __exit__(self, typ, value, traceback):
-        # type: (Optional[Type[BaseException]], Optional[BaseException], Optional[types.TracebackType]) -> None
-        """
-        Restores the everything to the original state
-        """
-        if self._old_executable is not None:
-            sys.executable = self._old_executable
-        if self.path and os.path.isdir(self.path):
-            shutil.rmtree(self.path)
-
-        self._restore_env()
 
     def install(self, requirements):  # type: (Iterable[str]) -> None
         """
         Installs the specified PEP 508 requirements on the environment
 
-        Passing non PEP 508 strings will result in undefined behavior, you
-        *should not* rely on it. It is merely an implementation detail, it may
-        change any time without warning.
+        :param requirements: PEP-508 requirement specification to install
+
+        :note: Passing non PEP 508 strings will result in undefined behavior, you *should not* rely on it. It is \
+               merely an implementation detail, it may change any time without warning.
         """
         if not requirements:
             return
@@ -224,10 +161,10 @@ class IsolatedEnvironment(object):
             req_file.write(os.linesep.join(requirements))
             req_file.close()
             cmd = [
-                typing.cast(str, self._pip_executable),
+                self._pip_executable,
                 # on python2 if isolation is achieved via environment variables, we need to ignore those while calling
                 # host python (otherwise pip would not be available within it)
-                '-{}m'.format('E' if self._pip_executable == self._executable and sys.version_info[0] == 2 else ''),
+                '-{}m'.format('E' if self._pip_executable == self.executable and sys.version_info[0] == 2 else ''),
                 'pip',
                 'install',
                 '--prefix',
@@ -239,3 +176,9 @@ class IsolatedEnvironment(object):
             ]
             subprocess.check_call(cmd)
             os.unlink(req_file.name)
+
+
+__all__ = (
+    'IsolatedEnvironment',
+    'isolated_env',
+)

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -24,18 +24,18 @@ class IsolatedEnvironment(object):
     Non-standard paths injected directly to sys.path still be passed to the environment.
     """
 
-    def __init__(self, path, executable, install_executable):
+    def __init__(self, path, python_executable, install_executable):
         # type: (str, str, str) -> None
         """
         Define an isolated build environment.
 
         :param path: the path where the environment exists
-        :param executable: the python executable within the environment
+        :param python_executable: the python executable within the environment
         :param install_executable: an executable that allows installing packages within the environment
         """
         self._path = path
         self._install_executable = install_executable
-        self._executable = executable
+        self._python_executable = python_executable
 
     @classmethod
     def for_current(cls):  # type: () -> IsolatedEnvironment
@@ -46,7 +46,7 @@ class IsolatedEnvironment(object):
         """
         path = tempfile.mkdtemp(prefix='build-env-')
         executable, pip_executable = _create_isolated_env(path)
-        return cls(path=path, executable=executable, install_executable=pip_executable)
+        return cls(path=path, python_executable=executable, install_executable=pip_executable)
 
     def __enter__(self):  # type: () -> IsolatedEnvironment
         """Enable the isolated build environment"""
@@ -76,7 +76,7 @@ class IsolatedEnvironment(object):
     @property
     def executable(self):  # type: () -> str
         """:return: the python executable of the isolated build environment"""
-        return self._executable
+        return self._python_executable
 
     def install(self, requirements):  # type: (Iterable[str]) -> None
         """

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -13,7 +13,7 @@ import build.env
 @pytest.mark.isolated
 def test_isolation():
     subprocess.check_call([sys.executable, '-c', 'import build.env'])
-    with build.env.isolated_env() as env:
+    with build.env.IsolatedEnvironment.for_current() as env:
         with pytest.raises(subprocess.CalledProcessError):
             debug = 'import sys; import os; print(os.linesep.join(sys.path));'
             subprocess.check_call([env.executable, '-c', '{} import build.env'.format(debug)])
@@ -21,7 +21,7 @@ def test_isolation():
 
 @pytest.mark.isolated
 def test_isolated_environment_install(mocker):
-    with build.env.isolated_env() as env:
+    with build.env.IsolatedEnvironment.for_current() as env:
         mocker.patch('subprocess.check_call')
 
         env.install([])
@@ -32,8 +32,8 @@ def test_isolated_environment_install(mocker):
             subprocess.check_call.assert_called()
         args = subprocess.check_call.call_args[0][0][:-1]
         assert args == [
-            env._pip_executable,
-            '-{}m'.format('E' if env._pip_executable == env._executable and sys.version_info[0] == 2 else ''),
+            env._install_executable,
+            '-{}m'.format('E' if env._install_executable == env._executable and sys.version_info[0] == 2 else ''),
             'pip',
             'install',
             '--prefix',
@@ -49,11 +49,11 @@ def test_create_isolated_build_host_with_no_pip(tmp_path, capfd, mocker):
     mocker.patch.object(build.env, 'pip', None)
     expected = {'pip', 'greenlet', 'readline', 'cffi'} if platform.python_implementation() == 'PyPy' else {'pip'}
 
-    with build.env.isolated_env() as isolated_env:
+    with build.env.IsolatedEnvironment.for_current() as isolated_env:
         cmd = [isolated_env.executable, '-m', 'pip', 'list', '--format', 'json']
         packages = {p['name'] for p in json.loads(subprocess.check_output(cmd, universal_newlines=True))}
         assert packages == expected
-    assert isolated_env._pip_executable == isolated_env.executable
+    assert isolated_env._install_executable == isolated_env.executable
     out, err = capfd.readouterr()
     if sys.version_info[0] == 3:
         assert out  # ensurepip prints onto the stdout
@@ -64,9 +64,9 @@ def test_create_isolated_build_host_with_no_pip(tmp_path, capfd, mocker):
 
 @pytest.mark.isolated
 def test_create_isolated_build_has_with_pip(tmp_path, capfd, mocker):
-    with build.env.isolated_env() as isolated_env:
+    with build.env.IsolatedEnvironment.for_current() as isolated_env:
         pass
-    assert isolated_env._pip_executable == sys.executable
+    assert isolated_env._install_executable == sys.executable
     out, err = capfd.readouterr()
     assert not out
     assert not err
@@ -76,7 +76,7 @@ def test_create_isolated_build_has_with_pip(tmp_path, capfd, mocker):
 def test_fail_to_get_script_path(mocker):
     get_path = mocker.patch('sysconfig.get_path', return_value=None)
     with pytest.raises(RuntimeError, match="Couldn't get environment scripts path"):
-        with build.env.isolated_env():
+        with build.env.IsolatedEnvironment.for_current():
             pass
     assert get_path.call_count == 1
 
@@ -93,6 +93,6 @@ def test_executable_missing_post_creation(mocker):
 
     get_path = mocker.patch('sysconfig.get_path', side_effect=_get_path)
     with pytest.raises(RuntimeError, match='Virtual environment creation failed, executable .* missing'):
-        with build.env.isolated_env():
+        with build.env.IsolatedEnvironment.for_current():
             pass
     assert get_path.call_count == 1

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: MIT
 import json
-import os
-import os.path
 import platform
+import shutil
 import subprocess
 import sys
 
@@ -14,23 +13,15 @@ import build.env
 @pytest.mark.isolated
 def test_isolation():
     subprocess.check_call([sys.executable, '-c', 'import build.env'])
-    with build.env.IsolatedEnvironment.for_current() as env:
+    with build.env.isolated_env() as env:
         with pytest.raises(subprocess.CalledProcessError):
             debug = 'import sys; import os; print(os.linesep.join(sys.path));'
             subprocess.check_call([env.executable, '-c', '{} import build.env'.format(debug)])
 
 
 @pytest.mark.isolated
-def test_isolated_environment_setup_require_virtualenv(mocker):
-    mocker.patch.dict(os.environ, {'PIP_REQUIRE_VIRTUALENV': 'true'})
-    with build.env.IsolatedEnvironment.for_current():
-        assert 'PIP_REQUIRE_VIRTUALENV' not in os.environ
-    assert os.environ['PIP_REQUIRE_VIRTUALENV'] == 'true'
-
-
-@pytest.mark.isolated
 def test_isolated_environment_install(mocker):
-    with build.env.IsolatedEnvironment.for_current() as env:
+    with build.env.isolated_env() as env:
         mocker.patch('subprocess.check_call')
 
         env.install([])
@@ -53,19 +44,12 @@ def test_isolated_environment_install(mocker):
         ]
 
 
-def test_uninitialised_isolated_environment():
-    env = build.env.IsolatedEnvironment.for_current()
-
-    with pytest.raises(RuntimeError):
-        env.path
-
-
 @pytest.mark.isolated
 def test_create_isolated_build_host_with_no_pip(tmp_path, capfd, mocker):
     mocker.patch.object(build.env, 'pip', None)
     expected = {'pip', 'greenlet', 'readline', 'cffi'} if platform.python_implementation() == 'PyPy' else {'pip'}
 
-    with build.env.IsolatedEnvironment.for_current() as isolated_env:
+    with build.env.isolated_env() as isolated_env:
         cmd = [isolated_env.executable, '-m', 'pip', 'list', '--format', 'json']
         packages = {p['name'] for p in json.loads(subprocess.check_output(cmd, universal_newlines=True))}
         assert packages == expected
@@ -80,9 +64,35 @@ def test_create_isolated_build_host_with_no_pip(tmp_path, capfd, mocker):
 
 @pytest.mark.isolated
 def test_create_isolated_build_has_with_pip(tmp_path, capfd, mocker):
-    with build.env.IsolatedEnvironment.for_current() as isolated_env:
+    with build.env.isolated_env() as isolated_env:
         pass
     assert isolated_env._pip_executable == sys.executable
     out, err = capfd.readouterr()
     assert not out
     assert not err
+
+
+@pytest.mark.skipif(sys.version_info[0] == 2, reason='venv module used on Python 3 only')
+def test_fail_to_get_script_path(mocker):
+    get_path = mocker.patch('sysconfig.get_path', return_value=None)
+    with pytest.raises(RuntimeError, match="Couldn't get environment scripts path"):
+        with build.env.isolated_env():
+            pass
+    assert get_path.call_count == 1
+
+
+@pytest.mark.skipif(sys.version_info[0] == 2, reason='venv module used on Python 3 only')
+def test_executable_missing_post_creation(mocker):
+    import sysconfig
+
+    original_get_path = sysconfig.get_path
+
+    def _get_path(name, vars):  # noqa
+        shutil.rmtree(vars['base'])
+        return original_get_path(name, vars=vars)
+
+    get_path = mocker.patch('sysconfig.get_path', side_effect=_get_path)
+    with pytest.raises(RuntimeError, match='Virtual environment creation failed, executable .* missing'):
+        with build.env.isolated_env():
+            pass
+    assert get_path.call_count == 1

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -33,7 +33,7 @@ def test_isolated_environment_install(mocker):
         args = subprocess.check_call.call_args[0][0][:-1]
         assert args == [
             env._install_executable,
-            '-{}m'.format('E' if env._install_executable == env._executable and sys.version_info[0] == 2 else ''),
+            '-{}m'.format('E' if env._install_executable == env._python_executable and sys.version_info[0] == 2 else ''),
             'pip',
             'install',
             '--prefix',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -90,7 +90,7 @@ def test_prog():
 def test_build_isolated(mocker, test_flit_path):
     build_cmd = mocker.patch('build.ProjectBuilder.build')
     mocker.patch('build.__main__._error')
-    install = mocker.patch('build.env.IsolatedEnvironment.install')
+    install = mocker.patch('build.env._IsolatedEnvVenvPip.install')
 
     build.__main__.build(test_flit_path, '.', ['sdist'])
 
@@ -124,7 +124,7 @@ def test_build_no_isolation_with_check_deps(mocker, test_flit_path):
 def test_build_raises_build_exception(mocker, test_flit_path):
     error = mocker.patch('build.__main__._error')
     mocker.patch('build.ProjectBuilder.build', side_effect=build.BuildException)
-    mocker.patch('build.env.IsolatedEnvironment.install')
+    mocker.patch('build.env._IsolatedEnvVenvPip.install')
 
     build.__main__.build(test_flit_path, '.', ['sdist'])
 
@@ -135,7 +135,7 @@ def test_build_raises_build_exception(mocker, test_flit_path):
 def test_build_raises_build_backend_exception(mocker, test_flit_path):
     error = mocker.patch('build.__main__._error')
     mocker.patch('build.ProjectBuilder.build', side_effect=build.BuildBackendException)
-    mocker.patch('build.env.IsolatedEnvironment.install')
+    mocker.patch('build.env._IsolatedEnvVenvPip.install')
 
     build.__main__.build(test_flit_path, '.', ['sdist'])
 

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -88,16 +88,18 @@ def test_init(mocker, test_flit_path, legacy_path, test_no_permission, test_bad_
         'setuptools.build_meta:__legacy__': None,
     }
     mocker.patch('importlib.import_module', modules.get)
-    mocker.patch('pep517.wrappers.Pep517HookCaller')
+    caller = mocker.patch('pep517.wrappers.Pep517HookCaller')
 
     # correct flit pyproject.toml
     build.ProjectBuilder(test_flit_path)
-    pep517.wrappers.Pep517HookCaller.assert_called_with(test_flit_path, 'flit_core.buildapi', backend_path=None)
-    pep517.wrappers.Pep517HookCaller.reset_mock()
+    caller.assert_called_with(test_flit_path, 'flit_core.buildapi', backend_path=None, python_executable=sys.executable)
+    caller.reset_mock()
 
     # FileNotFoundError
     build.ProjectBuilder(legacy_path)
-    pep517.wrappers.Pep517HookCaller.assert_called_with(legacy_path, 'setuptools.build_meta:__legacy__', backend_path=None)
+    caller.assert_called_with(
+        legacy_path, 'setuptools.build_meta:__legacy__', backend_path=None, python_executable=sys.executable
+    )
 
     # PermissionError
     if sys.version_info[0] != 2 and os.name != 'nt':  # can't correctly set the permissions required for this

--- a/tox.ini
+++ b/tox.ini
@@ -52,8 +52,7 @@ commands =
 
 [testenv:type]
 description = run type check on code base
-deps =
-    mypy==0.782
+extras = typing
 commands =
     mypy --python-version 3.8 src/build
     mypy --python-version 2.7 src/build


### PR DESCRIPTION
Create the isolated build environment upfront to avoid executable, pip executable or path not yet set. Remove unused code segments.

Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>

As promised in https://github.com/pypa/build/pull/140 this is the follow-up PR to clean up the env code a bit and avoid some redundant type casts. There have been many code segments we don't need actually anymore with the switch to venv/virtualenv. While doing it I've taken the liberty to add a few tests to get 100% coverage for the module.