### PR TITLE
Work around https://github.com/python/mypy/issues/1153

### DIFF
--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -64,7 +64,7 @@ def check_dependency(req_string, ancestral_req_strings=(), parent_extras=frozens
     if sys.version_info >= (3, 8):
         from importlib import metadata as importlib_metadata
     else:
-        import importlib_metadata
+        import importlib_metadata  # type: ignore
 
     req = packaging.requirements.Requirement(req_string)
 


### PR DESCRIPTION
Work around https://github.com/python/mypy/issues/1153; see also https://github.com/pypa/twine/pull/551.

This fixes #221, “Mypy error: Module 'importlib' has no attribute 'metadata'”.