### PR TITLE
docs: fix sphinx syntax @ `--config-setting` doc

### DIFF
--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -160,7 +160,7 @@ def main_parser():  # type: () -> argparse.ArgumentParser
         '-C',
         action='append',
         help='pass options to the backend.  options which begin with a hyphen must be in the form of '
-        '`--config-setting=--opt(=value)` or `-C--opt(=value)`',
+        '``--config-setting=--opt(=value)`` or ``-C--opt(=value)``',
     )
     return parser
 

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -160,7 +160,7 @@ def main_parser():  # type: () -> argparse.ArgumentParser
         '-C',
         action='append',
         help='pass options to the backend.  options which begin with a hyphen must be in the form of '
-        '``--config-setting=--opt(=value)`` or ``-C--opt(=value)``',
+        '"--config-setting=--opt(=value)" or "-C--opt(=value)"',
     )
     return parser
 


### PR DESCRIPTION
RST treats single backticks as `:any:` role that tries
to automatically match something with that name. This
generates a warning because there's nothing to be found.
But running Sphinx in nitpicky mode turns the warning
into an error.

There's two ways of fixing this: either use double backticks
for inline code or drop them and maybe switch to double-
quotes. This change does the former.