### PR TITLE
build: add exports to __init__.py for strict type checking support

### DIFF
--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -241,3 +241,14 @@ class ProjectBuilder(object):
             raise BuildException("Backend '{}' is not available.".format(self._backend))
         except Exception as e:  # noqa: E722
             raise BuildBackendException('Backend operation failed: {!r}'.format(e))
+
+
+__all__ = (
+    '__version__',
+    'ConfigSettings',
+    'BuildException',
+    'BuildBackendException',
+    'TypoWarning',
+    'check_dependency',
+    'ProjectBuilder',
+)


### PR DESCRIPTION
With `mypy --strict` (or `pyright: strict`, etc.) you cannot
import symbols which are not explicitly (re-)exported.
This can be accomplished in one of two ways: using `__all__`
or with `import x as x` if a symbol is imported from another module.