### PR TITLE
main: fix missing dependencies error

### DIFF
--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -122,7 +122,8 @@ def _build_in_current_env(
         missing = builder.check_dependencies(distribution)
         if missing:
             dependencies = ''.join('\n\t' + dep for deps in missing for dep in (deps[0], _format_dep_chain(deps[1:])) if dep)
-            _error(f'\nMissing dependencies:{dependencies}')
+            print()
+            _error(f'Missing dependencies:{dependencies}')
 
     return builder.build(distribution, outdir, config_settings or {})
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -162,7 +162,7 @@ def test_build_no_isolation_with_check_deps(mocker, test_flit_path, missing_deps
     build.__main__.build_package(test_flit_path, '.', ['sdist'], isolation=False)
 
     build_cmd.assert_called_with('sdist', '.', {})
-    error.assert_called_with('\nMissing dependencies:' + output)
+    error.assert_called_with('Missing dependencies:' + output)
 
 
 @pytest.mark.isolated


### PR DESCRIPTION
7ed0a6bf06e05e6ccc72a99fe8194ebb9a2f1d20 added the new line in the
_error call, but we want it before.

Signed-off-by: Filipe Laíns <lains@riseup.net>