### PR TITLE
tests: fix build being invoked in the wrong path for integration tests

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -97,6 +97,7 @@ def get_project(name, tmp_path):
     ],
 )
 @pytest.mark.isolated
+@pytest.mark.skipif(sys.version_info[0] == 2, reason='flit can only be built on Python 3')
 def test_build(monkeypatch, project, args, call, tmp_path):
     if project == 'flit' and '--no-isolation' in args:
         pytest.xfail("can't build flit without isolation due to missing dependencies")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -69,7 +69,7 @@ def get_project(name, tmp_path):
                     request.close()
     with tarfile.open(tarball, 'r:gz') as tar_handler:
         tar_handler.extractall(str(dest))
-    return dest
+    return dest / '{}-{}'.format(name, version)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -98,6 +98,9 @@ def get_project(name, tmp_path):
 )
 @pytest.mark.isolated
 def test_build(monkeypatch, project, args, call, tmp_path):
+    if project == 'flit' and '--no-isolation' in args:
+        pytest.xfail("can't build flit without isolation due to missing dependencies")
+
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv('SETUPTOOLS_SCM_PRETEND_VERSION', 'dummy')  # for the projects that use setuptools_scm
 


### PR DESCRIPTION
We extract the github tarballs and invoke build on the extracted
contents, but inside them there is a folder with the project sources,
which is where the build should be invoked.

Signed-off-by: Filipe Laíns <lains@riseup.net>