### PR TITLE
ci: decapitaze os name to match current style

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -108,7 +108,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - Ubuntu
+          - ubuntu
         tox_env:
           - type
           - docs


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@archlinux.org>