### PR TITLE
ci: don't pass a token to the codecov action

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -99,7 +99,6 @@ jobs:
         env:
           PYTHON: ${{ matrix.python }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./.tox/coverage.xml
           flags: tests
           env_vars: PYTHON


### PR DESCRIPTION
It's no longer necessary, it supports tokenless uploads for quite a while now.