### PR TITLE
build: remove unneeded importlib_metadata dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,6 @@ install_requires =
     pep517>=0.9.1
     toml>=0.10.0
     colorama;os_name == "nt" # not actually a runtime dependency, only supplied as there is not "recomended dependency" support
-    importlib-metadata>=0.22;python_version < "3.8"
     typing>=3.5.3.0;python_version < "3"
     virtualenv>=20.0.35;python_version < "3"
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
@@ -59,6 +58,7 @@ test =
     pytest-xdist>=1.34
     setuptools>=42.0.0
     wheel>=0.36.0
+    importlib-metadata>=0.22;python_version < "3.8"
     pathlib2>=2.0.0;python_version < "3"
 typing =
     mypy==0.800


### PR DESCRIPTION
This is leftover, we don't actually need it anymore.

Signed-off-by: Filipe Laíns <lains@riseup.net>