### PR TITLE
build: un-nest `chdir` context manager

### DIFF
--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -233,13 +233,13 @@ class ProjectBuilder(object):
         """
         get_requires = getattr(self._hook, 'get_requires_for_build_{}'.format(distribution))
 
-        try:
-            with _working_directory(self.srcdir):
+        with _working_directory(self.srcdir):
+            try:
                 return set(get_requires(config_settings))
-        except pep517.wrappers.BackendUnavailable:
-            raise BuildException("Backend '{}' is not available.".format(self._backend))
-        except Exception as e:
-            raise BuildBackendException(e)
+            except pep517.wrappers.BackendUnavailable:
+                raise BuildException("Backend '{}' is not available.".format(self._backend))
+            except Exception as e:
+                raise BuildBackendException(e)
 
     def check_dependencies(self, distribution, config_settings=None):
         # type: (str, Optional[ConfigSettings]) -> Set[Tuple[str, ...]]
@@ -299,14 +299,14 @@ class ProjectBuilder(object):
         else:
             os.mkdir(outdir)
 
-        try:
-            with _working_directory(self.srcdir):
+        with _working_directory(self.srcdir):
+            try:
                 basename = callback(outdir, config_settings, **kwargs)  # type: str
                 return os.path.join(outdir, basename)
-        except pep517.wrappers.BackendUnavailable:
-            raise BuildException("Backend '{}' is not available.".format(self._backend))
-        except Exception as exception:
-            raise BuildBackendException(exception)
+            except pep517.wrappers.BackendUnavailable:
+                raise BuildException("Backend '{}' is not available.".format(self._backend))
+            except Exception as exception:
+                raise BuildBackendException(exception)
 
 
 __all__ = (

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -243,6 +243,14 @@ def test_working_directory(tmp_dir):
         assert os.path.realpath(os.curdir) == os.path.realpath(tmp_dir)
 
 
+def test_working_directory_exc_is_not_transformed(mocker, test_flit_path, tmp_dir):
+    mocker.patch('build._working_directory', side_effect=OSError)
+
+    builder = build.ProjectBuilder(test_flit_path)
+    with pytest.raises(OSError):
+        builder._call_backend(lambda: None, tmp_dir)
+
+
 def test_build(mocker, test_flit_path, tmp_dir):
     mocker.patch('pep517.wrappers.Pep517HookCaller', autospec=True)
     mocker.patch('build._working_directory', autospec=True)


### PR DESCRIPTION
An OS error in `_working_directory` would have been incorrectly
transformed into a `BuildBackendException`.