### PR TITLE
main: fix warnings.showwarnings compatibility

### DIFF
--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -6,7 +6,7 @@ import sys
 import traceback
 import warnings
 
-from typing import List, Optional, TextIO, Type
+from typing import List, Optional, TextIO, Type, Union
 
 from build import BuildBackendException, BuildException, ConfigSettings, ProjectBuilder
 from build.env import IsolatedEnvironment
@@ -16,11 +16,11 @@ __all__ = ['build', 'main', 'main_parser']
 
 
 def _showwarning(message, category, filename, lineno, file=None, line=None):  # pragma: no cover
-    # type: (str, Type[Warning], str, int, Optional[TextIO], Optional[str]) -> None
+    # type: (Union[Warning, str], Type[Warning], str, int, Optional[TextIO], Optional[str]) -> None
     prefix = 'WARNING'
     if sys.stdout.isatty():
         prefix = '\33[93m' + prefix + '\33[0m'
-    print('{} {}'.format(prefix, message))
+    print('{} {}'.format(prefix, str(message)))
 
 
 warnings.showwarning = _showwarning


### PR DESCRIPTION
For some reason mypy isn't saying anything in the CI but locally it
complains:

src/build/__main__.py:26: error: Incompatible types in assignment (expression has type "Callable[[str, Type[Warning], str, int, Optional[TextIO], Optional[str]], None]", variable has type "Callable[[Union[Warning, str], Type[Warning], str, int, Optional[TextIO], Optional[str]], None]")

Signed-off-by: Filipe Laíns <lains@archlinux.org>