### PR TITLE
setup.cfg: disable universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -69,9 +69,6 @@ build =
 [options.packages.find]
 where = src
 
-[bdist_wheel]
-universal = 1
-
 [tool:pytest]
 junit_family = xunit2
 norecursedirs = tests/integration/*


### PR DESCRIPTION
We have now dropped Python 2, this should be disabled, otherwise
setuptools will still build a py2.py3 wheel.

Signed-off-by: Filipe Laíns <lains@riseup.net>