### PR TITLE
docs: improve the formatting, style and accuracy of docstrings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,3 +63,5 @@ html_title = f'build {version}'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named 'default.css' will overwrite the builtin 'default.css'.
 # html_static_path = ['_static']
+
+autoclass_content = 'both'

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 """
-build - A simple, correct PEP517 package builder
+build - A simple, correct PEP 517 package builder
 """
 __version__ = '0.2.0'
 
@@ -117,14 +117,16 @@ def _working_directory(path):  # type: (str) -> Iterator[None]
 
 
 class ProjectBuilder(object):
+    """
+    The PEP 517 consumer API.
+    """
+
     def __init__(self, srcdir, python_executable=sys.executable, scripts_dir=None):
         # type: (str, Union[bytes, Text], Optional[Union[bytes, Text]]) -> None
         """
-        Create a project builder.
-
-        :param srcdir: the source directory
-        :param scripts_dir: the location of the scripts dir (defaults to the folder where the python executable lives)
-        :param python_executable: the python executable where the backend lives
+        :param srcdir: The source directory
+        :param scripts_dir: The location of the scripts dir (defaults to the folder where the python executable lives)
+        :param python_executable: The python executable where the backend lives
         """
         self.srcdir = os.path.abspath(srcdir)  # type: str
 

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -30,7 +30,7 @@ warnings.showwarning = _showwarning
 
 def _error(msg, code=1):  # type: (str, int) -> None  # pragma: no cover
     """
-    Prints an error message and exits. Will color the output when writing to a TTY.
+    Print an error message and exit. Will color the output when writing to a TTY.
 
     :param msg: Error message
     :param code: Error code
@@ -76,7 +76,7 @@ def _build_in_current_env(builder, outdir, distributions, config_settings, skip_
 def build_package(srcdir, outdir, distributions, config_settings=None, isolation=True, skip_dependencies=False):
     # type: (str, str, List[str], Optional[ConfigSettings], bool, bool) -> None
     """
-    Runs the build process
+    Run the build process.
 
     :param srcdir: Source directory
     :param outdir: Output directory
@@ -106,7 +106,7 @@ def build_package(srcdir, outdir, distributions, config_settings=None, isolation
 
 def main_parser():  # type: () -> argparse.ArgumentParser
     """
-    Constructs the main parser
+    Construct the main parser.
     """
     # mypy does not recognize module.__path__
     # https://github.com/python/mypy/issues/1422
@@ -167,9 +167,10 @@ def main_parser():  # type: () -> argparse.ArgumentParser
 
 def main(cli_args, prog=None):  # type: (List[str], Optional[str]) -> None
     """
-    Parses the CLI arguments and invokes the build process.
+    Parse the CLI arguments and invoke the build process.
 
     :param cli_args: CLI arguments
+    :param prog: Program name to show in help text
     """
     parser = main_parser()
     if prog:


### PR DESCRIPTION
Sphinx does not extract docstrings from `__init__` - these
must be placed under the class.