### PR TITLE
docs: build on RTD using Python 3.8 

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,7 @@
 version: 2
 
 python:
+  version: 3.8
   install:
     - requirements: docs/requirements.txt
     - method: pip


### PR DESCRIPTION
autodoc-typehints is not able to display type hints under
Python 3.7 and earlier without the `typed_comments` extra.

Closes #118.