### PR TITLE
Document CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ See the [documentation](https://pypa-build.readthedocs.io/en/latest/) for more i
 $ pip install build
 ```
 
+### Usage
+
+```bash
+python -m build . --sdist --wheel
+```
+
+This will build the package in an isolated environment, generating a
+source-distribution and wheel in the directory `dist/`.
+
 ### Code of Conduct
 
 Everyone interacting in the build's codebase, issue trackers, chat rooms, and mailing lists is expected to follow

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,16 @@
+=========
+CLI Usage
+=========
+
+.. autoprogram:: build.__main__:main_parser()
+   :prog: python -m build
+
+.. note::
+
+   A ``pyproject-build`` CLI script is also available, so that tools such as pipx_
+   can use it.
+
+By default build will build the package in an isolated
+environment, but this behavior can be disabled with `--no-isolation`.
+
+.. _pipx: https://github.com/pipxproject/pipx

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,16 +9,12 @@ A simple, correct :pep:`517` package builder.
 build will invoke the :pep:`517` hooks to build a distribution package.
 It is a simple build tool and does not perform any dependency management.
 
-.. autoprogram:: build.__main__:main_parser()
-   :prog: python -m build
+.. code-block::
 
-.. note::
+   python -m build . --sdist --wheel
 
-   A ``pyproject-build`` CLI script is also available, so that tools such as pipx_
-   can use it.
-
-By default build will build the package in an isolated
-environment, but this behavior can be disabled with `--no-isolation`.
+This will build the package in an isolated environment, generating a
+source-distribution and wheel in the directory ``dist/``.
 
 .. toctree::
    :hidden:
@@ -31,9 +27,8 @@ environment, but this behavior can be disabled with `--no-isolation`.
    :hidden:
 
    installation
+   cli
    api
 
    Source Code <https://github.com/pypa/build/>
    Issue Tracker <https://github.com/pypa/build/issues>
-
-.. _pipx: https://github.com/pipxproject/pipx


### PR DESCRIPTION
Document example CLI usage in the README and on the home-page of the docs. Move CLI help to a separate docs page "CLI Usage"