### PR TITLE
build: implement metadata preparation hook

### DIFF
--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -48,7 +48,7 @@ class BuildBackendException(Exception):
         super(BuildBackendException, self).__init__()
         self.exception = exception  # type: Exception
 
-    def __repr__(self):  # type: () -> str
+    def __str__(self):  # type: () -> str
         return 'Backend operation failed: {!r}'.format(self.exception)
 
 

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -247,23 +247,24 @@ class ProjectBuilder(object):
         dependencies = self.get_dependencies(distribution, config_settings).union(self.build_dependencies)
         return {u for d in dependencies for u in check_dependency(d)}
 
-    def prepare(self, distribution, outdir, config_settings=None):
+    def prepare(self, distribution, output_directory, config_settings=None):
         # type: (str, str, Optional[ConfigSettings]) -> Optional[str]
         """
         Prepare metadata for a distribution.
 
         :param distribution: Distribution to build (must be ``wheel``)
-        :param outdir: Output directory
+        :param output_directory: Directory to put the prepared metadata in
+        :param config_settings: Config settings for the build backend
         :returns: The full path to the prepared metadata directory
         """
         prepare = getattr(self._hook, 'prepare_metadata_for_build_{}'.format(distribution))
-        outdir = os.path.abspath(outdir)
+        outdir = os.path.abspath(output_directory)
 
-        if os.path.exists(outdir):
-            if not os.path.isdir(outdir):
-                raise BuildException("Build path '{}' exists and is not a directory".format(outdir))
+        if os.path.exists(output_directory):
+            if not os.path.isdir(output_directory):
+                raise BuildException("Build path '{}' exists and is not a directory".format(output_directory))
         else:
-            os.mkdir(outdir)
+            os.mkdir(output_directory)
 
         try:
             with _working_directory(self.srcdir):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -64,19 +64,15 @@ def test_fail_to_get_script_path(mocker):
 @pytest.mark.skipif(sys.version_info[0] == 2, reason='venv module used on Python 3 only')
 @pytest.mark.skipif(IS_PYPY3, reason='PyPy3 uses get path to create and provision venv')
 def test_fail_to_get_purepath(mocker):
+    mocker.patch.object(build.env, 'virtualenv', None)
     sysconfig_get_path = sysconfig.get_path
-
-    def mock_sysconfig_get_path(path, *args, **kwargs):
-        if path == 'purelib':
-            return ''
-        else:
-            return sysconfig_get_path(path, *args, **kwargs)
-
-    mocker.patch('sysconfig.get_path', side_effect=mock_sysconfig_get_path)
+    mocker.patch(
+        'sysconfig.get_path',
+        side_effect=lambda path, *args, **kwargs: '' if path == 'purelib' else sysconfig_get_path(path, *args, **kwargs),
+    )
 
     with pytest.raises(RuntimeError, match="Couldn't get environment purelib folder"):
-        env = build.env.IsolatedEnvBuilder()
-        with env:
+        with build.env.IsolatedEnvBuilder():
             pass
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -163,7 +163,7 @@ def test_build_raises_build_exception(mocker, test_flit_path):
 @pytest.mark.isolated
 def test_build_raises_build_backend_exception(mocker, test_flit_path):
     error = mocker.patch('build.__main__._error')
-    mocker.patch('build.ProjectBuilder.get_dependencies', side_effect=build.BuildBackendException)
+    mocker.patch('build.ProjectBuilder.get_dependencies', side_effect=build.BuildBackendException(Exception('a')))
     mocker.patch('build.env._IsolatedEnvVenvPip.install')
 
     build.__main__.build_package(test_flit_path, '.', ['sdist'])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -167,5 +167,5 @@ def test_build_raises_build_backend_exception(mocker, test_flit_path):
     mocker.patch('build.env._IsolatedEnvVenvPip.install')
 
     build.__main__.build_package(test_flit_path, '.', ['sdist'])
-
-    error.assert_called_with('')
+    msg = "Backend operation failed: Exception('a'{})".format(',' if sys.version_info < (3, 7) else '')
+    error.assert_called_with(msg)

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -402,9 +402,8 @@ def test_prepare_no_hook(mocker, tmp_dir, test_flit_path):
     mocker.patch('pep517.wrappers.Pep517HookCaller', autospec=True)
 
     builder = build.ProjectBuilder(test_flit_path)
-    builder._hook.prepare_metadata_for_build_wheel.side_effect = pep517.wrappers.HookMissing(
-        'prepare_metadata_for_build_wheel'
-    )
+    failure = pep517.wrappers.HookMissing('prepare_metadata_for_build_wheel')
+    builder._hook.prepare_metadata_for_build_wheel.side_effect = failure
 
     assert builder.prepare('wheel', tmp_dir) is None
 

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -414,7 +414,7 @@ def test_prepare_error(mocker, tmp_dir, test_flit_path):
     builder = build.ProjectBuilder(test_flit_path)
     builder._hook.prepare_metadata_for_build_wheel.side_effect = Exception
 
-    with pytest.raises(build.BuildBackendException):
+    with pytest.raises(build.BuildBackendException, match='Backend operation failed: Exception'):
         builder.prepare('wheel', tmp_dir)
 
 
@@ -426,6 +426,5 @@ def test_prepare_not_dir_outdir(mocker, tmp_dir, test_flit_path):
     out = os.path.join(tmp_dir, 'out')
     with open(out, 'w') as f:
         f.write('Not a directory')
-
-    with pytest.raises(build.BuildException):
+    with pytest.raises(build.BuildException, match='Build path .* exists and is not a directory'):
         builder.prepare('wheel', out)


### PR DESCRIPTION
Fix #130.

I make the function signature require the user to pass in `"wheel"` explicitly. This is of course redundant, but I have a feeling we’re going to have a `prepare_metadata_for_sdist` at some point and it’s better to leave room now than having to change things later. And `prepare("wheel")` is arguably more consistent with `build("wheel")` anyway.

Due to the issues mentioned in https://github.com/pypa/build/issues/130#issuecomment-769849702, I’m *not* using the `build_wheel` fallback provided by `pep517`, and instead return `None` when the backend does not implement `prepare_metadata_for_wheel`. The returned result is stored in a member attribute and popped out when `build_wheel` is called.