### PR TITLE
Verify `get_dependencies` returns empty set when its hooks are undefined

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,11 @@ def test_no_requires_path(packages_path):
 
 
 @pytest.fixture
+def test_optional_hooks_path(packages_path):
+    return os.path.join(packages_path, 'test-optional-hooks')
+
+
+@pytest.fixture
 def test_typo(packages_path):
     return os.path.join(packages_path, 'test-typo')
 

--- a/tests/packages/test-optional-hooks/pyproject.toml
+++ b/tests/packages/test-optional-hooks/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = []
+build-backend = 'hookless_backend'
+backend-path = ['.']

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -149,6 +149,13 @@ def test_get_dependencies_missing_backend(packages_path, distribution):
 
 
 @pytest.mark.parametrize('distribution', ['wheel', 'sdist'])
+def test_get_dependencies_missing_optional_hooks(test_optional_hooks_path, distribution):
+    builder = build.ProjectBuilder(test_optional_hooks_path)
+
+    assert builder.get_dependencies(distribution) == set()
+
+
+@pytest.mark.parametrize('distribution', ['wheel', 'sdist'])
 def test_build_missing_backend(packages_path, distribution, tmpdir):
     bad_backend_path = os.path.join(packages_path, 'test-bad-backend')
     builder = build.ProjectBuilder(bad_backend_path)


### PR DESCRIPTION
We're testing this against a local backend which does not expose
any hooks.

See #132.