### PR TITLE
tox: don't run integration tests by default

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -75,7 +75,7 @@ jobs:
         run: tox -vv --notest -e ${{env.BASE}},${{env.BASE}}-path,${{env.BASE}}-sdist,${{env.BASE}}-wheel
 
       - name: Run test suite via tox
-        run: tox -e ${{env.BASE}} --skip-pkg-install -- --run-integration
+        run: tox -e ${{env.BASE}} --skip-pkg-install
 
       - name: Run test suite via path
         run: tox -e ${{env.BASE}}-path --skip-pkg-install -- --run-integration

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -75,16 +75,16 @@ jobs:
         run: tox -vv --notest -e ${{env.BASE}},${{env.BASE}}-path,${{env.BASE}}-sdist,${{env.BASE}}-wheel
 
       - name: Run test suite via tox
-        run: tox -e ${{env.BASE}} --skip-pkg-install
+        run: tox -e ${{env.BASE}} --skip-pkg-install -- --run-integration
 
       - name: Run test suite via path
-        run: tox -e ${{env.BASE}}-path --skip-pkg-install
+        run: tox -e ${{env.BASE}}-path --skip-pkg-install -- --run-integration
 
       - name: Run test suite via sdist
-        run: tox -e ${{env.BASE}}-sdist --skip-pkg-install
+        run: tox -e ${{env.BASE}}-sdist --skip-pkg-install -- --run-integration
 
       - name: Run test suite via wheel
-        run: tox -e ${{env.BASE}}-wheel --skip-pkg-install
+        run: tox -e ${{env.BASE}}-wheel --skip-pkg-install -- --run-integration
 
       - name: Rename coverage report file
         run: |

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
     pytest -rsx --cov --cov-config setup.cfg \
       --cov-report=html:{envdir}/htmlcov --cov-context=test \
       --cov-report=xml:{toxworkdir}/coverage.{envname}.xml \
-      tests {posargs:--run-integration}
+      tests {posargs}
 
 [testenv:fix]
 description = run static analysis and style checks


### PR DESCRIPTION
People can opt in via posargs.

Signed-off-by: Filipe Laíns <lains@archlinux.org>