### PR TITLE
release 0.1.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = build
-version = 0.0.4
+version = 0.1.0
 description = A simple, correct PEP517 package builder
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -3,7 +3,7 @@
 """
 build - A simple, correct PEP517 package builder
 """
-__version__ = '0.0.4'
+__version__ = '0.1.0'
 
 import contextlib
 import difflib


### PR DESCRIPTION
- Moved the upstream to PyPA
- Fixed building with isolation in a virtual environment
- Renamed the entrypoint script to pyproject-build (!)
- Removed default arguments from all paths in ProjectBuilder (!)
- Removed ProjectBuilder.hook (!)
- Renamed __main__.build to __main__.build_package (!)
- Changed the default outdir value to {srcdir}/dest (!)
- Removed env.IsolatedEnvironment (!)
- Added env.IsolatedEnv abstract class
- Added env.IsolatedEnvBuilder (replaces env.IsolatedEnvironment usages)
- Added python_executable argument to the ProjectBuilder constructor
- Added --version/-V option to the CLI
- Added support for Python 3.9
- Added py.typed marker
- Various miscelaneous fixes in the virtual environment creation
- Many general improvements in the documentation
- Documentation moved to the furo theme
- Updated the CoC to the PSF CoC, which PyPA has adopted

(!) - breaking change

Signed-off-by: Filipe Laíns <lains@archlinux.org>