### PR TITLE
main: disable colors on windows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Unreleased
 - Error sooner if pip upgrade is required and fails (`PR #288`_, Fixes `#256`_)
 - Add a ``runner`` argument to ``ProjectBuilder`` (`PR #290`_, Fixes `#289`_)
 - Hide irrelevant ``pep517`` error traceback and improve error messages (`PR #296`_)
+- Try to use ``colorama`` to fix colors on Windows (`PR #300`_)
 
 .. _PR #260: https://github.com/pypa/build/pull/260
 .. _PR #267: https://github.com/pypa/build/pull/267
@@ -19,6 +20,7 @@ Unreleased
 .. _PR #288: https://github.com/pypa/build/pull/288
 .. _PR #290: https://github.com/pypa/build/pull/290
 .. _PR #296: https://github.com/pypa/build/pull/296
+.. _PR #300: https://github.com/pypa/build/pull/300
 .. _#256: https://github.com/pypa/build/issues/256
 .. _#259: https://github.com/pypa/build/issues/259
 .. _#263: https://github.com/pypa/build/issues/263

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     packaging>=19.0
     pep517>=0.9.1
     toml>=0.10.0
+    colorama;os_name == "nt" # not actually a runtime dependency, only supplied as there is not "recomended dependency" support
     importlib-metadata>=0.22;python_version < "3.8"
     typing>=3.5.3.0;python_version < "3"
     virtualenv>=20.0.35;python_version < "3"

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -17,6 +17,14 @@ from build import BuildBackendException, BuildException, ConfigSettingsType, Pro
 from build.env import IsolatedEnvBuilder
 
 
+try:
+    import colorama
+except ImportError:
+    pass
+else:
+    colorama.init()  # fix colors on windows
+
+
 __all__ = ['build', 'main', 'main_parser']
 
 


### PR DESCRIPTION
It seems Windows has settings to enable/disable color support by default
and we'd have to use low level Windows APIs to force enable, so I am
just gonna remove colors altogether. Shouldn't really be a big deal as
they are only used for the ERROR and WARNING prefixes.

Signed-off-by: Filipe Laíns <lains@riseup.net>