### PR TITLE
Remove `srcdir` default value

### DIFF
--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -117,7 +117,7 @@ def _working_directory(path):  # type: (str) -> Iterator[None]
 
 
 class ProjectBuilder(object):
-    def __init__(self, srcdir='.', config_settings=None, python_executable=sys.executable):
+    def __init__(self, srcdir, config_settings=None, python_executable=sys.executable):
         # type: (str, Optional[ConfigSettings], Union[bytes, Text]) -> None
         """
         Create a project builder.


### PR DESCRIPTION
As discussed in https://github.com/pypa/build/pull/157 this is not a good default for the programmatic API.