### PR TITLE
setup.cfg: support direct usage from pipx run in 0.16.1.0+

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,15 @@ Changelog
 +++++++++
 
 
+Unreleased
+==========
+
+- Support direct usage from pipx run in 0.16.1.0+ (`PR #247`_)
+
+.. _PR #247: https://github.com/pypa/build/pull/217
+
+
+
 0.3.0 (19-02-2021)
 ==================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,8 @@ package_dir =
 [options.entry_points]
 console_scripts =
     pyproject-build = build.__main__:entrypoint
+pipx.run =
+    build = build.__main__:entrypoint
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
Pipx has added a feature at our request to run packages with differently named entrypoints without having to use `--spec`. This is before:

```bash
pipx run --spec build pyproject-build
```

and this will work after this PR with Pipx 0.16.1.0+:

```bash
pipx run build
```

See pipxproject/pipx#600.
