### PR TITLE
Curate output

### DIFF
--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -7,6 +7,7 @@ __version__ = '0.1.0'
 
 import contextlib
 import difflib
+import logging
 import os
 import sys
 import warnings
@@ -48,6 +49,19 @@ class TypoWarning(Warning):
     """
     Warning raised when a potential typo is found
     """
+
+
+_logger = logging.getLogger('build')
+
+
+def print_info(msg):  # type: (str) -> None
+    """
+    Prints information
+
+    The default implementation uses the logging module but this function can be
+    overwritten by users to have a different implementation.
+    """
+    _logger.log(logging.INFO, msg, stacklevel=2)
 
 
 def check_dependency(req_string, ancestral_req_strings=(), parent_extras=frozenset()):
@@ -235,6 +249,7 @@ class ProjectBuilder(object):
             os.mkdir(outdir)
 
         try:
+            print_info('Building {}...'.format(distribution))
             with _working_directory(self.srcdir):
                 build(outdir, self.config_settings)
         except pep517.wrappers.BackendUnavailable:

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -42,6 +42,19 @@ def _error(msg, code=1):  # type: (str, int) -> None  # pragma: no cover
     exit(code)
 
 
+def _print_info(msg):  # type: (str) -> None
+    """
+    Custom build.print_info implementation to print directly to stdout, and with
+    colors.
+    """
+    prefix = '*'
+    end = ''
+    if sys.stdout.isatty():
+        prefix = '\33[1m\33[36m' + prefix + '\33[39m'
+        end = '\33[0m'
+    print('{} {}{}'.format(prefix, msg, end))
+
+
 def _format_dep_chain(dep_chain):  # type: (Sequence[str]) -> str
     return ' -> '.join(dep.partition(';')[0].strip() for dep in dep_chain)
 
@@ -167,6 +180,8 @@ def main(cli_args, prog=None):  # type: (List[str], Optional[str]) -> None
 
     :param cli_args: CLI arguments
     """
+    build.print_info = _print_info
+
     parser = main_parser()
     if prog:
         parser.prog = prog


### PR DESCRIPTION
Fixes #142

This only implements the changes suggested in #142 to curate the output. It does not implement debug messages, as I said there, if we see the need, we can do it in the future. Things like the output of the environment creation, like pip, ensurepip, venv or virtualenv that are swallowed could be outputed in the future with a `-v` flag or something similar.