### PR TITLE
Run test suite in parallel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ test =
     pytest
     pytest-cov
     pytest-mock
+    pytest-xdist>=1.34
 typing =
     mypy==0.790
     typing-extensions>=3.7.4.3

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -195,7 +195,7 @@ else:
         :param path: the location of the virtual environment
         :return: the python executable
         """
-        config_vars = sysconfig.get_config_vars()
+        config_vars = sysconfig.get_config_vars().copy()  # globally cached, copy before altering it
         config_vars['base'] = path
         env_scripts = sysconfig.get_path('scripts', vars=config_vars)
         if not env_scripts:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import sysconfig
 import tempfile
 
 import pytest
@@ -40,6 +41,13 @@ def pytest_addoption(parser):
     parser.addoption('--run-integration', action='store_true', help='run the integration tests')
     parser.addoption('--only-integration', action='store_true', help='only run the integration tests')
 
+    # pytest-xdist does not work on Windows PyPy2 - we need to disable it
+    if platform.python_implementation() == 'PyPy' and sys.version_info[0] == 2 and os.name == 'nt':
+        # the patch here is compatible with pytest 4 + pytest-xdist 1.31 (last release on python2)
+        num_process_option_xdist = next(o for o in parser.getgroup('xdist').options if o.dest == 'numprocesses')
+        # change the type to return None -> no parallel runs
+        num_process_option_xdist._attrs['type'] = lambda s: None  # noqa
+
 
 PYPY3_WIN_VENV_BAD = platform.python_implementation() == 'PyPy' and sys.version_info[0] == 3 and os.name == 'nt'
 PYPY3_WIN_M = 'https://foss.heptapod.net/pypy/pypy/-/issues/3323 and https://foss.heptapod.net/pypy/pypy/-/issues/3321'
@@ -72,6 +80,12 @@ def pytest_collection_modifyitems(config, items):
 
 def is_integration(item):
     return os.path.basename(item.location[0]) == 'test_integration.py'
+
+
+@pytest.fixture(scope='session', autouse=True)
+def ensure_syconfig_vars_created():
+    # the config vars are globally cached and may use get_path, make sure they are created
+    sysconfig.get_config_vars()
 
 
 @pytest.fixture

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -76,7 +76,6 @@ def test_create_isolated_build_has_with_pip(tmp_path, capfd, mocker):
 
 @pytest.mark.skipif(sys.version_info[0] == 2, reason='venv module used on Python 3 only')
 def test_fail_to_get_script_path(mocker):
-    sysconfig.get_config_vars()  # the config vars are globally cached and may use get_path, make sure they are created
     get_path = mocker.patch('sysconfig.get_path', return_value=None)
     with pytest.raises(RuntimeError, match="Couldn't get environment scripts path"):
         env = build.env.IsolatedEnvBuilder()
@@ -88,7 +87,6 @@ def test_fail_to_get_script_path(mocker):
 
 @pytest.mark.skipif(sys.version_info[0] == 2, reason='venv module used on Python 3 only')
 def test_executable_missing_post_creation(mocker):
-    sysconfig.get_config_vars()  # the config vars are globally cached and may use get_path, make sure they are created
     original_get_path = sysconfig.get_path
 
     def _get_path(name, vars):  # noqa

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -5,6 +5,7 @@ import platform
 import shutil
 import subprocess
 import sys
+import sysconfig
 
 import pytest
 
@@ -75,6 +76,7 @@ def test_create_isolated_build_has_with_pip(tmp_path, capfd, mocker):
 
 @pytest.mark.skipif(sys.version_info[0] == 2, reason='venv module used on Python 3 only')
 def test_fail_to_get_script_path(mocker):
+    sysconfig.get_config_vars()  # the config vars are globally cached and may use get_path, make sure they are created
     get_path = mocker.patch('sysconfig.get_path', return_value=None)
     with pytest.raises(RuntimeError, match="Couldn't get environment scripts path"):
         env = build.env.IsolatedEnvBuilder()
@@ -86,8 +88,7 @@ def test_fail_to_get_script_path(mocker):
 
 @pytest.mark.skipif(sys.version_info[0] == 2, reason='venv module used on Python 3 only')
 def test_executable_missing_post_creation(mocker):
-    import sysconfig
-
+    sysconfig.get_config_vars()  # the config vars are globally cached and may use get_path, make sure they are created
     original_get_path = sysconfig.get_path
 
     def _get_path(name, vars):  # noqa

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -35,10 +35,13 @@ def get_project(name, tmp_path):
     if name == 'build':
         # our own project is available in-source, just ignore development files
 
-        def _ignore_folder(_, filenames):
-            return [n for n in filenames if n in exclude or n.endswith('_cache') or n.endswith('.egg-info')]
+        def _ignore_folder(base, filenames):
+            ignore = [n for n in filenames if n in excl or any(n.endswith(i) for i in ('_cache', '.egg-info', '.pyc'))]
+            if os.path.basename == ROOT and 'build' in filenames:  # ignore build only at root (our module is build too)
+                ignore.append('build')
+            return ignore
 
-        exclude = '.tox', 'dist', 'build', '.git', '__pycache__'
+        excl = '.tox', 'dist', '.git', '__pycache__', '.integration-sources', '.github', 'tests', 'docs'
         shutil.copytree(ROOT, str(dest), ignore=_ignore_folder)
         return dest
 

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
     pytest -rsx --cov --cov-config setup.cfg \
       --cov-report=html:{envdir}/htmlcov --cov-context=test \
       --cov-report=xml:{toxworkdir}/coverage.{envname}.xml \
-      tests {posargs}
+      tests {posargs:-n auto}
 
 [testenv:fix]
 description = run static analysis and style checks


### PR DESCRIPTION
Using the pytest-xdist module to run up to number of user CPUs in
parallel. Fixed some bugs discovered by doing so.

Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>