### PR TITLE
build: rename get_dependencies to get_requires

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ Breaking Changes
 - The ``skip_dependencies`` argument of ``build.__main__.build_package`` has been renamed to ``skip_dependency_check``
 - ``build.ConfigSettings`` has been renamed to ``build.ConfigSettingsType``
 - ``build.ProjectBuilder.build_dependencies`` to ``build.ProjectBuilder.build_system_requires``
+- ``build.ProjectBuilder.get_dependencies`` to ``build.ProjectBuilder.get_requires_for_build``
 
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Breaking Changes
 - The ``--skip-depencencies`` option has been renamed to ``--skip-dependency-check``
 - The ``skip_dependencies`` argument of ``build.__main__.build_package`` has been renamed to ``skip_dependency_check``
 - ``build.ConfigSettings`` has been renamed to ``build.ConfigSettingsType``
+- ``build.ProjectBuilder.build_dependencies`` to ``build.ProjectBuilder.build_system_requires``
 
 
 

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -265,7 +265,8 @@ class ProjectBuilder(object):
         """
         return set(self._build_system['requires'])
 
-    def get_dependencies(self, distribution, config_settings=None):  # type: (str, Optional[ConfigSettingsType]) -> Set[str]
+    def get_requires_for_build(self, distribution, config_settings=None):
+        # type: (str, Optional[ConfigSettingsType]) -> Set[str]
         """
         Return the dependencies defined by the backend in addition to
         :attr:`build_system_requires` for a given distribution.
@@ -284,14 +285,14 @@ class ProjectBuilder(object):
         # type: (str, Optional[ConfigSettingsType]) -> Set[Tuple[str, ...]]
         """
         Return the dependencies which are not satisfied from the combined set of
-        :attr:`build_system_requires` and :meth:`get_dependencies` for a given
+        :attr:`build_system_requires` and :meth:`get_requires_for_build` for a given
         distribution.
 
         :param distribution: Distribution to check (``sdist`` or ``wheel``)
         :param config_settings: Config settings for the build backend
         :returns: Set of variable-length unmet dependency tuples
         """
-        dependencies = self.get_dependencies(distribution, config_settings).union(self.build_system_requires)
+        dependencies = self.get_requires_for_build(distribution, config_settings).union(self.build_system_requires)
         return {u for d in dependencies for u in check_dependency(d)}
 
     def prepare(self, distribution, output_directory, config_settings=None):

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -257,7 +257,7 @@ class ProjectBuilder(object):
         self._scripts_dir = value
 
     @property
-    def build_dependencies(self):  # type: () -> Set[str]
+    def build_system_requires(self):  # type: () -> Set[str]
         """
         The dependencies defined in the ``pyproject.toml``'s
         ``build-system.requires`` field or the default build dependencies
@@ -268,7 +268,7 @@ class ProjectBuilder(object):
     def get_dependencies(self, distribution, config_settings=None):  # type: (str, Optional[ConfigSettingsType]) -> Set[str]
         """
         Return the dependencies defined by the backend in addition to
-        :attr:`build_dependencies` for a given distribution.
+        :attr:`build_system_requires` for a given distribution.
 
         :param distribution: Distribution to get the dependencies of
             (``sdist`` or ``wheel``)
@@ -284,14 +284,14 @@ class ProjectBuilder(object):
         # type: (str, Optional[ConfigSettingsType]) -> Set[Tuple[str, ...]]
         """
         Return the dependencies which are not satisfied from the combined set of
-        :attr:`build_dependencies` and :meth:`get_dependencies` for a given
+        :attr:`build_system_requires` and :meth:`get_dependencies` for a given
         distribution.
 
         :param distribution: Distribution to check (``sdist`` or ``wheel``)
         :param config_settings: Config settings for the build backend
         :returns: Set of variable-length unmet dependency tuples
         """
-        dependencies = self.get_dependencies(distribution, config_settings).union(self.build_dependencies)
+        dependencies = self.get_dependencies(distribution, config_settings).union(self.build_system_requires)
         return {u for d in dependencies for u in check_dependency(d)}
 
     def prepare(self, distribution, output_directory, config_settings=None):

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -58,7 +58,7 @@ def _build_in_isolated_env(builder, outdir, distributions, config_settings):
             # first install the build dependencies
             env.install(builder.build_system_requires)
             # then get the extra required dependencies from the backend (which was installed in the call above :P)
-            env.install(builder.get_dependencies(distribution))
+            env.install(builder.get_requires_for_build(distribution))
             builder.build(distribution, outdir, config_settings)
 
 

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -56,7 +56,7 @@ def _build_in_isolated_env(builder, outdir, distributions, config_settings):
             builder.python_executable = env.executable
             builder.scripts_dir = env.scripts_dir
             # first install the build dependencies
-            env.install(builder.build_dependencies)
+            env.install(builder.build_system_requires)
             # then get the extra required dependencies from the backend (which was installed in the call above :P)
             env.install(builder.get_dependencies(distribution))
             builder.build(distribution, outdir, config_settings)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -103,7 +103,7 @@ def test_version(capsys):
 def test_build_isolated(mocker, test_flit_path):
     build_cmd = mocker.patch('build.ProjectBuilder.build')
     required_cmd = mocker.patch(
-        'build.ProjectBuilder.get_dependencies',
+        'build.ProjectBuilder.get_requires_for_build',
         side_effect=[
             ['dep1', 'dep2'],
         ],
@@ -152,7 +152,7 @@ def test_build_no_isolation_with_check_deps(mocker, test_flit_path, missing_deps
 @pytest.mark.isolated
 def test_build_raises_build_exception(mocker, test_flit_path):
     error = mocker.patch('build.__main__._error')
-    mocker.patch('build.ProjectBuilder.get_dependencies', side_effect=build.BuildException)
+    mocker.patch('build.ProjectBuilder.get_requires_for_build', side_effect=build.BuildException)
     mocker.patch('build.env._IsolatedEnvVenvPip.install')
 
     build.__main__.build_package(test_flit_path, '.', ['sdist'])
@@ -163,7 +163,7 @@ def test_build_raises_build_exception(mocker, test_flit_path):
 @pytest.mark.isolated
 def test_build_raises_build_backend_exception(mocker, test_flit_path):
     error = mocker.patch('build.__main__._error')
-    mocker.patch('build.ProjectBuilder.get_dependencies', side_effect=build.BuildBackendException(Exception('a')))
+    mocker.patch('build.ProjectBuilder.get_requires_for_build', side_effect=build.BuildBackendException(Exception('a')))
     mocker.patch('build.env._IsolatedEnvVenvPip.install')
 
     build.__main__.build_package(test_flit_path, '.', ['sdist'])

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -405,7 +405,7 @@ def test_build_with_dep_on_console_script(tmp_path, demo_pkg_inline, capfd, mock
     (tmp_path / 'build.py').write_text(code)
 
     deps = {str(demo_pkg_inline)}  # we patch the requires demo_pkg_inline to refer to the wheel -> we don't need index
-    mocker.patch('build.ProjectBuilder.build_dependencies', new_callable=mocker.PropertyMock, return_value=deps)
+    mocker.patch('build.ProjectBuilder.build_system_requires', new_callable=mocker.PropertyMock, return_value=deps)
     from build.__main__ import main
 
     with pytest.raises(SystemExit):

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -195,19 +195,19 @@ def test_python_executable(test_flit_path, value):
 
 
 @pytest.mark.parametrize('distribution', ['wheel', 'sdist'])
-def test_get_dependencies_missing_backend(packages_path, distribution):
+def test_get_requires_for_build_missing_backend(packages_path, distribution):
     bad_backend_path = os.path.join(packages_path, 'test-bad-backend')
     builder = build.ProjectBuilder(bad_backend_path)
 
     with pytest.raises(build.BuildBackendException):
-        builder.get_dependencies(distribution)
+        builder.get_requires_for_build(distribution)
 
 
 @pytest.mark.parametrize('distribution', ['wheel', 'sdist'])
-def test_get_dependencies_missing_optional_hooks(test_optional_hooks_path, distribution):
+def test_get_requires_for_build_missing_optional_hooks(test_optional_hooks_path, distribution):
     builder = build.ProjectBuilder(test_optional_hooks_path)
 
-    assert builder.get_dependencies(distribution) == set()
+    assert builder.get_requires_for_build(distribution) == set()
 
 
 @pytest.mark.parametrize('distribution', ['wheel', 'sdist'])


### PR DESCRIPTION
Fixes #182

Signed-off-by: Filipe Laíns <lains@riseup.net>