### PR TITLE
docs: put project links in separate section

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,10 @@ environment, but this behavior can be disabled with ``--no-isolation``.
    changelog
    api
 
+.. toctree::
+   :caption: Project Links
+   :hidden:
+
    Source Code <https://github.com/pypa/build/>
    Issue Tracker <https://github.com/pypa/build/issues>
 


### PR DESCRIPTION
Right now they are in the usage section, which is wrong.

Signed-off-by: Filipe Laíns <lains@riseup.net>