### PR TITLE
env: pass --use-pep517 to force build isolation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,9 +7,12 @@ Unreleased
 ==========
 
 - Upgrade pip based on venv pip version, avoids error from unrecognised pip flag on Debian Python 3.6.5-3.8 (`PR #229`_, Fixes `#228`_)
+- Build dependencies in isolation, instead of in the build environment (`PR #232`_, Fixes `#231`_)
 
 .. _PR #229: https://github.com/pypa/build/pull/229
 .. _#228: https://github.com/pypa/build/issues/228
+.. _PR #232: https://github.com/pypa/build/pull/232
+.. _#231: https://github.com/pypa/build/issues/231
 
 
 

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -143,6 +143,7 @@ class _IsolatedEnvVenvPip(IsolatedEnv):
                 '-{}m'.format('E' if sys.version_info[0] == 2 else 'I'),
                 'pip',
                 'install',
+                '--use-pep517',
                 '--no-warn-script-location',
                 '-r',
                 os.path.abspath(req_file.name),

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -42,6 +42,7 @@ def test_isolated_environment_install(mocker):
             '-{}m'.format('E' if sys.version_info[0] == 2 else 'I'),
             'pip',
             'install',
+            '--use-pep517',
             '--no-warn-script-location',
             '-r',
         ]


### PR DESCRIPTION
In #231 we discovered pip is not building some dependencies in
isolation, it is using the build environment, which can become an issue
since we remove setuptools from the environment.

As suggested by @layday, this patch passes --use-pep517 to pip so that
it builds in isolation, as recomended by PEP 517.

Fixes #231

Signed-off-by: Filipe Laíns <lains@riseup.net>