### PR TITLE
Revert "setup.cfg: support direct usage from pipx run in 0.16.1.0+"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,15 +3,6 @@ Changelog
 +++++++++
 
 
-Unreleased
-==========
-
-- Support direct usage from pipx run in 0.16.1.0+ (`PR #247`_)
-
-.. _PR #247: https://github.com/pypa/build/pull/217
-
-
-
 0.3.0 (19-02-2021)
 ==================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,8 +40,6 @@ package_dir =
 [options.entry_points]
 console_scripts =
     pyproject-build = build.__main__:entrypoint
-pipx.run =
-    build = build.__main__:entrypoint
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
We should not expose the tool under multiple executable names. 

Reverts pypa/build#247