### PR TITLE
Annotate public API in full and add py.typed marker file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,10 @@ typing =
     mypy==0.790
     typing-extensions>=3.7.4.3
 
+[options.package_data]
+build =
+    py.typed
+
 [options.packages.find]
 where = src
 

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -84,7 +84,7 @@ def check_version(requirement_string, extra=''):  # type: (str, str) -> bool
             return False
         warnings.warn(
             "Verified that the '{}[{}]' extra is present but did not verify that it is active "
-            "(it's dependencies are met)".format(req.name, extra),
+            '(its dependencies are met)'.format(req.name, extra),
             IncompleteCheckWarning,
         )
 

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -11,7 +11,7 @@ import os
 import sys
 import warnings
 
-from typing import Dict, Iterator, List, Mapping, Optional, Set, Union, Text
+from typing import Iterator, Mapping, Optional, Sequence, Set, Text, Union
 
 import pep517.wrappers
 import toml
@@ -22,7 +22,7 @@ if sys.version_info < (3,):
     PermissionError = OSError
 
 
-ConfigSettings = Dict[str, Union[str, List[str]]]
+ConfigSettings = Mapping[str, Union[str, Sequence[str]]]
 
 
 _DEFAULT_BACKEND = {

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -126,8 +126,8 @@ class ProjectBuilder(object):
         :param config_settings: config settings for the build backend
         :param python_executable: the python executable where the backend lives
         """
-        self.srcdir = os.path.abspath(srcdir)
-        self.config_settings = config_settings if config_settings else {}
+        self.srcdir = os.path.abspath(srcdir)  # type: str
+        self.config_settings = config_settings if config_settings else {}  # type: ConfigSettings
 
         spec_file = os.path.join(srcdir, 'pyproject.toml')
 


### PR DESCRIPTION
The impetus for these changes is to make `build` easier to use as a library in combination with type checking.