### PR TITLE
pre-commit: exclude test-no-permission/pyproject.toml from check-toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
   - id: check-merge-conflict
   - id: check-yaml
   - id: check-toml
-    exclude: tests/packages/test-bad-syntax/pyproject.toml
+    exclude: tests/packages/test-(bad-syntax|no-permission)/pyproject.toml
   - id: debug-statements
   - id: end-of-file-fixer
   - id: trailing-whitespace


### PR DESCRIPTION
When running tox in parallel, pre-commit might run at the same time as
the tests. This is problematic because the tests will remove read
permissions from the file and pre-commit won't be able to reade it. So,
we will ignore it.

Signed-off-by: Filipe Laíns <lains@riseup.net>