### PR TITLE
env: upgrade pip based on pi version (fixes Python 3.6.5-3.8 issues, including in GitHub Actions via pipx)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,16 @@ Changelog
 +++++++++
 
 
+Unreleased
+==========
+
+- Upgrade pip based on venv pip version, avoids error from unrecognised pip flag on Debian Python 3.6.5-3.8 (`PR #229`_, Fixes `#228`_)
+
+.. _PR #229: https://github.com/pypa/build/pull/229
+.. _#228: https://github.com/pypa/build/issues/228
+
+
+
 0.2.1 (09-02-2021)
 ==================
 

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -13,8 +13,15 @@ import tempfile
 from types import TracebackType
 from typing import Iterable, Optional, Tuple, Type
 
+import packaging.version
+
 from ._compat import abstractproperty, add_metaclass
 
+
+if sys.version_info < (3, 8):
+    import importlib_metadata as metadata
+else:
+    from importlib import metadata
 
 try:
     import virtualenv
@@ -169,20 +176,28 @@ def _create_isolated_env_venv(path):  # type: (str) -> Tuple[str, str]
     import venv
 
     venv.EnvBuilder(with_pip=True).create(path)
-    executable, script_dir = _find_executable_and_scripts(path)
-    # avoid the setuptools from ensurepip to break the isolation
-    if sys.version_info < (3, 6, 6):  # python 3.5 up to 3.6.5 come with pip 9 that's too old, for new standards
+    executable, script_dir, purelib = _find_executable_and_scripts(path)
+
+    # Get the version of pip in the environment
+    pip_distribution = next(iter(metadata.distributions(name='pip', path=[purelib])))
+    pip_version = packaging.version.Version(pip_distribution.version)
+
+    # Currently upgrade if Pip 19.1+ not available, since Pip 19 is the first
+    # one to officially support PEP 517, and 19.1 supports manylinux1.
+    if pip_version < packaging.version.Version('19.1'):
         subprocess.check_call([executable, '-m', 'pip', 'install', '-U', 'pip'])
+
+    # Avoid the setuptools from ensurepip to break the isolation
     subprocess.check_call([executable, '-m', 'pip', 'uninstall', 'setuptools', '-y'])
     return executable, script_dir
 
 
-def _find_executable_and_scripts(path):  # type: (str) -> Tuple[str, str]
+def _find_executable_and_scripts(path):  # type: (str) -> Tuple[str, str, str]
     """
     Detect the Python executable and script folder of a virtual environment.
 
     :param path: The location of the virtual environment
-    :return: The Python executable and script folder
+    :return: The Python executable, script folder, and purelib folder
     """
     config_vars = sysconfig.get_config_vars().copy()  # globally cached, copy before altering it
     config_vars['base'] = path
@@ -195,7 +210,11 @@ def _find_executable_and_scripts(path):  # type: (str) -> Tuple[str, str]
     executable = os.path.join(env_scripts, exe)
     if not os.path.exists(executable):
         raise RuntimeError('Virtual environment creation failed, executable {} missing'.format(executable))
-    return executable, env_scripts
+
+    purelib = sysconfig.get_path('purelib', vars=config_vars)
+    if not purelib:
+        raise RuntimeError("Couldn't get environment purelib folder")
+    return executable, env_scripts, purelib
 
 
 __all__ = (

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -8,6 +8,8 @@ import sysconfig
 
 import pytest
 
+from packaging.version import Version
+
 import build.env
 
 
@@ -60,6 +62,25 @@ def test_fail_to_get_script_path(mocker):
 
 @pytest.mark.skipif(sys.version_info[0] == 2, reason='venv module used on Python 3 only')
 @pytest.mark.skipif(IS_PYPY3, reason='PyPy3 uses get path to create and provision venv')
+def test_fail_to_get_purepath(mocker):
+    sysconfig_get_path = sysconfig.get_path
+
+    def mock_sysconfig_get_path(path, *args, **kwargs):
+        if path == 'purelib':
+            return ''
+        else:
+            return sysconfig_get_path(path, *args, **kwargs)
+
+    mocker.patch('sysconfig.get_path', side_effect=mock_sysconfig_get_path)
+
+    with pytest.raises(RuntimeError, match="Couldn't get environment purelib folder"):
+        env = build.env.IsolatedEnvBuilder()
+        with env:
+            pass
+
+
+@pytest.mark.skipif(sys.version_info[0] == 2, reason='venv module used on Python 3 only')
+@pytest.mark.skipif(IS_PYPY3, reason='PyPy3 uses get path to create and provision venv')
 def test_executable_missing_post_creation(mocker):
     mocker.patch.object(build.env, 'virtualenv', None)
     original_get_path = sysconfig.get_path
@@ -100,7 +121,9 @@ def test_isolated_env_has_install_still_abstract():
 
 
 @pytest.mark.isolated
-@pytest.mark.skipif(sys.version_info > (3, 6, 5), reason='inapplicable')
-def test_default_pip_is_upgraded_on_python_3_6_5_and_below():
+def test_default_pip_is_never_too_old():
     with build.env.IsolatedEnvBuilder() as env:
-        assert not subprocess.check_output([env.executable, '-m', 'pip', '-V']).startswith(b'pip 9.0')
+        version = subprocess.check_output(
+            [env.executable, '-c', 'import pip; print(pip.__version__)'], universal_newlines=True
+        ).strip()
+        assert Version(version) >= Version('19.1')


### PR DESCRIPTION
Fixes #228

- fix: Upgrade pip for all Python < 3.7
- fix: avoid breaking so badly if pip is too old
