### PR TITLE
Resolve `outdir` relative to working directory

### DIFF
--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -113,10 +113,7 @@ class ProjectBuilder(object):
         :param config_settings: config settings for the build backend
         :param python_executable: the python executable where the backend lives
         """
-        if srcdir is None:
-            self.srcdir = os.getcwd()
-        else:
-            self.srcdir = os.path.abspath(srcdir)
+        self.srcdir = os.getcwd() if srcdir is None else os.path.abspath(srcdir)
         self.config_settings = config_settings if config_settings else {}
 
         spec_file = os.path.join(self.srcdir, 'pyproject.toml')

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -197,8 +197,7 @@ class ProjectBuilder(object):
         build = getattr(self.hook, 'build_{}'.format(distribution))
 
         if outdir is None:
-            # Resolve outdir relative to project root if not specified.
-            # See: https://github.com/pypa/build/issues/69#issuecomment-704312424
+            # resolve outdir relative to project root if not specified.
             outdir = os.path.join(self.srcdir, 'dist')
         else:
             outdir = os.path.abspath(outdir)

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -104,8 +104,8 @@ def _find_typo(dictionary, expected):  # type: (Mapping[str, str], str) -> None
 
 
 class ProjectBuilder(object):
-    def __init__(self, srcdir='.', config_settings=None, python_executable=sys.executable):
-        # type: (str, Optional[ConfigSettings], Union[bytes, Text]) -> None
+    def __init__(self, srcdir=None, config_settings=None, python_executable=sys.executable):
+        # type: (Optional[str], Optional[ConfigSettings], Union[bytes, Text]) -> None
         """
         Create a project builder.
 
@@ -113,10 +113,13 @@ class ProjectBuilder(object):
         :param config_settings: config settings for the build backend
         :param python_executable: the python executable where the backend lives
         """
-        self.srcdir = os.path.abspath(srcdir)
+        if srcdir is None:
+            self.srcdir = os.getcwd()
+        else:
+            self.srcdir = os.path.abspath(srcdir)
         self.config_settings = config_settings if config_settings else {}
 
-        spec_file = os.path.join(srcdir, 'pyproject.toml')
+        spec_file = os.path.join(self.srcdir, 'pyproject.toml')
 
         try:
             with open(spec_file) as f:

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -40,7 +40,7 @@ def _error(msg, code=1):  # type: (str, int) -> None  # pragma: no cover
 
 
 def _build_in_isolated_env(builder, outdir, distributions):
-    # type: (ProjectBuilder, str, List[str]) -> None
+    # type: (ProjectBuilder, Optional[str], List[str]) -> None
     with IsolatedEnvBuilder() as env:
         builder.python_executable = env.executable
         env.install(builder.build_dependencies)
@@ -49,7 +49,7 @@ def _build_in_isolated_env(builder, outdir, distributions):
 
 
 def _build_in_current_env(builder, outdir, distributions, skip_dependencies=False):
-    # type: (ProjectBuilder, str, List[str], bool) -> None
+    # type: (ProjectBuilder, Optional[str], List[str], bool) -> None
     for dist in distributions:
         if not skip_dependencies:
             missing = builder.check_dependencies(dist)
@@ -60,7 +60,7 @@ def _build_in_current_env(builder, outdir, distributions, skip_dependencies=Fals
 
 
 def build(srcdir, outdir, distributions, config_settings=None, isolation=True, skip_dependencies=False):
-    # type: (str, str, List[str], Optional[ConfigSettings], bool, bool) -> None
+    # type: (Optional[str], Optional[str], List[str], Optional[ConfigSettings], bool, bool) -> None
     """
     Runs the build process
 

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -98,7 +98,6 @@ def main_parser():  # type: () -> argparse.ArgumentParser
         'srcdir',
         type=str,
         nargs='?',
-        metavar='sourcedir',
         default='.',
         help='source directory (defaults to current directory)',
     )
@@ -118,7 +117,8 @@ def main_parser():  # type: () -> argparse.ArgumentParser
         '--outdir',
         '-o',
         type=str,
-        help='output directory (defaults to sourcedir/dist)',
+        metavar='dir',
+        help='output directory (defaults to {srcdir}/dist)',
     )
     parser.add_argument(
         '--skip-dependencies',

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -99,7 +99,6 @@ def main_parser():  # type: () -> argparse.ArgumentParser
         'srcdir',
         type=str,
         nargs='?',
-        default='.',
         help='source directory (defaults to current directory)',
     )
     parser.add_argument(

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
 
 import argparse
-import os
 import sys
 import traceback
 import warnings
@@ -94,15 +93,13 @@ def main_parser():  # type: () -> argparse.ArgumentParser
     """
     Constructs the main parser
     """
-    cwd = os.getcwd()
-    out = os.path.join(cwd, 'dist')
     parser = argparse.ArgumentParser()
     parser.add_argument(
         'srcdir',
         type=str,
         nargs='?',
         metavar='sourcedir',
-        default=cwd,
+        default='.',
         help='source directory (defaults to current directory)',
     )
     parser.add_argument(
@@ -117,7 +114,12 @@ def main_parser():  # type: () -> argparse.ArgumentParser
         action='store_true',
         help='build a wheel',
     )
-    parser.add_argument('--outdir', '-o', metavar='dist', type=str, default=out, help='output directory')
+    parser.add_argument(
+        '--outdir',
+        '-o',
+        type=str,
+        help='output directory (defaults to sourcedir/dist)',
+    )
     parser.add_argument(
         '--skip-dependencies',
         '-x',

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 import argparse
+import os
 import sys
 import traceback
 import warnings
@@ -118,7 +119,7 @@ def main_parser():  # type: () -> argparse.ArgumentParser
         '-o',
         type=str,
         metavar='dir',
-        help='output directory (defaults to {srcdir}/dist)',
+        help='output directory (defaults to {{srcdir}}{sep}dist)'.format(sep=os.sep),
     )
     parser.add_argument(
         '--skip-dependencies',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,7 +2,6 @@
 
 import contextlib
 import io
-import os
 import sys
 
 import pytest
@@ -16,52 +15,48 @@ else:  # pragma: no cover
     build_open_owner = 'build'
 
 
-cwd = os.getcwd()
-out = os.path.join(cwd, 'dist')
-
-
 @pytest.mark.parametrize(
     ('cli_args', 'build_args'),
     [
         (
             [],
-            [cwd, out, ['sdist', 'wheel'], {}, True, False],
+            ['.', None, ['sdist', 'wheel'], {}, True, False],
         ),
         (
             ['-n'],
-            [cwd, out, ['sdist', 'wheel'], {}, False, False],
+            ['.', None, ['sdist', 'wheel'], {}, False, False],
         ),
         (
             ['-s'],
-            [cwd, out, ['sdist'], {}, True, False],
+            ['.', None, ['sdist'], {}, True, False],
         ),
         (
             ['-w'],
-            [cwd, out, ['wheel'], {}, True, False],
+            ['.', None, ['wheel'], {}, True, False],
         ),
         (
             ['source'],
-            ['source', out, ['sdist', 'wheel'], {}, True, False],
+            ['source', None, ['sdist', 'wheel'], {}, True, False],
         ),
         (
             ['-o', 'out'],
-            [cwd, 'out', ['sdist', 'wheel'], {}, True, False],
+            ['.', 'out', ['sdist', 'wheel'], {}, True, False],
         ),
         (
             ['-x'],
-            [cwd, out, ['sdist', 'wheel'], {}, True, True],
+            ['.', None, ['sdist', 'wheel'], {}, True, True],
         ),
         (
             ['-C--flag1', '-C--flag2'],
-            [cwd, out, ['sdist', 'wheel'], {'--flag1': '', '--flag2': ''}, True, False],
+            ['.', None, ['sdist', 'wheel'], {'--flag1': '', '--flag2': ''}, True, False],
         ),
         (
             ['-C--flag=value'],
-            [cwd, out, ['sdist', 'wheel'], {'--flag': 'value'}, True, False],
+            ['.', None, ['sdist', 'wheel'], {'--flag': 'value'}, True, False],
         ),
         (
             ['-C--flag1=value', '-C--flag2=other_value', '-C--flag2=extra_value'],
-            [cwd, out, ['sdist', 'wheel'], {'--flag1': 'value', '--flag2': ['other_value', 'extra_value']}, True, False],
+            ['.', None, ['sdist', 'wheel'], {'--flag1': 'value', '--flag2': ['other_value', 'extra_value']}, True, False],
         ),
     ],
 )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -20,19 +20,19 @@ else:  # pragma: no cover
     [
         (
             [],
-            ['.', None, ['sdist', 'wheel'], {}, True, False],
+            [None, None, ['sdist', 'wheel'], {}, True, False],
         ),
         (
             ['-n'],
-            ['.', None, ['sdist', 'wheel'], {}, False, False],
+            [None, None, ['sdist', 'wheel'], {}, False, False],
         ),
         (
             ['-s'],
-            ['.', None, ['sdist'], {}, True, False],
+            [None, None, ['sdist'], {}, True, False],
         ),
         (
             ['-w'],
-            ['.', None, ['wheel'], {}, True, False],
+            [None, None, ['wheel'], {}, True, False],
         ),
         (
             ['source'],
@@ -40,23 +40,23 @@ else:  # pragma: no cover
         ),
         (
             ['-o', 'out'],
-            ['.', 'out', ['sdist', 'wheel'], {}, True, False],
+            [None, 'out', ['sdist', 'wheel'], {}, True, False],
         ),
         (
             ['-x'],
-            ['.', None, ['sdist', 'wheel'], {}, True, True],
+            [None, None, ['sdist', 'wheel'], {}, True, True],
         ),
         (
             ['-C--flag1', '-C--flag2'],
-            ['.', None, ['sdist', 'wheel'], {'--flag1': '', '--flag2': ''}, True, False],
+            [None, None, ['sdist', 'wheel'], {'--flag1': '', '--flag2': ''}, True, False],
         ),
         (
             ['-C--flag=value'],
-            ['.', None, ['sdist', 'wheel'], {'--flag': 'value'}, True, False],
+            [None, None, ['sdist', 'wheel'], {'--flag': 'value'}, True, False],
         ),
         (
             ['-C--flag1=value', '-C--flag2=other_value', '-C--flag2=extra_value'],
-            ['.', None, ['sdist', 'wheel'], {'--flag1': 'value', '--flag2': ['other_value', 'extra_value']}, True, False],
+            [None, None, ['sdist', 'wheel'], {'--flag1': 'value', '--flag2': ['other_value', 'extra_value']}, True, False],
         ),
     ],
 )
@@ -87,9 +87,9 @@ def test_build_isolated(mocker, test_flit_path):
     mocker.patch('build.__main__._error')
     install = mocker.patch('build.env._IsolatedEnvVenvPip.install')
 
-    build.__main__.build(test_flit_path, '.', ['sdist'])
+    build.__main__.build(test_flit_path, None, ['sdist'])
 
-    build_cmd.assert_called_with('sdist', '.')
+    build_cmd.assert_called_with('sdist', None)
     install.assert_called_with({'flit_core >=2,<3'})
 
 
@@ -98,9 +98,9 @@ def test_build_no_isolation_check_deps_empty(mocker, test_flit_path):
     build_cmd = mocker.patch('build.ProjectBuilder.build')
     mocker.patch('build.ProjectBuilder.check_dependencies', return_value=[])
 
-    build.__main__.build(test_flit_path, '.', ['sdist'], isolation=False)
+    build.__main__.build(test_flit_path, None, ['sdist'], isolation=False)
 
-    build_cmd.assert_called_with('sdist', '.')
+    build_cmd.assert_called_with('sdist', None)
 
 
 def test_build_no_isolation_with_check_deps(mocker, test_flit_path):
@@ -109,9 +109,9 @@ def test_build_no_isolation_with_check_deps(mocker, test_flit_path):
     build_cmd = mocker.patch('build.ProjectBuilder.build')
     mocker.patch('build.ProjectBuilder.check_dependencies', return_value=['something'])
 
-    build.__main__.build(test_flit_path, '.', ['sdist'], isolation=False)
+    build.__main__.build(test_flit_path, None, ['sdist'], isolation=False)
 
-    build_cmd.assert_called_with('sdist', '.')
+    build_cmd.assert_called_with('sdist', None)
     error.assert_called_with('Missing dependencies:\n\tsomething')
 
 
@@ -121,7 +121,7 @@ def test_build_raises_build_exception(mocker, test_flit_path):
     mocker.patch('build.ProjectBuilder.build', side_effect=build.BuildException)
     mocker.patch('build.env._IsolatedEnvVenvPip.install')
 
-    build.__main__.build(test_flit_path, '.', ['sdist'])
+    build.__main__.build(test_flit_path, None, ['sdist'])
 
     error.assert_called_with('')
 
@@ -132,6 +132,6 @@ def test_build_raises_build_backend_exception(mocker, test_flit_path):
     mocker.patch('build.ProjectBuilder.build', side_effect=build.BuildBackendException)
     mocker.patch('build.env._IsolatedEnvVenvPip.install')
 
-    build.__main__.build(test_flit_path, '.', ['sdist'])
+    build.__main__.build(test_flit_path, None, ['sdist'])
 
     error.assert_called_with('')


### PR DESCRIPTION
This patch consolidates path manipulation in `ProjectBuilder`
which has the added benefit of providing the same interface
for both entry points.

Closes #69.