### PR TITLE
ci: rerun tests if they fail with subprocess.CalledProcessError

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
   pytest:
     runs-on: ${{ matrix.os }}-latest
     env:
-      PYTEST_ADDOPTS: "--run-integration --showlocals -vv --durations=10"
+      PYTEST_ADDOPTS: "--run-integration --showlocals -vv --durations=10 --reruns 5" # --only-rerun subprocess.CalledProcessError (only on 9.1, which does not support Python 2)
     strategy:
       fail-fast: false
       matrix:

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ test =
     pytest>=4
     pytest-cov>=2
     pytest-mock>=2
+    pytest-rerunfailures>=8.0
     pytest-xdist>=1.34
     setuptools>=42.0.0
     wheel>=0.36.0


### PR DESCRIPTION
Tests that use ensurepip are a bit flaky, let's rerun tests to avoid us
having to manually rerun the whole CI pipeline.

Signed-off-by: Filipe Laíns <lains@riseup.net>