### PR TITLE
env: fix issue installing wheels on Big Sur

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Unreleased
 - Upgrade pip based on venv pip version, avoids error from unrecognised pip flag on Debian Python 3.6.5-3.8 (`PR #229`_, Fixes `#228`_)
 - Build dependencies in isolation, instead of in the build environment (`PR #232`_, Fixes `#231`_)
 
+.. _PR #230: https://github.com/pypa/build/pull/230
 .. _PR #229: https://github.com/pypa/build/pull/229
 .. _#228: https://github.com/pypa/build/issues/228
 .. _PR #232: https://github.com/pypa/build/pull/232

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -11,7 +11,7 @@ import sysconfig
 import tempfile
 
 from types import TracebackType
-from typing import Iterable, Optional, Tuple, Type
+from typing import Any, Iterable, Optional, Tuple, Type, cast
 
 import packaging.version
 
@@ -183,10 +183,31 @@ def _create_isolated_env_venv(path):  # type: (str) -> Tuple[str, str]
     pip_distribution = next(iter(metadata.distributions(name='pip', path=[purelib])))
     pip_version = packaging.version.Version(pip_distribution.version)
 
-    # Currently upgrade if Pip 19.1+ not available, since Pip 19 is the first
-    # one to officially support PEP 517, and 19.1 supports manylinux1.
+    # If any of these match, an upgrade is needed
     if pip_version < packaging.version.Version('19.1'):
+        # Currently upgrade if Pip 19.1+ not available, since Pip 19 is the first
+        # one to officially support PEP 517, and 19.1 supports manylinux1.
         subprocess.check_call([executable, '-m', 'pip', 'install', '-U', 'pip'])
+    elif platform.system() == 'Darwin':
+        # macOS 11+ needs Pip 20.3+ due to the name scheme change.  Note
+        # that Intel macOS 11.0 can be told to report 10.16 for backwards
+        # compatibility; but that also fixes earlier versions of pip so
+        # this is only needed for 11+.
+
+        # Have to use workaround due to missing typestub in Python 2 typeshed
+        platform_mac_ver = cast(Any, platform.mac_ver)
+
+        mac_ver = int(platform_mac_ver()[0].split('.')[0])
+        if mac_ver >= 11:
+            if pip_version < packaging.version.Version('20.3'):
+                subprocess.check_call([executable, '-m', 'pip', 'install', '-U', 'pip'])
+            elif (
+                pip_version < packaging.version.Version('21.0.1')
+                and sys.version_info >= (3, 6)
+                and platform.machine() != 'x86_64'
+            ):
+                # The first version of Pip to fully support Apple Silicon macOS was 21.0.1.
+                subprocess.check_call([executable, '-m', 'pip', 'install', '-U', 'pip'])
 
     # Avoid the setuptools from ensurepip to break the isolation
     subprocess.check_call([executable, '-m', 'pip', 'uninstall', 'setuptools', '-y'])


### PR DESCRIPTION
Followup to #229. This fixes an issue I've seen trying to install `cmake` on Big Sur (Intel), and preemptively fixes an issue for Big Sur (Apple Silicon).

Edit: I'm now questioning if I got the version right for pip breaking on Big Sur Intel...
EditEdit: Ahh, I have a custom wheel cached as workaround. 🤦 Yes, 20.2 does break, as promised. 

To see the problem, `pyenv install 3.9.1`, activate it, install build, then build the following `pyproject.toml`:

```toml
[build-system]
requires = ["flit_core >=2,<4", "cmake"]
build-backend = "flit_core.buildapi"

[tool.flit.metadata]
module = "foobar"
author = "Sir Robin"
author-email = "robin@camelot.uk"
home-page = "https://github.com/sirrobin/foobar"
```

You will see `Building wheel for cmake (PEP 517)` because it's using the venv's pip 20.2.