### PR TITLE
tox: run mypy against the minimum supported Python 3 minor version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ commands =
 description = run type check on code base
 extras = typing
 commands =
-    mypy --python-version 3.8 src/build
+    mypy --python-version 3.5 src/build
     mypy --python-version 2.7 src/build
 
 [testenv:docs]


### PR DESCRIPTION
This ensures typing is right on Python 3 conditional branches.
Currently, we could have code that isn't compatible with Python 3 minor
version lower than Python 3.8. Running against the minimum supported
version ensures everything is checked correctly on older versions.

Signed-off-by: Filipe Laíns <lains@riseup.net>