### PR TITLE
build: use UTF-8 encoding when reading pyproject.toml

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,11 @@ Unreleased
 ==========
 
 - Support direct usage from pipx run in 0.16.1.0+ (`PR #247`_)
+- Use UTF-8 encoding when reading pyproject.toml (`PR #251`_, Fixes `#250`_)
 
-.. _PR #247: https://github.com/pypa/build/pull/217
+.. _PR #247: https://github.com/pypa/build/pull/247
+.. _PR #251: https://github.com/pypa/build/pull/251
+.. _#250: https://github.com/pypa/build/issues/250
 
 
 

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -7,6 +7,7 @@ __version__ = '0.3.0'
 
 import contextlib
 import difflib
+import io
 import os
 import sys
 import warnings
@@ -140,7 +141,7 @@ class ProjectBuilder(object):
         spec_file = os.path.join(srcdir, 'pyproject.toml')
 
         try:
-            with open(spec_file) as f:
+            with io.open(spec_file, encoding="UTF-8") as f:
                 spec = toml.load(f)
         except FileNotFoundError:
             spec = {}

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -141,7 +141,7 @@ class ProjectBuilder(object):
         spec_file = os.path.join(srcdir, 'pyproject.toml')
 
         try:
-            with io.open(spec_file, encoding="UTF-8") as f:
+            with io.open(spec_file, encoding='UTF-8') as f:
                 spec = toml.load(f)
         except FileNotFoundError:
             spec = {}

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MIT
+# coding=utf-8
 
 from __future__ import unicode_literals
 
@@ -352,7 +353,17 @@ def test_build_with_dep_on_console_script(tmp_path, demo_pkg_inline, capfd, mock
     # we first install demo pkg inline as build dependency (as this provides a console script we can check)
     # to validate backend invocations contain the correct path we use an inline backend that will fail, but first
     # provides the PATH information (and validates shutil.which is able to discover the executable - as PEP states)
-    toml = '[build-system]\nrequires = ["demo_pkg_inline"]\nbuild-backend = "build"\nbackend-path = ["."]\n'
+    toml = textwrap.dedent(u'''
+        [build-system]
+        requires = ["demo_pkg_inline"]
+        build-backend = "build"
+        backend-path = ["."]
+        
+        [project]
+        description = "Factory ⸻ A code generator 🏭"
+        authors = [{name = "Łukasz Langa"}]
+        '''
+    )
     code = textwrap.dedent(
         '''
         import os

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -353,12 +353,13 @@ def test_build_with_dep_on_console_script(tmp_path, demo_pkg_inline, capfd, mock
     # we first install demo pkg inline as build dependency (as this provides a console script we can check)
     # to validate backend invocations contain the correct path we use an inline backend that will fail, but first
     # provides the PATH information (and validates shutil.which is able to discover the executable - as PEP states)
-    toml = textwrap.dedent(u'''
+    toml = textwrap.dedent(
+        u'''
         [build-system]
         requires = ["demo_pkg_inline"]
         build-backend = "build"
         backend-path = ["."]
-        
+
         [project]
         description = "Factory ⸻ A code generator 🏭"
         authors = [{name = "Łukasz Langa"}]
@@ -380,7 +381,7 @@ def test_build_with_dep_on_console_script(tmp_path, demo_pkg_inline, capfd, mock
         print("BB " + exe_at)
         '''
     )
-    (tmp_path / 'pyproject.toml').write_text(toml)
+    (tmp_path / 'pyproject.toml').write_text(toml, encoding='UTF-8')
     (tmp_path / 'build.py').write_text(code)
 
     deps = {str(demo_pkg_inline)}  # we patch the requires demo_pkg_inline to refer to the wheel -> we don't need index


### PR DESCRIPTION
Fixes #250

This avoids a `UnicodeDecodeError` when reading `pyproject.toml` files containing unicode characters on Windows. These characters may be present in a project's metadata, such as its description or an author's name.

Furthermore, the [TOML specification](https://toml.io/en/v1.0.0#spec) requires files to be encoded in UTF-8.