### PR TITLE
mypy: fix importlib.metadata import error

### DIFF
--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -62,7 +62,7 @@ def check_dependency(req_string, ancestral_req_strings=(), parent_extras=frozens
     import packaging.requirements
 
     if sys.version_info >= (3, 8):
-        from importlib import metadata as importlib_metadata
+        import importlib.metadata as importlib_metadata
     else:
         import importlib_metadata
 


### PR DESCRIPTION
This fixes https://github.com/pypa/build/issues/211. It replaces incorrect PR https://github.com/pypa/build/pull/212.