### PR TITLE
env: refactor `IsolatedEnv`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,5 +29,5 @@ jobs:
       - name: Setup run environment
         run: tox -vv --notest -e docs
 
-      - name: Run check for type
+      - name: Run check for docs
         run: tox -e docs --skip-pkg-install

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,11 @@
 version: 2
 
+build:
+  os: ubuntu-20.04
+  tools:
+    python: '3.10'
+
 python:
-  version: 3.8
   install:
     - method: pip
       path: .

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,19 @@ Unreleased
 - Add schema validation for ``build-system`` table to check conformity
   with PEP 517 and PEP 518 (`PR #365`_, Fixes `#364`_)
 
+Breaking changes
+----------------
+
+- The isolated environment interface was redesigned (`PR #361`_)
+
+  - ``IsolatedEnvBuilder`` removed and its functionality taken over by
+    ``DefaultIsolatedEnv.with_temp_dir``
+  - ``ProjectBuiler.from_isolated_env`` added to initialise a builder from
+    an isolated environment
+  - ``RunnerType`` callback signature changed to allow modifying the
+    ``os.environ`` wholesale
+
+.. _PR #361: https://github.com/pypa/build/pull/361
 .. _PR #365: https://github.com/pypa/build/pull/365
 .. _PR #392: https://github.com/pypa/build/pull/392
 .. _#364: https://github.com/pypa/build/issues/364

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,8 +1,6 @@
 API Documentation
 =================
 
-This project exposes 2 modules:
-
 ``build`` module
 ----------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,6 +10,7 @@ This project exposes 2 modules:
    :members:
    :undoc-members:
    :show-inheritance:
+   :special-members: __call__
 
 ``build.env`` module
 --------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,5 +65,5 @@ html_title = f'build {version}'
 # html_static_path = ['_static']
 
 autoclass_content = 'both'
-
+autodoc_member_order = 'bysource'
 autodoc_preserve_defaults = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,3 +65,5 @@ html_title = f'build {version}'
 # html_static_path = ['_static']
 
 autoclass_content = 'both'
+
+autodoc_preserve_defaults = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ source = [
 exclude_lines = [
   '\#\s*pragma: no cover',
   '^\s*raise NotImplementedError\b',
+  "if TYPE_CHECKING:",
 ]
 
 [tool.coverage.paths]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ exclude_lines = [
   '\#\s*pragma: no cover',
   '^\s*raise NotImplementedError\b',
   "if TYPE_CHECKING:",
+  "@overload",
 ]
 
 [tool.coverage.paths]

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     tomli>=1.0.0 # toml can be used instead -- in case it makes bootstrapping easier
     colorama;os_name == "nt" # not actually a runtime dependency, only supplied as there is not "recommended dependency" support
     importlib-metadata>=0.22;python_version < "3.8"
+    typing-extensions>=3.8;python_version < "3.8"
 python_requires = >=3.6
 package_dir =
     =src
@@ -64,7 +65,6 @@ test =
 typing =
     importlib-metadata>=4.6.4
     mypy==0.910
-    typing-extensions>=3.7.4.3
 virtualenv =
     virtualenv>=20.0.35
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,6 @@ install_requires =
     tomli>=1.0.0 # toml can be used instead -- in case it makes bootstrapping easier
     colorama;os_name == "nt" # not actually a runtime dependency, only supplied as there is not "recommended dependency" support
     importlib-metadata>=0.22;python_version < "3.8"
-    typing-extensions>=3.8;python_version < "3.8"
 python_requires = >=3.6
 package_dir =
     =src
@@ -65,6 +64,7 @@ test =
 typing =
     importlib-metadata>=4.6.4
     mypy==0.910
+    typing-extensions>=3.8;python_version < "3.8"
 virtualenv =
     virtualenv>=20.0.35
 

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -19,7 +19,6 @@ import zipfile
 
 from typing import (
     TYPE_CHECKING,
-    AbstractSet,
     Any,
     Callable,
     Dict,
@@ -27,7 +26,6 @@ from typing import (
     Mapping,
     MutableMapping,
     Optional,
-    Sequence,
     Set,
     Tuple,
     Type,
@@ -36,10 +34,12 @@ from typing import (
 
 import pep517.wrappers
 
+from . import env
+from ._helpers import ConfigSettingsType, PathType, check_dependency
+
 
 if TYPE_CHECKING:
-    # Avoid import cycle.
-    from . import env
+    from ._helpers import RunnerType
 
 
 TOMLDecodeError: Type[Exception]
@@ -54,27 +54,7 @@ except ModuleNotFoundError:  # pragma: no cover
     from toml import loads as toml_loads  # type: ignore
 
 
-ConfigSettingsType = Mapping[str, Union[str, Sequence[str]]]
-PathType = Union[str, 'os.PathLike[str]']
 _ExcInfoType = Union[Tuple[Type[BaseException], BaseException, types.TracebackType], Tuple[None, None, None]]
-
-
-if TYPE_CHECKING:
-    from typing_extensions import Protocol
-
-    class RunnerType(Protocol):
-        def __call__(
-            self, cmd: Sequence[str], cwd: Optional[PathType] = None, extra_environ: Optional[Mapping[str, str]] = None
-        ) -> None:
-            """
-            Run a command in a Python subprocess.
-
-            The parameters mirror those of ``subprocess.run``.
-
-            :param cmd: The command to execute
-            :param cwd: The working directory
-            :param extra_environ: Variables to be exported to the environment
-            """
 
 
 _WHEEL_NAME_REGEX = re.compile(
@@ -143,49 +123,6 @@ def _working_directory(path: str) -> Iterator[None]:
         yield
     finally:
         os.chdir(current)
-
-
-def check_dependency(
-    req_string: str, ancestral_req_strings: Tuple[str, ...] = (), parent_extras: AbstractSet[str] = frozenset()
-) -> Iterator[Tuple[str, ...]]:
-    """
-    Verify that a dependency and all of its dependencies are met.
-
-    :param req_string: Requirement string
-    :param parent_extras: Extras (eg. "test" in myproject[test])
-    :yields: Unmet dependencies
-    """
-    import packaging.requirements
-
-    if sys.version_info >= (3, 8):
-        import importlib.metadata as importlib_metadata
-    else:
-        import importlib_metadata
-
-    req = packaging.requirements.Requirement(req_string)
-
-    if req.marker:
-        extras = frozenset(('',)).union(parent_extras)
-        # a requirement can have multiple extras but ``evaluate`` can
-        # only check one at a time.
-        if all(not req.marker.evaluate(environment={'extra': e}) for e in extras):
-            # if the marker conditions are not met, we pretend that the
-            # dependency is satisfied.
-            return
-
-    try:
-        dist = importlib_metadata.distribution(req.name)  # type: ignore[no-untyped-call]
-    except importlib_metadata.PackageNotFoundError:
-        # dependency is not installed in the environment.
-        yield ancestral_req_strings + (req_string,)
-    else:
-        if req.specifier and not req.specifier.contains(dist.version, prereleases=True):
-            # the installed version is incompatible.
-            yield ancestral_req_strings + (req_string,)
-        elif dist.requires:
-            for other_req_string in dist.requires:
-                # yields transitive dependencies that are not satisfied.
-                yield from check_dependency(other_req_string, ancestral_req_strings + (req_string,), req.extras)
 
 
 def _parse_source_dir(source_dir: PathType) -> str:

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -17,20 +17,7 @@ import types
 import warnings
 import zipfile
 
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Iterator,
-    Mapping,
-    MutableMapping,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, Mapping, MutableMapping, Optional, Set, Tuple, Type, Union
 
 import pep517.wrappers
 
@@ -39,7 +26,7 @@ from ._helpers import ConfigSettingsType, PathType, check_dependency
 
 
 if TYPE_CHECKING:
-    from ._helpers import RunnerType
+    from ._helpers import Distribution, RunnerType, WheelDistribution
 
 
 TOMLDecodeError: Type[Exception]
@@ -260,12 +247,14 @@ class ProjectBuilder:
         """
         return self._requires
 
-    def get_requires_for_build(self, distribution: str, config_settings: Optional[ConfigSettingsType] = None) -> Set[str]:
+    def get_requires_for_build(
+        self, distribution: 'Distribution', config_settings: Optional[ConfigSettingsType] = None
+    ) -> Set[str]:
         """
         Get the build dependencies requested by the backend for
         a given distribution.
 
-        :param distribution: Distribution (``sdist`` or ``wheel``)
+        :param distribution: Distribution to build
         :param config_settings: Config settings passed to the backend
         """
         self.log(f'Getting dependencies for {distribution}...')
@@ -276,14 +265,14 @@ class ProjectBuilder:
             return set(get_requires(config_settings))
 
     def check_dependencies(
-        self, distribution: str, config_settings: Optional[ConfigSettingsType] = None
+        self, distribution: 'Distribution', config_settings: Optional[ConfigSettingsType] = None
     ) -> Set[Tuple[str, ...]]:
         """
         Check that the :attr:`build_system_requires` and :meth:`get_requires_for_build`
         dependencies for a given distribution are satisfied and return the dependency
         chain of those which aren't.  The unmet dependency is the last value in the chain.
 
-        :param distribution: Distribution (``sdist`` or ``wheel``)
+        :param distribution: Distribution to build
         :param config_settings: Config settings passed to the backend
         :returns: Unmet dependencies in the PEP 508 format
         """
@@ -291,12 +280,15 @@ class ProjectBuilder:
         return {u for d in dependencies for u in check_dependency(d)}
 
     def prepare(
-        self, distribution: str, output_directory: PathType, config_settings: Optional[ConfigSettingsType] = None
+        self,
+        distribution: 'WheelDistribution',
+        output_directory: PathType,
+        config_settings: Optional[ConfigSettingsType] = None,
     ) -> Optional[str]:
         """
         Prepare metadata for a distribution.
 
-        :param distribution: Distribution (must be ``wheel``)
+        :param distribution: Distribution to build
         :param output_directory: Directory to put the prepared metadata in
         :param config_settings: Config settings passed to the backend
         :returns: The path of the metadata directory
@@ -316,7 +308,7 @@ class ProjectBuilder:
 
     def build(
         self,
-        distribution: str,
+        distribution: 'Distribution',
         output_directory: PathType,
         config_settings: Optional[ConfigSettingsType] = None,
         metadata_directory: Optional[str] = None,
@@ -324,7 +316,7 @@ class ProjectBuilder:
         """
         Build a distribution.
 
-        :param distribution: Distribution (``sdist`` or ``wheel``)
+        :param distribution: Distribution to build
         :param output_directory: Directory to put the built distribution in
         :param config_settings: Config settings passed to the backend
         :param metadata_directory: If provided, should be the return value of a

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -479,7 +479,7 @@ class ProjectBuilder:
             _logger.log(logging.INFO, message)
 
 
-__all__ = (
+__all__ = [
     '__version__',
     'ConfigSettingsType',
     'RunnerType',
@@ -489,4 +489,4 @@ __all__ = (
     'TypoWarning',
     'check_dependency',
     'ProjectBuilder',
-)
+]

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -73,7 +73,7 @@ _DEFAULT_BACKEND = {
 }
 
 
-_logger = logging.getLogger('build')
+_logger = logging.getLogger(__name__)
 
 
 class BuildException(Exception):

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -484,6 +484,7 @@ __all__ = (
     'ConfigSettingsType',
     'RunnerType',
     'BuildException',
+    'BuildSystemTableValidationError',
     'BuildBackendException',
     'TypoWarning',
     'check_dependency',

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -197,7 +197,7 @@ class ProjectBuilder:
             PEP 517 hooks
         :param runner: Callback for executing PEP 517 hooks in a subprocess
         """
-        self.srcdir = _parse_source_dir(srcdir)
+        self._srcdir = _parse_source_dir(srcdir)
         self._python_executable = python_executable
         self._build_system = _parse_build_system_table(_load_pyproject_toml(self.srcdir))
         self._requires = set(self._build_system['requires'])
@@ -227,6 +227,11 @@ class ProjectBuilder:
             subprocess.check_call(cmd, cwd=cwd, env=env)
 
         return cls(srcdir, python_executable=isolated_env.python_executable, runner=runner)
+
+    @property
+    def srcdir(self) -> str:
+        """Project source directory."""
+        return self._srcdir
 
     @property
     def python_executable(self) -> str:

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -17,16 +17,22 @@ import types
 import warnings
 import zipfile
 
-from typing import TYPE_CHECKING, Any, Dict, Iterator, Mapping, Optional, Set, Tuple, Type, Union
+from typing import Any, Dict, Iterator, Mapping, Optional, Set, Tuple, Type, Union
 
 import pep517.wrappers
 
 from . import env
-from ._helpers import ConfigSettingsType, PathType, check_dependency, default_runner, rewrap_runner_for_pep517_lib
+from ._helpers import (
+    ConfigSettingsType,
+    Distribution,
+    PathType,
+    RunnerType,
+    WheelDistribution,
+    check_dependency,
+    default_runner,
+    rewrap_runner_for_pep517_lib,
+)
 
-
-if TYPE_CHECKING:
-    from ._helpers import Distribution, RunnerType, WheelDistribution
 
 try:
     from tomli import TOMLDecodeError
@@ -191,7 +197,7 @@ class ProjectBuilder:
         self,
         srcdir: PathType,
         python_executable: str = sys.executable,
-        runner: Optional[Union['RunnerType', Tuple['RunnerType', Optional[Mapping[str, str]]]]] = None,
+        runner: Optional[Union[RunnerType, Tuple[RunnerType, Optional[Mapping[str, str]]]]] = None,
     ) -> None:
         """
         :param srcdir: The project source directory
@@ -217,7 +223,7 @@ class ProjectBuilder:
         cls,
         isolated_env: 'env.IsolatedEnv',
         srcdir: PathType,
-        runner: Optional['RunnerType'] = None,
+        runner: Optional[RunnerType] = None,
     ) -> 'ProjectBuilder':
         """
         Instantiate the builder from an isolated environment.
@@ -251,7 +257,7 @@ class ProjectBuilder:
         return self._requires
 
     def get_requires_for_build(
-        self, distribution: 'Distribution', config_settings: Optional[ConfigSettingsType] = None
+        self, distribution: Distribution, config_settings: Optional[ConfigSettingsType] = None
     ) -> Set[str]:
         """
         Get the build dependencies requested by the backend for
@@ -268,7 +274,7 @@ class ProjectBuilder:
             return set(get_requires(config_settings))
 
     def check_dependencies(
-        self, distribution: 'Distribution', config_settings: Optional[ConfigSettingsType] = None
+        self, distribution: Distribution, config_settings: Optional[ConfigSettingsType] = None
     ) -> Set[Tuple[str, ...]]:
         """
         Check that the :attr:`build_system_requires` and :meth:`get_requires_for_build`
@@ -284,7 +290,7 @@ class ProjectBuilder:
 
     def prepare(
         self,
-        distribution: 'WheelDistribution',
+        distribution: WheelDistribution,
         output_directory: PathType,
         config_settings: Optional[ConfigSettingsType] = None,
     ) -> Optional[str]:
@@ -311,7 +317,7 @@ class ProjectBuilder:
 
     def build(
         self,
-        distribution: 'Distribution',
+        distribution: Distribution,
         output_directory: PathType,
         config_settings: Optional[ConfigSettingsType] = None,
         metadata_directory: Optional[str] = None,

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -17,7 +17,7 @@ import types
 import warnings
 import zipfile
 
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, Mapping, MutableMapping, Optional, Set, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Mapping, Optional, Set, Tuple, Type, Union
 
 import pep517.wrappers
 
@@ -28,18 +28,12 @@ from ._helpers import ConfigSettingsType, PathType, check_dependency
 if TYPE_CHECKING:
     from ._helpers import Distribution, RunnerType, WheelDistribution
 
-
-TOMLDecodeError: Type[Exception]
-toml_loads: Callable[[str], MutableMapping[str, Any]]
-
-
 try:
     from tomli import TOMLDecodeError
     from tomli import loads as toml_loads
 except ModuleNotFoundError:  # pragma: no cover
     from toml import TomlDecodeError as TOMLDecodeError  # type: ignore
     from toml import loads as toml_loads  # type: ignore
-
 
 _ExcInfoType = Union[Tuple[Type[BaseException], BaseException, types.TracebackType], Tuple[None, None, None]]
 

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -18,7 +18,7 @@ import build
 
 from build import BuildBackendException, BuildException, ProjectBuilder
 from build._helpers import ConfigSettingsType, Distribution, PathType
-from build.env import IsolatedEnvManager, _DefaultIsolatedEnv
+from build.env import DefaultIsolatedEnv
 
 
 _COLORS = {
@@ -85,7 +85,7 @@ class _ProjectBuilder(ProjectBuilder):
         print('{bold}* {}{reset}'.format(message, **_STYLES))
 
 
-class _IsolatedEnv(_DefaultIsolatedEnv):
+class _IsolatedEnv(DefaultIsolatedEnv):
     @staticmethod
     def log(message: str) -> None:
         print('{bold}* {}{reset}'.format(message, **_STYLES))
@@ -98,7 +98,7 @@ def _format_dep_chain(dep_chain: Sequence[str]) -> str:
 def _build_in_isolated_env(
     srcdir: PathType, outdir: PathType, distribution: Distribution, config_settings: Optional[ConfigSettingsType]
 ) -> str:
-    with IsolatedEnvManager(_IsolatedEnv()) as env:
+    with _IsolatedEnv.with_temp_dir() as env:
         builder = _ProjectBuilder.from_isolated_env(env, srcdir)
         # first install the build dependencies
         env.install_packages(builder.build_system_requires)

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -79,7 +79,7 @@ def _error(msg: str, code: int = 1) -> None:  # pragma: no cover
     :param msg: Error message
     :param code: Error code
     """
-    print('{red}ERROR{reset} {}'.format(msg, **_STYLES))
+    print('{red}ERROR{reset} {}'.format(msg, **_STYLES), file=sys.stderr)
     exit(code)
 
 
@@ -163,7 +163,11 @@ def _handle_build_error() -> Iterator[None]:
                 tb = ''.join(tb_lines)
             else:
                 tb = traceback.format_exc(-1)
-            print('\n{dim}{}{reset}\n'.format(tb.strip('\n'), **_STYLES))
+            print('\n{dim}{}{reset}\n'.format(tb.strip('\n'), **_STYLES), file=sys.stderr)
+        _error(str(e))
+    except Exception as e:  # pragma: no cover
+        tb = traceback.format_exc().strip('\n')
+        print('\n{dim}{}{reset}\n'.format(tb, **_STYLES), file=sys.stderr)
         _error(str(e))
 
 
@@ -372,19 +376,14 @@ def main(cli_args: Sequence[str], prog: Optional[str] = None) -> None:  # noqa: 
     else:
         build_call = build_package_via_sdist
         distributions = ['wheel']
-    try:
-        with _handle_build_error():
-            built = build_call(
-                args.srcdir, outdir, distributions, config_settings, not args.no_isolation, args.skip_dependency_check
-            )
-            artifact_list = _natural_language_list(
-                ['{underline}{}{reset}{bold}{green}'.format(artifact, **_STYLES) for artifact in built]
-            )
-            print('{bold}{green}Successfully built {}{reset}'.format(artifact_list, **_STYLES))
-    except Exception as e:  # pragma: no cover
-        tb = traceback.format_exc().strip('\n')
-        print('\n{dim}{}{reset}\n'.format(tb, **_STYLES))
-        _error(str(e))
+    with _handle_build_error():
+        built = build_call(
+            args.srcdir, outdir, distributions, config_settings, not args.no_isolation, args.skip_dependency_check
+        )
+        artifact_list = _natural_language_list(
+            ['{underline}{}{reset}{bold}{green}'.format(artifact, **_STYLES) for artifact in built]
+        )
+        print('{bold}{green}Successfully built {}{reset}'.format(artifact_list, **_STYLES))
 
 
 def entrypoint() -> None:

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -18,7 +18,7 @@ import build
 
 from build import BuildBackendException, BuildException, ProjectBuilder
 from build._helpers import ConfigSettingsType, PathType
-from build.env import IsolatedEnvManager
+from build.env import IsolatedEnvManager, _DefaultIsolatedEnv
 
 
 if TYPE_CHECKING:
@@ -89,7 +89,7 @@ class _ProjectBuilder(ProjectBuilder):
         print('{bold}* {}{reset}'.format(message, **_STYLES))
 
 
-class _IsolatedEnvManager(IsolatedEnvManager):
+class _IsolatedEnv(_DefaultIsolatedEnv):
     @staticmethod
     def log(message: str) -> None:
         print('{bold}* {}{reset}'.format(message, **_STYLES))
@@ -102,7 +102,7 @@ def _format_dep_chain(dep_chain: Sequence[str]) -> str:
 def _build_in_isolated_env(
     srcdir: PathType, outdir: PathType, distribution: 'Distribution', config_settings: Optional[ConfigSettingsType]
 ) -> str:
-    with _IsolatedEnvManager() as env:
+    with IsolatedEnvManager(_IsolatedEnv()) as env:
         builder = _ProjectBuilder.from_isolated_env(env, srcdir)
         # first install the build dependencies
         env.install_packages(builder.build_system_requires)

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -21,9 +21,6 @@ from build import BuildBackendException, BuildException, ConfigSettingsType, Pat
 from build.env import IsolatedEnvBuilder
 
 
-__all__ = ['build', 'main', 'main_parser']
-
-
 _COLORS = {
     'red': '\33[91m',
     'green': '\33[92m',
@@ -388,3 +385,10 @@ def entrypoint() -> None:
 
 if __name__ == '__main__':  # pragma: no cover
     main(sys.argv[1:], 'python -m build')
+
+
+__all__ = [
+    'build',
+    'main',
+    'main_parser',
+]

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -16,7 +16,8 @@ from typing import Dict, Iterable, Iterator, List, Optional, Sequence, TextIO, T
 
 import build
 
-from build import BuildBackendException, BuildException, ConfigSettingsType, PathType, ProjectBuilder
+from build import BuildBackendException, BuildException, ProjectBuilder
+from build._helpers import ConfigSettingsType, PathType
 from build.env import IsolatedEnvManager
 
 

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -12,13 +12,17 @@ import textwrap
 import traceback
 import warnings
 
-from typing import Dict, Iterable, Iterator, List, Optional, Sequence, TextIO, Type, Union
+from typing import TYPE_CHECKING, Dict, Iterable, Iterator, List, Optional, Sequence, TextIO, Type, Union
 
 import build
 
 from build import BuildBackendException, BuildException, ProjectBuilder
 from build._helpers import ConfigSettingsType, PathType
 from build.env import IsolatedEnvManager
+
+
+if TYPE_CHECKING:
+    from ._helpers import Distribution
 
 
 _COLORS = {
@@ -96,7 +100,7 @@ def _format_dep_chain(dep_chain: Sequence[str]) -> str:
 
 
 def _build_in_isolated_env(
-    srcdir: PathType, outdir: PathType, distribution: str, config_settings: Optional[ConfigSettingsType]
+    srcdir: PathType, outdir: PathType, distribution: 'Distribution', config_settings: Optional[ConfigSettingsType]
 ) -> str:
     with _IsolatedEnvManager() as env:
         builder = _ProjectBuilder.from_isolated_env(env, srcdir)
@@ -110,7 +114,7 @@ def _build_in_isolated_env(
 def _build_in_current_env(
     srcdir: PathType,
     outdir: PathType,
-    distribution: str,
+    distribution: 'Distribution',
     config_settings: Optional[ConfigSettingsType],
     skip_dependency_check: bool = False,
 ) -> str:
@@ -129,7 +133,7 @@ def _build(
     isolation: bool,
     srcdir: PathType,
     outdir: PathType,
-    distribution: str,
+    distribution: 'Distribution',
     config_settings: Optional[ConfigSettingsType],
     skip_dependency_check: bool,
 ) -> str:
@@ -178,7 +182,7 @@ def _natural_language_list(elements: Sequence[str]) -> str:
 def build_package(
     srcdir: PathType,
     outdir: PathType,
-    distributions: Sequence[str],
+    distributions: Sequence['Distribution'],
     config_settings: Optional[ConfigSettingsType] = None,
     isolation: bool = True,
     skip_dependency_check: bool = False,
@@ -203,7 +207,7 @@ def build_package(
 def build_package_via_sdist(
     srcdir: PathType,
     outdir: PathType,
-    distributions: Sequence[str],
+    distributions: Sequence['Distribution'],
     config_settings: Optional[ConfigSettingsType] = None,
     isolation: bool = True,
     skip_dependency_check: bool = False,
@@ -341,7 +345,7 @@ def main(cli_args: Sequence[str], prog: Optional[str] = None) -> None:  # noqa: 
         parser.prog = prog
     args = parser.parse_args(cli_args)
 
-    distributions = []
+    distributions: List['Distribution'] = []
     config_settings = {}
 
     if args.config_setting:

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -388,7 +388,6 @@ if __name__ == '__main__':  # pragma: no cover
 
 
 __all__ = [
-    'build',
     'main',
     'main_parser',
 ]

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -230,24 +230,18 @@ def build_package_via_sdist(
     sdist_name = os.path.basename(sdist)
     sdist_out = tempfile.mkdtemp(prefix='build-via-sdist-')
     built: List[str] = []
-    # extract sdist
-    with tarfile.open(sdist) as t:
-        t.extractall(sdist_out)
-        try:
-            if distributions:
+    if distributions:
+        # extract sdist
+        with tarfile.open(sdist) as t:
+            t.extractall(sdist_out)
+            try:
                 _ProjectBuilder.log(f'Building {_natural_language_list(distributions)} from sdist')
-            for distribution in distributions:
-                out = _build(
-                    isolation,
-                    os.path.join(sdist_out, sdist_name[: -len('.tar.gz')]),
-                    outdir,
-                    distribution,
-                    config_settings,
-                    skip_dependency_check,
-                )
-                built.append(os.path.basename(out))
-        finally:
-            shutil.rmtree(sdist_out, ignore_errors=True)
+                srcdir = os.path.join(sdist_out, sdist_name[: -len('.tar.gz')])
+                for distribution in distributions:
+                    out = _build(isolation, srcdir, outdir, distribution, config_settings, skip_dependency_check)
+                    built.append(os.path.basename(out))
+            finally:
+                shutil.rmtree(sdist_out, ignore_errors=True)
     return [sdist_name] + built
 
 

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -12,17 +12,13 @@ import textwrap
 import traceback
 import warnings
 
-from typing import TYPE_CHECKING, Dict, Iterable, Iterator, List, Optional, Sequence, TextIO, Type, Union
+from typing import Dict, Iterable, Iterator, List, Optional, Sequence, TextIO, Type, Union
 
 import build
 
 from build import BuildBackendException, BuildException, ProjectBuilder
-from build._helpers import ConfigSettingsType, PathType
+from build._helpers import ConfigSettingsType, Distribution, PathType
 from build.env import IsolatedEnvManager, _DefaultIsolatedEnv
-
-
-if TYPE_CHECKING:
-    from ._helpers import Distribution
 
 
 _COLORS = {
@@ -100,7 +96,7 @@ def _format_dep_chain(dep_chain: Sequence[str]) -> str:
 
 
 def _build_in_isolated_env(
-    srcdir: PathType, outdir: PathType, distribution: 'Distribution', config_settings: Optional[ConfigSettingsType]
+    srcdir: PathType, outdir: PathType, distribution: Distribution, config_settings: Optional[ConfigSettingsType]
 ) -> str:
     with IsolatedEnvManager(_IsolatedEnv()) as env:
         builder = _ProjectBuilder.from_isolated_env(env, srcdir)
@@ -114,7 +110,7 @@ def _build_in_isolated_env(
 def _build_in_current_env(
     srcdir: PathType,
     outdir: PathType,
-    distribution: 'Distribution',
+    distribution: Distribution,
     config_settings: Optional[ConfigSettingsType],
     skip_dependency_check: bool = False,
 ) -> str:
@@ -133,7 +129,7 @@ def _build(
     isolation: bool,
     srcdir: PathType,
     outdir: PathType,
-    distribution: 'Distribution',
+    distribution: Distribution,
     config_settings: Optional[ConfigSettingsType],
     skip_dependency_check: bool,
 ) -> str:
@@ -186,7 +182,7 @@ def _natural_language_list(elements: Sequence[str]) -> str:
 def build_package(
     srcdir: PathType,
     outdir: PathType,
-    distributions: Sequence['Distribution'],
+    distributions: Sequence[Distribution],
     config_settings: Optional[ConfigSettingsType] = None,
     isolation: bool = True,
     skip_dependency_check: bool = False,
@@ -211,7 +207,7 @@ def build_package(
 def build_package_via_sdist(
     srcdir: PathType,
     outdir: PathType,
-    distributions: Sequence['Distribution'],
+    distributions: Sequence[Distribution],
     config_settings: Optional[ConfigSettingsType] = None,
     isolation: bool = True,
     skip_dependency_check: bool = False,
@@ -349,7 +345,7 @@ def main(cli_args: Sequence[str], prog: Optional[str] = None) -> None:  # noqa: 
         parser.prog = prog
     args = parser.parse_args(cli_args)
 
-    distributions: List['Distribution'] = []
+    distributions: List[Distribution] = []
     config_settings = {}
 
     if args.config_setting:

--- a/src/build/_compat.py
+++ b/src/build/_compat.py
@@ -1,0 +1,26 @@
+import functools
+import sys
+
+
+if sys.version_info >= (3, 8):
+    from typing import Literal, Protocol
+else:
+    from typing_extensions import Literal, Protocol
+
+if sys.version_info >= (3, 9):
+    cache = functools.cache
+
+else:
+    from typing import Callable, TypeVar
+
+    _C = TypeVar('_C', bound=Callable[..., object])
+
+    def cache(fn: _C) -> _C:
+        return functools.lru_cache(maxsize=None)(fn)  # type: ignore
+
+
+__all__ = [
+    'Literal',
+    'Protocol',
+    'cache',
+]

--- a/src/build/_compat.py
+++ b/src/build/_compat.py
@@ -1,11 +1,30 @@
 import functools
 import sys
 
+from typing import TYPE_CHECKING
+
+
+class _GenericGetitemMeta(type):
+    # ``__class_getitem__`` was added in 3.7.
+    # TODO: Merge into ``_GenericGetitem`` when we drop support for Python 3.6.
+    def __getitem__(self, value: object) -> None:
+        ...
+
+
+class _GenericGetitem(metaclass=_GenericGetitemMeta):
+    pass
+
 
 if sys.version_info >= (3, 8):
-    from typing import Literal, Protocol, runtime_checkable
+    from typing import Literal, Protocol
 else:
-    from typing_extensions import Literal, Protocol, runtime_checkable
+    if TYPE_CHECKING:
+        from typing_extensions import Literal, Protocol
+    else:
+        from abc import ABC as Protocol
+
+        Literal = _GenericGetitem
+
 
 if sys.version_info >= (3, 8):
     import importlib.metadata as importlib_metadata
@@ -27,7 +46,6 @@ else:
 __all__ = [
     'Literal',
     'Protocol',
-    'runtime_checkable',
     'importlib_metadata',
     'cache',
 ]

--- a/src/build/_compat.py
+++ b/src/build/_compat.py
@@ -7,6 +7,11 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Literal, Protocol
 
+if sys.version_info >= (3, 8):
+    import importlib.metadata as importlib_metadata
+else:
+    import importlib_metadata
+
 if sys.version_info >= (3, 9):
     cache = functools.cache
 
@@ -22,5 +27,6 @@ else:
 __all__ = [
     'Literal',
     'Protocol',
+    'importlib_metadata',
     'cache',
 ]

--- a/src/build/_compat.py
+++ b/src/build/_compat.py
@@ -3,9 +3,9 @@ import sys
 
 
 if sys.version_info >= (3, 8):
-    from typing import Literal, Protocol
+    from typing import Literal, Protocol, runtime_checkable
 else:
-    from typing_extensions import Literal, Protocol
+    from typing_extensions import Literal, Protocol, runtime_checkable
 
 if sys.version_info >= (3, 8):
     import importlib.metadata as importlib_metadata
@@ -27,6 +27,7 @@ else:
 __all__ = [
     'Literal',
     'Protocol',
+    'runtime_checkable',
     'importlib_metadata',
     'cache',
 ]

--- a/src/build/_helpers.py
+++ b/src/build/_helpers.py
@@ -8,7 +8,10 @@ ConfigSettingsType = Mapping[str, Union[str, Sequence[str]]]
 PathType = Union[str, 'os.PathLike[str]']
 
 if TYPE_CHECKING:
-    from typing_extensions import Protocol
+    from typing_extensions import Literal, Protocol
+
+    Distribution = Literal['sdist', 'wheel']
+    WheelDistribution = Literal['wheel']
 
     class RunnerType(Protocol):
         def __call__(

--- a/src/build/_helpers.py
+++ b/src/build/_helpers.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import sys
 
-from typing import TYPE_CHECKING, AbstractSet, Iterator, Mapping, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, AbstractSet, Callable, Iterator, Mapping, Optional, Sequence, Tuple, TypeVar, Union
 
 
 ConfigSettingsType = Mapping[str, Union[str, Sequence[str]]]
@@ -106,3 +106,12 @@ def check_dependency(
             for other_req_string in dist.requires:
                 # yields transitive dependencies that are not satisfied.
                 yield from check_dependency(other_req_string, ancestral_req_strings + (req_string,), req.extras)
+
+
+if sys.version_info >= (3, 9):
+    cache = functools.cache
+else:
+    _C = TypeVar('_C', bound=Callable[..., object])
+
+    def cache(fn: _C) -> _C:
+        return functools.lru_cache(maxsize=None)(fn)  # type: ignore

--- a/src/build/_helpers.py
+++ b/src/build/_helpers.py
@@ -1,11 +1,10 @@
 import functools
 import os
 import subprocess
-import sys
 
 from typing import AbstractSet, Iterator, Mapping, Optional, Sequence, Tuple, Union
 
-from ._compat import Literal, Protocol
+from ._compat import Literal, Protocol, importlib_metadata
 
 
 ConfigSettingsType = Mapping[str, Union[str, Sequence[str]]]
@@ -75,11 +74,6 @@ def check_dependency(
     :yields: Unmet dependencies
     """
     import packaging.requirements
-
-    if sys.version_info >= (3, 8):
-        import importlib.metadata as importlib_metadata
-    else:
-        import importlib_metadata
 
     req = packaging.requirements.Requirement(req_string)
 

--- a/src/build/_helpers.py
+++ b/src/build/_helpers.py
@@ -1,0 +1,69 @@
+import os
+import sys
+
+from typing import TYPE_CHECKING, AbstractSet, Iterator, Mapping, Optional, Sequence, Tuple, Union
+
+
+ConfigSettingsType = Mapping[str, Union[str, Sequence[str]]]
+PathType = Union[str, 'os.PathLike[str]']
+
+if TYPE_CHECKING:
+    from typing_extensions import Protocol
+
+    class RunnerType(Protocol):
+        def __call__(
+            self, cmd: Sequence[str], cwd: Optional[PathType] = None, extra_environ: Optional[Mapping[str, str]] = None
+        ) -> None:
+            """
+            Run a command in a Python subprocess.
+
+            The parameters mirror those of ``subprocess.run``.
+
+            :param cmd: The command to execute
+            :param cwd: The working directory
+            :param extra_environ: Variables to be exported to the environment
+            """
+
+
+def check_dependency(
+    req_string: str, ancestral_req_strings: Tuple[str, ...] = (), parent_extras: AbstractSet[str] = frozenset()
+) -> Iterator[Tuple[str, ...]]:
+    """
+    Verify that a dependency and all of its dependencies are met.
+
+    :param req_string: Requirement string
+    :param ancestral_req_strings: The dependency chain leading to this ``req_string``
+    :param parent_extras: Extras (eg. "test" in ``myproject[test]``)
+    :yields: Unmet dependencies
+    """
+    import packaging.requirements
+
+    if sys.version_info >= (3, 8):
+        import importlib.metadata as importlib_metadata
+    else:
+        import importlib_metadata
+
+    req = packaging.requirements.Requirement(req_string)
+
+    if req.marker:
+        extras = frozenset(('',)).union(parent_extras)
+        # a requirement can have multiple extras but ``evaluate`` can
+        # only check one at a time.
+        if all(not req.marker.evaluate(environment={'extra': e}) for e in extras):
+            # if the marker conditions are not met, we pretend that the
+            # dependency is satisfied.
+            return
+
+    try:
+        dist = importlib_metadata.distribution(req.name)  # type: ignore[no-untyped-call]
+    except importlib_metadata.PackageNotFoundError:
+        # dependency is not installed in the environment.
+        yield ancestral_req_strings + (req_string,)
+    else:
+        if req.specifier and not req.specifier.contains(dist.version, prereleases=True):
+            # the installed version is incompatible.
+            yield ancestral_req_strings + (req_string,)
+        elif dist.requires:
+            for other_req_string in dist.requires:
+                # yields transitive dependencies that are not satisfied.
+                yield from check_dependency(other_req_string, ancestral_req_strings + (req_string,), req.extras)

--- a/src/build/_helpers.py
+++ b/src/build/_helpers.py
@@ -42,15 +42,7 @@ def quiet_runner(cmd: Sequence[str], cwd: Optional[PathType] = None, env: Option
     subprocess.run(cmd, check=True, cwd=cwd, env=env, stdout=subprocess.DEVNULL)
 
 
-def rewrap_runner_for_pep517_lib(
-    values: Union[RunnerType, Tuple[RunnerType, Optional[Mapping[str, str]]]]
-) -> '_Pep517CallbackType':
-    if isinstance(values, tuple):
-        runner, env = values
-    else:
-        runner = values
-        env = None
-
+def rewrap_runner_for_pep517_lib(runner: RunnerType, env: Optional[Mapping[str, str]] = None) -> '_Pep517CallbackType':
     @functools.wraps(runner)
     def inner(cmd: Sequence[str], cwd: Optional[PathType] = None, extra_environ: Optional[Mapping[str, str]] = None) -> None:
         local_env = os.environ.copy() if env is None else dict(env)

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -13,7 +13,8 @@ import tempfile
 
 from typing import Dict, Generic, Iterable, Optional, Sequence, Tuple, TypeVar, cast, overload
 
-from ._helpers import cache, check_dependency, default_runner
+from ._compat import cache
+from ._helpers import check_dependency, default_runner
 
 
 _logger = logging.getLogger(__name__)

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -3,7 +3,6 @@ Creates and manages isolated build environments.
 """
 
 import abc
-import functools
 import logging
 import os
 import platform
@@ -14,12 +13,10 @@ import tempfile
 
 from typing import Dict, Iterable, Sequence, Tuple
 
-from ._helpers import check_dependency, default_runner
+from ._helpers import cache, check_dependency, default_runner
 
 
 _logger = logging.getLogger(__name__)
-
-_cache = functools.partial(functools.lru_cache, maxsize=None)
 
 
 class IsolatedEnv(metaclass=abc.ABCMeta):
@@ -47,7 +44,7 @@ class IsolatedEnv(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
 
-@_cache()
+@cache
 def _fs_supports_symlinks() -> bool:
     """Check if symlinks are supported."""
     # Using definition used by venv.main()
@@ -115,7 +112,7 @@ def _create_isolated_env_virtualenv(path: str) -> Tuple[str, str]:
     return executable, script_dir
 
 
-@_cache()
+@cache
 def _should_use_virtualenv() -> bool:
     import packaging.requirements
 
@@ -127,7 +124,7 @@ def _should_use_virtualenv() -> bool:
     )
 
 
-@_cache()
+@cache
 def _get_min_pip_version() -> str:
     if platform.system() == 'Darwin':
         release, _, machine = platform.mac_ver()

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -40,7 +40,8 @@ class IsolatedEnv(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def python_executable(self) -> str:
         """The isolated environment's Python executable."""
         raise NotImplementedError

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -1,6 +1,7 @@
 """
 Creates and manages isolated build environments.
 """
+
 import abc
 import functools
 import logging
@@ -12,63 +13,39 @@ import sys
 import sysconfig
 import tempfile
 
-from types import TracebackType
-from typing import Callable, Iterable, List, Optional, Tuple, Type
+from typing import Dict, Iterable, List, Tuple
 
-import build
-
-
-if sys.version_info < (3, 8):
-    import importlib_metadata as metadata
-else:
-    from importlib import metadata
-
-try:
-    import virtualenv
-except ModuleNotFoundError:
-    virtualenv = None
+from . import check_dependency
 
 
 _logger = logging.getLogger('build.env')
 
+_cache = functools.partial(functools.lru_cache, maxsize=None)
+
 
 class IsolatedEnv(metaclass=abc.ABCMeta):
-    """Abstract base of isolated build environments, as required by the build project."""
-
-    @property
-    @abc.abstractmethod
-    def executable(self) -> str:
-        """The executable of the isolated build environment."""
-        raise NotImplementedError
-
-    @property
-    @abc.abstractmethod
-    def scripts_dir(self) -> str:
-        """The scripts directory of the isolated build environment."""
-        raise NotImplementedError
+    """ABC for isolated build environments."""
 
     @abc.abstractmethod
-    def install(self, requirements: Iterable[str]) -> None:
+    def create(self, path: str) -> None:
         """
-        Install packages from PEP 508 requirements in the isolated build environment.
+        Create the isolated environment.
 
-        :param requirements: PEP 508 requirements
+        This method should be idempotent.
         """
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def prepare_environ(self) -> Dict[str, str]:
+        """
+        Modify environment variables.
+        """
+        raise NotImplementedError
 
-@functools.lru_cache(maxsize=None)
-def _should_use_virtualenv() -> bool:
-    import packaging.requirements
-
-    # virtualenv might be incompatible if it was installed separately
-    # from build. This verifies that virtualenv and all of its
-    # dependencies are installed as specified by build.
-    return virtualenv is not None and not any(
-        packaging.requirements.Requirement(d[1]).name == 'virtualenv'
-        for d in build.check_dependency('build[virtualenv]')
-        if len(d) > 1
-    )
+    @abc.abstractproperty
+    def python_executable(self) -> str:
+        """The isolated environment's Python executable."""
+        raise NotImplementedError
 
 
 def _subprocess(cmd: List[str]) -> None:
@@ -80,216 +57,29 @@ def _subprocess(cmd: List[str]) -> None:
         raise e
 
 
-class IsolatedEnvBuilder:
-    """Builder object for isolated environments."""
-
-    def __init__(self) -> None:
-        self._path: Optional[str] = None
-
-    def __enter__(self) -> IsolatedEnv:
-        """
-        Create an isolated build environment.
-
-        :return: The isolated build environment
-        """
-        # Call ``realpath`` to prevent spurious warning from being emitted
-        # that the venv location has changed on Windows. The username is
-        # DOS-encoded in the output of tempfile - the location is the same
-        # but the representation of it is different, which confuses venv.
-        # Ref: https://bugs.python.org/issue46171
-        self._path = os.path.realpath(tempfile.mkdtemp(prefix='build-env-'))
-        try:
-            # use virtualenv when available (as it's faster than venv)
-            if _should_use_virtualenv():
-                self.log('Creating virtualenv isolated environment...')
-                executable, scripts_dir = _create_isolated_env_virtualenv(self._path)
-            else:
-                self.log('Creating venv isolated environment...')
-                executable, scripts_dir = _create_isolated_env_venv(self._path)
-            return _IsolatedEnvVenvPip(
-                path=self._path,
-                python_executable=executable,
-                scripts_dir=scripts_dir,
-                log=self.log,
-            )
-        except Exception:  # cleanup folder if creation fails
-            self.__exit__(*sys.exc_info())
-            raise
-
-    def __exit__(
-        self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
-    ) -> None:
-        """
-        Delete the created isolated build environment.
-
-        :param exc_type: The type of exception raised (if any)
-        :param exc_val: The value of exception raised (if any)
-        :param exc_tb: The traceback of exception raised (if any)
-        """
-        if self._path is not None and os.path.exists(self._path):  # in case the user already deleted skip remove
-            shutil.rmtree(self._path)
-
-    @staticmethod
-    def log(message: str) -> None:
-        """
-        Prints message
-
-        The default implementation uses the logging module but this function can be
-        overwritten by users to have a different implementation.
-
-        :param msg: Message to output
-        """
-        if sys.version_info >= (3, 8):
-            _logger.log(logging.INFO, message, stacklevel=2)
-        else:
-            _logger.log(logging.INFO, message)
-
-
-class _IsolatedEnvVenvPip(IsolatedEnv):
-    """
-    Isolated build environment context manager
-
-    Non-standard paths injected directly to sys.path will still be passed to the environment.
-    """
-
-    def __init__(
-        self,
-        path: str,
-        python_executable: str,
-        scripts_dir: str,
-        log: Callable[[str], None],
-    ) -> None:
-        """
-        :param path: The path where the environment exists
-        :param python_executable: The python executable within the environment
-        :param log: Log function
-        """
-        self._path = path
-        self._python_executable = python_executable
-        self._scripts_dir = scripts_dir
-        self._log = log
-
-    @property
-    def path(self) -> str:
-        """The location of the isolated build environment."""
-        return self._path
-
-    @property
-    def executable(self) -> str:
-        """The python executable of the isolated build environment."""
-        return self._python_executable
-
-    @property
-    def scripts_dir(self) -> str:
-        return self._scripts_dir
-
-    def install(self, requirements: Iterable[str]) -> None:
-        """
-        Install packages from PEP 508 requirements in the isolated build environment.
-
-        :param requirements: PEP 508 requirement specification to install
-
-        :note: Passing non-PEP 508 strings will result in undefined behavior, you *should not* rely on it. It is
-               merely an implementation detail, it may change any time without warning.
-        """
-        if not requirements:
-            return
-
-        self._log('Installing packages in isolated environment... ({})'.format(', '.join(sorted(requirements))))
-
-        # pip does not honour environment markers in command line arguments
-        # but it does for requirements from a file
-        with tempfile.NamedTemporaryFile('w+', prefix='build-reqs-', suffix='.txt', delete=False) as req_file:
-            req_file.write(os.linesep.join(requirements))
-        try:
-            cmd = [
-                self.executable,
-                '-Im',
-                'pip',
-                'install',
-                '--use-pep517',
-                '--no-warn-script-location',
-                '-r',
-                os.path.abspath(req_file.name),
-            ]
-            _subprocess(cmd)
-        finally:
-            os.unlink(req_file.name)
-
-
-def _create_isolated_env_virtualenv(path: str) -> Tuple[str, str]:
-    """
-    On Python 2 we use the virtualenv package to provision a virtual environment.
-
-    :param path: The path where to create the isolated build environment
-    :return: The Python executable and script folder
-    """
-    cmd = [str(path), '--no-setuptools', '--no-wheel', '--activators', '']
-    result = virtualenv.cli_run(cmd, setup_logging=False)
-    executable = str(result.creator.exe)
-    script_dir = str(result.creator.script_dir)
-    return executable, script_dir
-
-
-@functools.lru_cache(maxsize=None)
-def _fs_supports_symlink() -> bool:
-    """Return True if symlinks are supported"""
+@_cache()
+def _fs_supports_symlinks() -> bool:
+    """Check if symlinks are supported."""
     # Using definition used by venv.main()
     if os.name != 'nt':
         return True
 
     # Windows may support symlinks (setting in Windows 10)
-    with tempfile.NamedTemporaryFile(prefix='build-symlink-') as tmp_file:
-        dest = f'{tmp_file}-b'
+    with tempfile.TemporaryDirectory(prefix='build-try-symlink-') as temp_dir:
         try:
-            os.symlink(tmp_file.name, dest)
-            os.unlink(dest)
+            os.symlink(
+                os.path.join(temp_dir, 'foo'),
+                os.path.join(temp_dir, 'bar'),
+            )
             return True
         except (OSError, NotImplementedError, AttributeError):
             return False
 
 
-def _create_isolated_env_venv(path: str) -> Tuple[str, str]:
+def _get_isolated_env_executable_and_paths(path: str) -> Tuple[str, Dict[str, str]]:
     """
-    On Python 3 we use the venv package from the standard library.
-
-    :param path: The path where to create the isolated build environment
-    :return: The Python executable and script folder
-    """
-    import venv
-
-    import packaging.version
-
-    venv.EnvBuilder(with_pip=True, symlinks=_fs_supports_symlink()).create(path)
-    executable, script_dir, purelib = _find_executable_and_scripts(path)
-
-    # Get the version of pip in the environment
-    pip_distribution = next(iter(metadata.distributions(name='pip', path=[purelib])))  # type: ignore[no-untyped-call]
-    current_pip_version = packaging.version.Version(pip_distribution.version)
-
-    if platform.system() == 'Darwin' and int(platform.mac_ver()[0].split('.')[0]) >= 11:
-        # macOS 11+ name scheme change requires 20.3. Intel macOS 11.0 can be told to report 10.16 for backwards
-        # compatibility; but that also fixes earlier versions of pip so this is only needed for 11+.
-        is_apple_silicon_python = platform.machine() != 'x86_64'
-        minimum_pip_version = '21.0.1' if is_apple_silicon_python else '20.3.0'
-    else:
-        # PEP-517 and manylinux1 was first implemented in 19.1
-        minimum_pip_version = '19.1.0'
-
-    if current_pip_version < packaging.version.Version(minimum_pip_version):
-        _subprocess([executable, '-m', 'pip', 'install', f'pip>={minimum_pip_version}'])
-
-    # Avoid the setuptools from ensurepip to break the isolation
-    _subprocess([executable, '-m', 'pip', 'uninstall', 'setuptools', '-y'])
-    return executable, script_dir
-
-
-def _find_executable_and_scripts(path: str) -> Tuple[str, str, str]:
-    """
-    Detect the Python executable and script folder of a virtual environment.
-
-    :param path: The location of the virtual environment
-    :return: The Python executable, script folder, and purelib folder
+    :param path: venv path on disk
+    :returns: The Python executable and scripts folder
     """
     config_vars = sysconfig.get_config_vars().copy()  # globally cached, copy before altering it
     config_vars['base'] = path
@@ -307,11 +97,194 @@ def _find_executable_and_scripts(path: str) -> Tuple[str, str, str]:
     executable = os.path.join(paths['scripts'], 'python.exe' if os.name == 'nt' else 'python')
     if not os.path.exists(executable):
         raise RuntimeError(f'Virtual environment creation failed, executable {executable} missing')
+    return executable, paths
 
-    return executable, paths['scripts'], paths['purelib']
+
+def _create_isolated_env_venv(path: str) -> Tuple[str, Dict[str, str]]:
+    """
+    :param path: venv path on disk
+    :returns: The Python executable and scripts folder
+    """
+    import venv
+
+    venv.EnvBuilder(symlinks=_fs_supports_symlinks(), with_pip=True).create(path)
+    return _get_isolated_env_executable_and_paths(path)
+
+
+def _create_isolated_env_virtualenv(path: str) -> Tuple[str, str]:
+    """
+    :param path: virtualenv path on disk
+    :returns: The Python executable and scripts folder
+    """
+    import virtualenv
+
+    cmd = [str(path), '--no-setuptools', '--no-wheel', '--activators', '']
+    result = virtualenv.cli_run(cmd, setup_logging=False)
+    executable = str(result.creator.exe)
+    script_dir = str(result.creator.script_dir)
+    return executable, script_dir
+
+
+@_cache()
+def _should_use_virtualenv() -> bool:
+    import packaging.requirements
+
+    # virtualenv might be incompatible if it was installed separately
+    # from build. This verifies that virtualenv and all of its
+    # dependencies are installed as specified by build.
+    return not any(
+        packaging.requirements.Requirement(u).name == 'virtualenv' for d in check_dependency('build[virtualenv]') for u in d
+    )
+
+
+class _DefaultIsolatedEnv(IsolatedEnv):
+    """An isolated environment which combines venv or virtualenv with pip."""
+
+    def __init__(self, isolated_env_manager: 'IsolatedEnvManager') -> None:
+        self._log = isolated_env_manager.log
+        self._env_created = False
+
+    def create(self, path: str) -> None:
+        if self._env_created:
+            return
+
+        if _should_use_virtualenv():
+            self._log('Creating isolated environment (virtualenv)...')
+            self._python_executable, self._scripts_dir = _create_isolated_env_virtualenv(path)
+        else:
+            self._log('Creating isolated environment (venv)...')
+            # Call ``realpath`` to prevent spurious warning from being emitted
+            # that the venv location has changed on Windows. The username is
+            # DOS-encoded in the output of tempfile - the location is the same
+            # but the representation of it is different, which confuses venv.
+            # Ref: https://bugs.python.org/issue46171
+            path = os.path.realpath(tempfile.mkdtemp(prefix='build-env-'))
+            self._python_executable, paths = _create_isolated_env_venv(path)
+            self._scripts_dir = paths['scripts']
+            self._patch_up_venv(paths['purelib'])
+
+        self._env_created = True
+
+    def _patch_up_venv(self, venv_purelib: str) -> None:
+        import packaging.version
+
+        if sys.version_info >= (3, 8):
+            from importlib import metadata
+        else:
+            import importlib_metadata as metadata
+
+        # Get the version of pip in the environment
+        pip_distribution = next(iter(metadata.distributions(name='pip', path=[version])))  # type: ignore[no-untyped-call]
+        current_pip_version = packaging.version.Version(pip_distribution.version)
+
+        if platform.system() == 'Darwin' and int(platform.mac_ver()[0].split('.')[0]) >= 11:
+            # macOS 11+ name scheme change requires 20.3. Intel macOS 11.0 can be told to report 10.16 for backwards
+            # compatibility; but that also fixes earlier versions of pip so this is only needed for 11+.
+            is_apple_silicon_python = platform.machine() != 'x86_64'
+            minimum_pip_version = '21.0.1' if is_apple_silicon_python else '20.3.0'
+        else:
+            # PEP-517 and manylinux1 was first implemented in 19.1
+            minimum_pip_version = '19.1.0'
+
+        if current_pip_version < packaging.version.Version(minimum_pip_version):
+            _subprocess([self.python_executable, '-m', 'pip', 'install', f'pip>={minimum_pip_version}'])
+
+        # Avoid the setuptools from ensurepip to break the isolation
+        _subprocess([self.python_executable, '-m', 'pip', 'uninstall', 'setuptools', '-y'])
+
+    def install_packages(self, requirements: Iterable[str]) -> None:
+        """
+        Install packages in the isolated environment.
+
+        :param requirements: PEP 508-style requirements
+        """
+        req_list = sorted(requirements)
+        if not req_list:
+            return
+
+        # pip does not honour environment markers in command line arguments;
+        # it does for requirements from a file.
+        with tempfile.NamedTemporaryFile(
+            'w',
+            prefix='build-reqs-',
+            suffix='.txt',
+            # On Windows the temp file can't be opened by pip while it is kept open by build
+            # so we defer deleting it.
+            delete=False,
+        ) as req_file:
+            req_file.write(os.linesep.join(req_list))
+
+        try:
+            self._log(f'Installing build dependencies... ({", ".join(req_list)})')
+            _subprocess(
+                [
+                    self.python_executable,
+                    '-m',
+                    'pip',
+                    'install',
+                    # Enforce PEP 517 because "legacy" builds won't work for build dependencies
+                    # of a project which does not use setuptools.
+                    '--use-pep517',
+                    '-r',
+                    req_file.name,
+                ]
+            )
+        finally:
+            os.unlink(req_file.name)
+
+    def prepare_environ(self) -> Dict[str, str]:
+        environ = os.environ.copy()
+
+        # Make the virtual environment's scripts available to the project's build dependecies.
+        path = environ.get('PATH')
+        environ['PATH'] = os.pathsep.join([self._scripts_dir, path]) if path is not None else self._scripts_dir
+
+        return environ
+
+    @property
+    def python_executable(self) -> str:
+        return self._python_executable
+
+
+class IsolatedEnvManager:
+    """Create and dispose of isolated build environments."""
+
+    def __enter__(self) -> _DefaultIsolatedEnv:
+        """
+        Create an isolated build environment.
+
+        :returns: The isolated environment
+        """
+        self._path = tempfile.mkdtemp(prefix='build-env-')
+        try:
+            isolated_env = _DefaultIsolatedEnv(self)
+            isolated_env.create(self._path)
+            return isolated_env
+        except Exception:  # Delete folder if creation fails
+            self.__exit__(*sys.exc_info())
+            raise
+
+    def __exit__(self, *exc_info: object) -> None:
+        if os.path.exists(self._path):
+            shutil.rmtree(self._path)
+
+    @staticmethod
+    def log(message: str) -> None:
+        """
+        Log a message.
+
+        The default implementation uses the logging module but this function can be
+        overridden by users to have a different implementation.
+
+        :param message: Message to log
+        """
+        if sys.version_info >= (3, 8):
+            _logger.log(logging.INFO, message, stacklevel=2)
+        else:
+            _logger.log(logging.INFO, message)
 
 
 __all__ = [
-    'IsolatedEnvBuilder',
+    'IsolatedEnvManager',
     'IsolatedEnv',
 ]

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -18,7 +18,7 @@ from typing import Dict, Iterable, List, Tuple
 from . import check_dependency
 
 
-_logger = logging.getLogger('build.env')
+_logger = logging.getLogger(__name__)
 
 _cache = functools.partial(functools.lru_cache, maxsize=None)
 

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -8,14 +8,13 @@ import logging
 import os
 import platform
 import shutil
-import subprocess
 import sys
 import sysconfig
 import tempfile
 
-from typing import Dict, Iterable, List, Tuple
+from typing import Dict, Iterable, Sequence, Tuple
 
-from . import check_dependency
+from ._helpers import check_dependency, default_runner
 
 
 _logger = logging.getLogger(__name__)
@@ -46,15 +45,6 @@ class IsolatedEnv(metaclass=abc.ABCMeta):
     def python_executable(self) -> str:
         """The isolated environment's Python executable."""
         raise NotImplementedError
-
-
-def _subprocess(cmd: List[str]) -> None:
-    """Invoke subprocess and output stdout and stderr if it fails."""
-    try:
-        subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-    except subprocess.CalledProcessError as e:
-        print(e.output.decode(), end='', file=sys.stderr)
-        raise e
 
 
 @_cache()
@@ -165,6 +155,9 @@ class _DefaultIsolatedEnv(IsolatedEnv):
         self._log = isolated_env_manager.log
         self._env_created = False
 
+    def _run(self, cmd: Sequence[str]) -> None:
+        return default_runner(cmd, env=self.prepare_environ())
+
     def create(self, path: str) -> None:
         if self._env_created:
             return
@@ -199,9 +192,9 @@ class _DefaultIsolatedEnv(IsolatedEnv):
         )
         min_pip_version = _get_min_pip_version()
         if packaging.version.Version(cur_pip_version) < packaging.version.Version(min_pip_version):
-            _subprocess([self.python_executable, '-m', 'pip', 'install', f'pip>={min_pip_version}'])
+            self._run([self.python_executable, '-m', 'pip', 'install', f'pip>={min_pip_version}'])
 
-        _subprocess([self.python_executable, '-m', 'pip', 'uninstall', '-y', 'setuptools'])
+        self._run([self.python_executable, '-m', 'pip', 'uninstall', '-y', 'setuptools'])
 
     def install_packages(self, requirements: Iterable[str]) -> None:
         """
@@ -227,7 +220,7 @@ class _DefaultIsolatedEnv(IsolatedEnv):
 
         try:
             self._log(f'Installing build dependencies... ({", ".join(req_list)})')
-            _subprocess(
+            self._run(
                 [
                     self.python_executable,
                     '-m',

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -13,7 +13,7 @@ import tempfile
 
 from typing import Dict, Generic, Iterable, Optional, Sequence, Tuple, TypeVar, cast, overload
 
-from ._compat import cache
+from ._compat import cache, importlib_metadata
 from ._helpers import check_dependency, default_runner
 
 
@@ -182,13 +182,9 @@ class _DefaultIsolatedEnv(IsolatedEnv):
     def _patch_up_venv(self, venv_purelib: str) -> None:
         import packaging.version
 
-        if sys.version_info >= (3, 8):
-            from importlib.metadata import distributions
-        else:
-            from importlib_metadata import distributions
-
         cur_pip_version = next(
-            d.version for d in distributions(name='pip', path=[venv_purelib])  # type: ignore[no-untyped-call]
+            d.version
+            for d in importlib_metadata.distributions(name='pip', path=[venv_purelib])  # type: ignore[no-untyped-call]
         )
         min_pip_version = _get_min_pip_version()
         if packaging.version.Version(cur_pip_version) < packaging.version.Version(min_pip_version):

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -311,7 +311,7 @@ def _find_executable_and_scripts(path: str) -> Tuple[str, str, str]:
     return executable, paths['scripts'], paths['purelib']
 
 
-__all__ = (
+__all__ = [
     'IsolatedEnvBuilder',
     'IsolatedEnv',
-)
+]

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -13,7 +13,7 @@ import tempfile
 
 from typing import Dict, Generic, Iterable, Optional, Sequence, Tuple, TypeVar, cast, overload
 
-from ._compat import cache, importlib_metadata
+from ._compat import Protocol, cache, importlib_metadata, runtime_checkable
 from ._helpers import check_dependency, default_runner
 
 
@@ -22,8 +22,9 @@ _logger = logging.getLogger(__name__)
 IsolatedEnvType = TypeVar('IsolatedEnvType', bound='IsolatedEnv')  #: :class:`IsolatedEnv` type alias.
 
 
-class IsolatedEnv(metaclass=abc.ABCMeta):
-    """ABC for isolated build environments."""
+@runtime_checkable
+class IsolatedEnv(Protocol):
+    """Protocol for isolated build environments."""
 
     @abc.abstractmethod
     def create(self, path: str) -> None:

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -13,14 +13,13 @@ import tempfile
 
 from typing import Dict, Iterable, Iterator, Optional, Sequence, Tuple
 
-from ._compat import Protocol, cache, importlib_metadata, runtime_checkable
+from ._compat import Protocol, cache, importlib_metadata
 from ._helpers import check_dependency, default_runner
 
 
 _logger = logging.getLogger(__name__)
 
 
-@runtime_checkable
 class IsolatedEnv(Protocol):
     """Protocol for isolated build environments."""
 

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -11,7 +11,7 @@ import sys
 import sysconfig
 import tempfile
 
-from typing import Dict, Iterable, Sequence, Tuple
+from typing import Dict, Iterable, Optional, Sequence, Tuple
 
 from ._helpers import cache, check_dependency, default_runner
 
@@ -32,7 +32,7 @@ class IsolatedEnv(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def prepare_environ(self) -> Dict[str, str]:
+    def prepare_environ(self) -> Optional[Dict[str, str]]:
         """
         Modify environment variables.
         """

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -18,8 +18,8 @@ else:
 def _project_wheel_metadata(builder: ProjectBuilder) -> 'importlib_metadata.PackageMetadata':
     with tempfile.TemporaryDirectory() as tmpdir:
         path = pathlib.Path(builder.metadata_path(tmpdir))
-        # https://github.com/python/importlib_metadata/pull/343
-        return importlib_metadata.PathDistribution(path).metadata  # type: ignore
+        # https://github.com/python/importlib_metadata/pull/342
+        return importlib_metadata.PathDistribution(path).metadata  # type: ignore[arg-type]
 
 
 def project_wheel_metadata(

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -33,9 +33,8 @@ def project_wheel_metadata(
     otherwise ``build_wheel``.
 
     :param srcdir: Project source directory
-    :param isolated: Whether or not to run invoke the backend in the current
-                     environment or to create an isolated one and invoke it
-                     there.
+    :param isolated: Whether to invoke the backend in the current environment
+        or create an isolated environment and invoke it there
     """
     if not isolated:
         builder = ProjectBuilder(srcdir, runner=quiet_runner)

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -6,7 +6,7 @@ import tempfile
 from . import ProjectBuilder
 from ._compat import importlib_metadata
 from ._helpers import PathType, quiet_runner
-from .env import IsolatedEnvManager
+from .env import DefaultIsolatedEnv
 
 
 def _project_wheel_metadata(builder: ProjectBuilder) -> 'importlib_metadata.PackageMetadata':
@@ -34,7 +34,7 @@ def project_wheel_metadata(
         builder = ProjectBuilder(srcdir, runner=quiet_runner)
         return _project_wheel_metadata(builder)
 
-    with IsolatedEnvManager() as env:
+    with DefaultIsolatedEnv.with_temp_dir() as env:
         builder = ProjectBuilder.from_isolated_env(env, srcdir, runner=quiet_runner)
         env.install_packages(builder.build_system_requires)
         env.install_packages(builder.get_requires_for_build('wheel'))

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -4,10 +4,8 @@ import pathlib
 import sys
 import tempfile
 
-import pep517
-
 from . import ProjectBuilder
-from ._helpers import PathType
+from ._helpers import PathType, quiet_runner
 from .env import IsolatedEnvManager
 
 
@@ -40,7 +38,7 @@ def project_wheel_metadata(
                      there.
     """
     if not isolated:
-        builder = ProjectBuilder(srcdir, runner=pep517.quiet_subprocess_runner)
+        builder = ProjectBuilder(srcdir, runner=quiet_runner)
         return _project_wheel_metadata(builder)
 
     with IsolatedEnvManager() as env:

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -1,18 +1,12 @@
 # SPDX-License-Identifier: MIT
 
 import pathlib
-import sys
 import tempfile
 
 from . import ProjectBuilder
+from ._compat import importlib_metadata
 from ._helpers import PathType, quiet_runner
 from .env import IsolatedEnvManager
-
-
-if sys.version_info >= (3, 8):
-    import importlib.metadata as importlib_metadata
-else:
-    import importlib_metadata
 
 
 def _project_wheel_metadata(builder: ProjectBuilder) -> 'importlib_metadata.PackageMetadata':

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -6,7 +6,8 @@ import tempfile
 
 import pep517
 
-from . import PathType, ProjectBuilder
+from . import ProjectBuilder
+from ._helpers import PathType
 from .env import IsolatedEnvManager
 
 

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -55,4 +55,6 @@ def project_wheel_metadata(
         return _project_wheel_metadata(builder)
 
 
-__all__ = ('project_wheel_metadata',)
+__all__ = [
+    'project_wheel_metadata',
+]

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -42,7 +42,7 @@ def project_wheel_metadata(
         return _project_wheel_metadata(builder)
 
     with IsolatedEnvManager() as env:
-        builder = ProjectBuilder.from_isolated_env(env, srcdir)
+        builder = ProjectBuilder.from_isolated_env(env, srcdir, runner=quiet_runner)
         env.install_packages(builder.build_system_requires)
         env.install_packages(builder.get_requires_for_build('wheel'))
         return _project_wheel_metadata(builder)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -117,8 +117,10 @@ def test_pip_needs_upgrade_mac_os_11(mocker, arch, pip_version):
     mocker.patch('platform.system', return_value='Darwin')
     mocker.patch('platform.mac_ver', return_value=('11.0', ('', '', ''), arch))
 
-    target = 'importlib.metadata' if sys.version_info >= (3, 8) else 'importlib_metadata'
-    mocker.patch(f'{target}.distributions', return_value=iter((types.SimpleNamespace(version=pip_version),)))
+    mocker.patch(
+        'build._compat.importlib_metadata.distributions',
+        return_value=iter([types.SimpleNamespace(version=pip_version)]),
+    )
 
     # Cache must be cleared to rerun
     build.env._get_min_pip_version.cache_clear()

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: MIT
-import collections
 import logging
 import os
 import platform
@@ -7,6 +6,7 @@ import shutil
 import subprocess
 import sys
 import sysconfig
+import types
 
 import pytest
 
@@ -21,30 +21,29 @@ IS_PYPY3 = platform.python_implementation() == 'PyPy'
 @pytest.mark.isolated
 def test_isolation():
     subprocess.check_call([sys.executable, '-c', 'import build.env'])
-    with build.env.IsolatedEnvBuilder() as env:
+    with build.env.IsolatedEnvManager() as env:
         with pytest.raises(subprocess.CalledProcessError):
             debug = 'import sys; import os; print(os.linesep.join(sys.path));'
-            subprocess.check_call([env.executable, '-c', f'{debug} import build.env'])
+            subprocess.check_call([env.python_executable, '-c', f'{debug} import build.env'])
 
 
 @pytest.mark.isolated
 def test_isolated_environment_install(mocker):
-    with build.env.IsolatedEnvBuilder() as env:
+    with build.env.IsolatedEnvManager() as env:
         mocker.patch('build.env._subprocess')
 
-        env.install([])
+        env.install_packages([])
         build.env._subprocess.assert_not_called()
 
-        env.install(['some', 'requirements'])
+        env.install_packages(['some', 'requirements'])
         build.env._subprocess.assert_called()
         args = build.env._subprocess.call_args[0][0][:-1]
         assert args == [
-            env.executable,
-            '-Im',
+            env.python_executable,
+            '-m',
             'pip',
             'install',
             '--use-pep517',
-            '--no-warn-script-location',
             '-r',
         ]
 
@@ -53,7 +52,7 @@ def test_isolated_environment_install(mocker):
 @pytest.mark.skipif(sys.platform != 'darwin', reason='workaround for Apple Python')
 def test_can_get_venv_paths_with_conflicting_default_scheme(mocker):
     get_scheme_names = mocker.patch('sysconfig.get_scheme_names', return_value=('osx_framework_library',))
-    with build.env.IsolatedEnvBuilder():
+    with build.env.IsolatedEnvManager():
         pass
     assert get_scheme_names.call_count == 1
 
@@ -68,7 +67,7 @@ def test_executable_missing_post_creation(mocker):
 
     get_paths = mocker.patch('sysconfig.get_paths', side_effect=_get_paths)
     with pytest.raises(RuntimeError, match='Virtual environment creation failed, executable .* missing'):
-        with build.env.IsolatedEnvBuilder():
+        with build.env.IsolatedEnvManager():
             pass
     assert get_paths.call_count == 1
 
@@ -101,15 +100,15 @@ def test_isolated_env_log(mocker, caplog, package_test_flit):
     mocker.patch('build.env._subprocess')
     caplog.set_level(logging.DEBUG)
 
-    builder = build.env.IsolatedEnvBuilder()
+    builder = build.env.IsolatedEnvManager()
     builder.log('something')
     with builder as env:
-        env.install(['something'])
+        env.install_packages(['something'])
 
     assert [(record.levelname, record.message) for record in caplog.records] == [
         ('INFO', 'something'),
-        ('INFO', 'Creating venv isolated environment...'),
-        ('INFO', 'Installing packages in isolated environment... (something)'),
+        ('INFO', 'Creating isolated environment (venv)...'),
+        ('INFO', 'Installing build dependencies... (something)'),
     ]
     if sys.version_info >= (3, 8):  # stacklevel
         assert [(record.lineno) for record in caplog.records] == [105, 107, 198]
@@ -117,36 +116,39 @@ def test_isolated_env_log(mocker, caplog, package_test_flit):
 
 @pytest.mark.isolated
 def test_default_pip_is_never_too_old():
-    with build.env.IsolatedEnvBuilder() as env:
+    with build.env.IsolatedEnvManager() as env:
         version = subprocess.check_output(
-            [env.executable, '-c', 'import pip; print(pip.__version__)'], universal_newlines=True
+            [env.python_executable, '-c', 'import pip; print(pip.__version__)'], universal_newlines=True
         ).strip()
         assert Version(version) >= Version('19.1')
 
 
 @pytest.mark.isolated
-@pytest.mark.parametrize('pip_version', ['20.2.0', '20.3.0', '21.0.0', '21.0.1'])
 @pytest.mark.parametrize('arch', ['x86_64', 'arm64'])
-def test_pip_needs_upgrade_mac_os_11(mocker, pip_version, arch):
-    SimpleNamespace = collections.namedtuple('SimpleNamespace', 'version')
-
+@pytest.mark.parametrize('pip_version', ['20.2.0', '20.3.0', '21.0.0', '21.0.1'])
+@pytest.mark.skipif(sys.platform != 'darwin', reason='mac only')
+def test_pip_needs_upgrade_mac_os_11(mocker, arch, pip_version):
     _subprocess = mocker.patch('build.env._subprocess')
     mocker.patch('platform.system', return_value='Darwin')
-    mocker.patch('platform.machine', return_value=arch)
-    mocker.patch('platform.mac_ver', return_value=('11.0', ('', '', ''), ''))
-    mocker.patch('build.env.metadata.distributions', return_value=(SimpleNamespace(version=pip_version),))
+    mocker.patch('platform.mac_ver', return_value=('11.0', ('', '', ''), arch))
 
-    min_version = Version('20.3' if arch == 'x86_64' else '21.0.1')
-    with build.env.IsolatedEnvBuilder():
-        if Version(pip_version) < min_version:
+    target = 'importlib.metadata' if sys.version_info >= (3, 8) else 'importlib_metadata'
+    mocker.patch(f'{target}.distributions', return_value=iter((types.SimpleNamespace(version=pip_version),)))
+
+    # Cache must be cleared to rerun
+    build.env._get_min_pip_version.cache_clear()
+    min_version = build.env._get_min_pip_version()
+
+    with build.env.IsolatedEnvManager():
+        if Version(pip_version) < Version(min_version):
             print(_subprocess.call_args_list)
             upgrade_call, uninstall_call = _subprocess.call_args_list
-            answer = 'pip>=20.3.0' if arch == 'x86_64' else 'pip>=21.0.1'
+            answer = 'pip>=20.3' if arch == 'x86_64' else 'pip>=21.0.1'
             assert upgrade_call[0][0][1:] == ['-m', 'pip', 'install', answer]
-            assert uninstall_call[0][0][1:] == ['-m', 'pip', 'uninstall', 'setuptools', '-y']
+            assert uninstall_call[0][0][1:] == ['-m', 'pip', 'uninstall', '-y', 'setuptools']
         else:
             (uninstall_call,) = _subprocess.call_args_list
-            assert uninstall_call[0][0][1:] == ['-m', 'pip', 'uninstall', 'setuptools', '-y']
+            assert uninstall_call[0][0][1:] == ['-m', 'pip', 'uninstall', '-y', 'setuptools']
 
 
 @pytest.mark.isolated
@@ -160,8 +162,8 @@ def test_venv_symlink(mocker, has_symlink):
         mocker.patch('os.symlink', side_effect=OSError())
 
     # Cache must be cleared to rerun
-    build.env._fs_supports_symlink.cache_clear()
-    supports_symlink = build.env._fs_supports_symlink()
-    build.env._fs_supports_symlink.cache_clear()
+    build.env._fs_supports_symlinks.cache_clear()
+    supports_symlinks = build.env._fs_supports_symlinks()
+    build.env._fs_supports_symlinks.cache_clear()
 
-    assert supports_symlink is has_symlink
+    assert supports_symlinks is has_symlink

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -92,7 +92,11 @@ def test_isolated_env_log(mocker, caplog, package_test_flit):
         ('INFO', 'Installing build dependencies... (something)'),
     ]
     if sys.version_info >= (3, 8):  # stacklevel
-        assert [(record.lineno) for record in caplog.records] == [105, 107, 198]
+        assert [record.lineno for record in caplog.records] == [
+            build.env._DefaultIsolatedEnv.create.__code__.co_firstlineno + 8,
+            test_isolated_env_log.__code__.co_firstlineno + 6,
+            build.env._DefaultIsolatedEnv.install_packages.__code__.co_firstlineno + 23,
+        ]
 
 
 @pytest.mark.isolated

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -21,7 +21,7 @@ IS_PYPY3 = platform.python_implementation() == 'PyPy'
 @pytest.mark.isolated
 def test_isolation():
     subprocess.check_call([sys.executable, '-c', 'import build.env'])
-    with build.env.IsolatedEnvManager() as env:
+    with build.env.DefaultIsolatedEnv.with_temp_dir() as env:
         with pytest.raises(subprocess.CalledProcessError):
             debug = 'import sys; import os; print(os.linesep.join(sys.path));'
             subprocess.check_call([env.python_executable, '-c', f'{debug} import build.env'])
@@ -29,15 +29,15 @@ def test_isolation():
 
 @pytest.mark.isolated
 def test_isolated_environment_install(mocker):
-    with build.env.IsolatedEnvManager() as env:
-        mocker.patch('build.env._DefaultIsolatedEnv._run')
+    with build.env.DefaultIsolatedEnv.with_temp_dir() as env:
+        mocker.patch('build.env.DefaultIsolatedEnv._run')
 
         env.install_packages([])
-        build.env._DefaultIsolatedEnv._run.assert_not_called()
+        build.env.DefaultIsolatedEnv._run.assert_not_called()
 
         env.install_packages(['some', 'requirements'])
-        build.env._DefaultIsolatedEnv._run.assert_called()
-        args = build.env._DefaultIsolatedEnv._run.call_args[0][0][:-1]
+        build.env.DefaultIsolatedEnv._run.assert_called()
+        args = build.env.DefaultIsolatedEnv._run.call_args[0][0][:-1]
         assert args == [
             env.python_executable,
             '-m',
@@ -52,7 +52,7 @@ def test_isolated_environment_install(mocker):
 @pytest.mark.skipif(sys.platform != 'darwin', reason='workaround for Apple Python')
 def test_can_get_venv_paths_with_conflicting_default_scheme(mocker):
     get_scheme_names = mocker.patch('sysconfig.get_scheme_names', return_value=('osx_framework_library',))
-    with build.env.IsolatedEnvManager():
+    with build.env.DefaultIsolatedEnv.with_temp_dir():
         pass
     assert get_scheme_names.call_count == 1
 
@@ -62,12 +62,13 @@ def test_executable_missing_post_creation(mocker):
     original_get_paths = sysconfig.get_paths
 
     def _get_paths(vars):  # noqa
-        shutil.rmtree(vars['base'])
-        return original_get_paths(vars=vars)
+        paths = original_get_paths(vars=vars)
+        shutil.rmtree(paths['scripts'])
+        return paths
 
     get_paths = mocker.patch('sysconfig.get_paths', side_effect=_get_paths)
     with pytest.raises(RuntimeError, match='Virtual environment creation failed, executable .* missing'):
-        with build.env.IsolatedEnvManager():
+        with build.env.DefaultIsolatedEnv.with_temp_dir():
             pass
     assert get_paths.call_count == 1
 
@@ -78,10 +79,10 @@ def test_isolated_env_abstract():
 
 
 def test_isolated_env_log(mocker, caplog, package_test_flit):
-    mocker.patch('build.env._DefaultIsolatedEnv._run')
+    mocker.patch('build.env.DefaultIsolatedEnv._run')
     caplog.set_level(logging.DEBUG)
 
-    builder = build.env.IsolatedEnvManager()
+    builder = build.env.DefaultIsolatedEnv.with_temp_dir()
     with builder as env:
         env.log('something')
         env.install_packages(['something'])
@@ -93,15 +94,15 @@ def test_isolated_env_log(mocker, caplog, package_test_flit):
     ]
     if sys.version_info >= (3, 8):  # stacklevel
         assert [record.lineno for record in caplog.records] == [
-            build.env._DefaultIsolatedEnv.create.__code__.co_firstlineno + 8,
+            build.env.DefaultIsolatedEnv._create.__code__.co_firstlineno + 6,
             test_isolated_env_log.__code__.co_firstlineno + 6,
-            build.env._DefaultIsolatedEnv.install_packages.__code__.co_firstlineno + 23,
+            build.env.DefaultIsolatedEnv.install_packages.__code__.co_firstlineno + 23,
         ]
 
 
 @pytest.mark.isolated
 def test_default_pip_is_never_too_old():
-    with build.env.IsolatedEnvManager() as env:
+    with build.env.DefaultIsolatedEnv.with_temp_dir() as env:
         version = subprocess.check_output(
             [env.python_executable, '-c', 'import pip; print(pip.__version__)'], universal_newlines=True
         ).strip()
@@ -113,7 +114,7 @@ def test_default_pip_is_never_too_old():
 @pytest.mark.parametrize('pip_version', ['20.2.0', '20.3.0', '21.0.0', '21.0.1'])
 @pytest.mark.skipif(sys.platform != 'darwin', reason='mac only')
 def test_pip_needs_upgrade_mac_os_11(mocker, arch, pip_version):
-    _subprocess = mocker.patch('build.env._DefaultIsolatedEnv._run')
+    _subprocess = mocker.patch('build.env.DefaultIsolatedEnv._run')
     mocker.patch('platform.system', return_value='Darwin')
     mocker.patch('platform.mac_ver', return_value=('11.0', ('', '', ''), arch))
 
@@ -126,7 +127,7 @@ def test_pip_needs_upgrade_mac_os_11(mocker, arch, pip_version):
     build.env._get_min_pip_version.cache_clear()
     min_version = build.env._get_min_pip_version()
 
-    with build.env.IsolatedEnvManager():
+    with build.env.DefaultIsolatedEnv.with_temp_dir():
         if Version(pip_version) < Version(min_version):
             print(_subprocess.call_args_list)
             upgrade_call, uninstall_call = _subprocess.call_args_list

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -30,14 +30,14 @@ def test_isolation():
 @pytest.mark.isolated
 def test_isolated_environment_install(mocker):
     with build.env.IsolatedEnvManager() as env:
-        mocker.patch('build.env._subprocess')
+        mocker.patch('build.env._DefaultIsolatedEnv._run')
 
         env.install_packages([])
-        build.env._subprocess.assert_not_called()
+        build.env._DefaultIsolatedEnv._run.assert_not_called()
 
         env.install_packages(['some', 'requirements'])
-        build.env._subprocess.assert_called()
-        args = build.env._subprocess.call_args[0][0][:-1]
+        build.env._DefaultIsolatedEnv._run.assert_called()
+        args = build.env._DefaultIsolatedEnv._run.call_args[0][0][:-1]
         assert args == [
             env.python_executable,
             '-m',
@@ -97,7 +97,7 @@ def test_isolated_env_has_install_still_abstract():
 
 
 def test_isolated_env_log(mocker, caplog, package_test_flit):
-    mocker.patch('build.env._subprocess')
+    mocker.patch('build.env._DefaultIsolatedEnv._run')
     caplog.set_level(logging.DEBUG)
 
     builder = build.env.IsolatedEnvManager()
@@ -128,7 +128,7 @@ def test_default_pip_is_never_too_old():
 @pytest.mark.parametrize('pip_version', ['20.2.0', '20.3.0', '21.0.0', '21.0.1'])
 @pytest.mark.skipif(sys.platform != 'darwin', reason='mac only')
 def test_pip_needs_upgrade_mac_os_11(mocker, arch, pip_version):
-    _subprocess = mocker.patch('build.env._subprocess')
+    _subprocess = mocker.patch('build.env._DefaultIsolatedEnv._run')
     mocker.patch('platform.system', return_value='Darwin')
     mocker.patch('platform.mac_ver', return_value=('11.0', ('', '', ''), arch))
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -77,25 +77,6 @@ def test_isolated_env_abstract():
         build.env.IsolatedEnv()
 
 
-def test_isolated_env_has_executable_still_abstract():
-    class Env(build.env.IsolatedEnv):  # noqa
-        @property
-        def executable(self):
-            raise NotImplementedError
-
-    with pytest.raises(TypeError):
-        Env()
-
-
-def test_isolated_env_has_install_still_abstract():
-    class Env(build.env.IsolatedEnv):  # noqa
-        def install(self, requirements):
-            raise NotImplementedError
-
-    with pytest.raises(TypeError):
-        Env()
-
-
 def test_isolated_env_log(mocker, caplog, package_test_flit):
     mocker.patch('build.env._DefaultIsolatedEnv._run')
     caplog.set_level(logging.DEBUG)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -101,13 +101,13 @@ def test_isolated_env_log(mocker, caplog, package_test_flit):
     caplog.set_level(logging.DEBUG)
 
     builder = build.env.IsolatedEnvManager()
-    builder.log('something')
     with builder as env:
+        env.log('something')
         env.install_packages(['something'])
 
     assert [(record.levelname, record.message) for record in caplog.records] == [
-        ('INFO', 'something'),
         ('INFO', 'Creating isolated environment (venv)...'),
+        ('INFO', 'something'),
         ('INFO', 'Installing build dependencies... (something)'),
     ]
     if sys.version_info >= (3, 8):  # stacklevel

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -315,7 +315,7 @@ def main_reload_styles():
             True,
             [
                 '\33[1m* Creating isolated environment (venv)...\33[0m',
-                '\33[1m* Installing build dependencies... ' '(setuptools >= 42.0.0, this is invalid, wheel >= 0.36.0)\33[0m',
+                '\33[1m* Installing build dependencies... (setuptools >= 42.0.0, this is invalid, wheel >= 0.36.0)\33[0m',
             ],
             '\33[91mERROR\33[0m ',
         ),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -125,7 +125,7 @@ def test_build_isolated(mocker, package_test_flit):
         ],
     )
     mocker.patch('build.__main__._error')
-    install = mocker.patch('build.env._DefaultIsolatedEnv.install_packages')
+    install = mocker.patch('build.env.DefaultIsolatedEnv.install_packages')
 
     build.__main__.build_package(package_test_flit, '.', ['sdist'])
 
@@ -168,7 +168,7 @@ def test_build_no_isolation_with_check_deps(mocker, package_test_flit, missing_d
 @pytest.mark.isolated
 def test_build_raises_build_exception(mocker, package_test_flit):
     mocker.patch('build.ProjectBuilder.get_requires_for_build', side_effect=build.BuildException)
-    mocker.patch('build.env._DefaultIsolatedEnv.install_packages')
+    mocker.patch('build.env.DefaultIsolatedEnv.install_packages')
 
     with pytest.raises(build.BuildException):
         build.__main__.build_package(package_test_flit, '.', ['sdist'])
@@ -177,7 +177,7 @@ def test_build_raises_build_exception(mocker, package_test_flit):
 @pytest.mark.isolated
 def test_build_raises_build_backend_exception(mocker, package_test_flit):
     mocker.patch('build.ProjectBuilder.get_requires_for_build', side_effect=build.BuildBackendException(Exception('a')))
-    mocker.patch('build.env._DefaultIsolatedEnv.install_packages')
+    mocker.patch('build.env.DefaultIsolatedEnv.install_packages')
 
     msg = f"Backend operation failed: Exception('a'{',' if sys.version_info < (3, 7) else ''})"
     with pytest.raises(build.BuildBackendException, match=re.escape(msg)):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -301,27 +301,23 @@ def main_reload_styles():
 
 
 @pytest.mark.parametrize(
-    ('color', 'stdout_error', 'stdout_body'),
+    ('color', 'stdout_content', 'stderr_content'),
     [
         (
             False,
-            'ERROR ',
             [
                 '* Creating isolated environment (venv)...',
                 '* Installing build dependencies... (setuptools >= 42.0.0, this is invalid, wheel >= 0.36.0)',
-                '',
-                'Traceback (most recent call last):',
             ],
+            'ERROR ',
         ),
         (
             True,
-            '\33[91mERROR\33[0m ',
             [
                 '\33[1m* Creating isolated environment (venv)...\33[0m',
                 '\33[1m* Installing build dependencies... ' '(setuptools >= 42.0.0, this is invalid, wheel >= 0.36.0)\33[0m',
-                '',
-                '\33[2mTraceback (most recent call last):',
             ],
+            '\33[91mERROR\33[0m ',
         ),
     ],
     ids=['no-color', 'color'],
@@ -334,8 +330,8 @@ def test_output_env_subprocess_error(
     tmp_dir,
     capsys,
     color,
-    stdout_body,
-    stdout_error,
+    stdout_content,
+    stderr_content,
 ):
     try:
         # do not inject hook to have clear output on capsys
@@ -353,11 +349,8 @@ def test_output_env_subprocess_error(
     stdout, stderr = capsys.readouterr()
     stdout, stderr = stdout.splitlines(), stderr.splitlines()
 
-    assert stdout[:6] == stdout_body
-    assert stdout[-1].startswith(stdout_error)
-
-    assert len(stderr) == 1
-    assert stderr[0].startswith('ERROR: Invalid requirement: ')
+    assert stdout == stdout_content
+    assert stderr[-1].startswith(stderr_content)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -151,14 +151,22 @@ def test_init(mocker, package_test_flit, package_legacy, test_no_permission, pac
     # correct flit pyproject.toml
     builder = build.ProjectBuilder(package_test_flit)
     pep517.wrappers.Pep517HookCaller.assert_called_with(
-        package_test_flit, 'flit_core.buildapi', backend_path=None, python_executable=sys.executable, runner=builder._runner
+        package_test_flit,
+        'flit_core.buildapi',
+        backend_path=None,
+        python_executable=sys.executable,
+        runner=pep517.wrappers.default_subprocess_runner,
     )
     pep517.wrappers.Pep517HookCaller.reset_mock()
 
     # custom python
     builder = build.ProjectBuilder(package_test_flit, python_executable='some-python')
     pep517.wrappers.Pep517HookCaller.assert_called_with(
-        package_test_flit, 'flit_core.buildapi', backend_path=None, python_executable='some-python', runner=builder._runner
+        package_test_flit,
+        'flit_core.buildapi',
+        backend_path=None,
+        python_executable='some-python',
+        runner=pep517.wrappers.default_subprocess_runner,
     )
     pep517.wrappers.Pep517HookCaller.reset_mock()
 
@@ -169,7 +177,7 @@ def test_init(mocker, package_test_flit, package_legacy, test_no_permission, pac
         'setuptools.build_meta:__legacy__',
         backend_path=None,
         python_executable=sys.executable,
-        runner=builder._runner,
+        runner=pep517.wrappers.default_subprocess_runner,
     )
 
     # PermissionError
@@ -180,15 +188,6 @@ def test_init(mocker, package_test_flit, package_legacy, test_no_permission, pac
     # TomlDecodeError
     with pytest.raises(build.BuildException):
         build.ProjectBuilder(package_test_bad_syntax)
-
-
-@pytest.mark.parametrize('value', [b'something', 'something_else'])
-def test_python_executable(package_test_flit, value):
-    builder = build.ProjectBuilder(package_test_flit)
-
-    builder.python_executable = value
-    assert builder.python_executable == value
-    assert builder._hook.python_executable == value
 
 
 @pytest.mark.parametrize('distribution', ['wheel', 'sdist'])
@@ -213,7 +212,7 @@ def test_build_missing_backend(packages_path, distribution, tmpdir):
     builder = build.ProjectBuilder(bad_backend_path)
 
     with pytest.raises(build.BuildBackendException):
-        builder.build(distribution, str(tmpdir))
+        builder.build(distribution, tmpdir)
 
 
 def test_check_dependencies(mocker, package_test_flit):
@@ -356,9 +355,9 @@ def test_build_not_dir_outdir(mocker, tmp_dir, package_test_flit):
 def demo_pkg_inline(tmp_path_factory):
     # builds a wheel without any dependencies and with a console script demo-pkg-inline
     tmp_path = tmp_path_factory.mktemp('demo-pkg-inline')
-    builder = build.ProjectBuilder(srcdir=os.path.join(os.path.dirname(__file__), 'packages', 'inline'))
+    builder = build.ProjectBuilder(os.path.join(os.path.dirname(__file__), 'packages', 'inline'))
     out = tmp_path / 'dist'
-    builder.build('wheel', str(out))
+    builder.build('wheel', out)
     return next(out.iterdir())
 
 

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -154,8 +154,8 @@ def test_init(mocker, package_test_flit, package_legacy, test_no_permission, pac
         package_test_flit,
         'flit_core.buildapi',
         backend_path=None,
+        runner=build.ProjectBuilder._default_rewrapped_runner,
         python_executable=sys.executable,
-        runner=pep517.wrappers.default_subprocess_runner,
     )
     pep517.wrappers.Pep517HookCaller.reset_mock()
 
@@ -165,8 +165,8 @@ def test_init(mocker, package_test_flit, package_legacy, test_no_permission, pac
         package_test_flit,
         'flit_core.buildapi',
         backend_path=None,
+        runner=build.ProjectBuilder._default_rewrapped_runner,
         python_executable='some-python',
-        runner=pep517.wrappers.default_subprocess_runner,
     )
     pep517.wrappers.Pep517HookCaller.reset_mock()
 
@@ -176,8 +176,8 @@ def test_init(mocker, package_test_flit, package_legacy, test_no_permission, pac
         package_legacy,
         'setuptools.build_meta:__legacy__',
         backend_path=None,
+        runner=build.ProjectBuilder._default_rewrapped_runner,
         python_executable=sys.executable,
-        runner=pep517.wrappers.default_subprocess_runner,
     )
 
     # PermissionError

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -597,7 +597,7 @@ def test_log(mocker, caplog, package_test_flit):
         ('INFO', 'something'),
     ]
     if sys.version_info >= (3, 8):  # stacklevel
-        assert caplog.records[-1].lineno == 562
+        assert caplog.records[-1].lineno == test_log.__code__.co_firstlineno + 11
 
 
 @pytest.mark.parametrize(

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -151,7 +151,7 @@ def test_init(mocker, package_test_flit, package_legacy, test_no_permission, pac
     mocker.patch('pep517.wrappers.Pep517HookCaller')
 
     # correct flit pyproject.toml
-    builder = build.ProjectBuilder(package_test_flit)
+    build.ProjectBuilder(package_test_flit)
     pep517.wrappers.Pep517HookCaller.assert_called_with(
         package_test_flit,
         'flit_core.buildapi',
@@ -162,7 +162,7 @@ def test_init(mocker, package_test_flit, package_legacy, test_no_permission, pac
     pep517.wrappers.Pep517HookCaller.reset_mock()
 
     # custom python
-    builder = build.ProjectBuilder(package_test_flit, python_executable='some-python')
+    build.ProjectBuilder(package_test_flit, python_executable='some-python')
     pep517.wrappers.Pep517HookCaller.assert_called_with(
         package_test_flit,
         'flit_core.buildapi',
@@ -173,7 +173,7 @@ def test_init(mocker, package_test_flit, package_legacy, test_no_permission, pac
     pep517.wrappers.Pep517HookCaller.reset_mock()
 
     # FileNotFoundError
-    builder = build.ProjectBuilder(package_legacy)
+    build.ProjectBuilder(package_legacy)
     pep517.wrappers.Pep517HookCaller.assert_called_with(
         package_legacy,
         'setuptools.build_meta:__legacy__',

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ commands =
 
 [testenv:docs]
 description = build documentations
-basepython = python3.8
+basepython = python3.10
 extras =
     docs
 commands =


### PR DESCRIPTION
The `IsolatedEnv` is made responsible for env creation to allow pip
to implement custom env creation logic.

~~`IsolatedEnvBuilder` takes an `IsolatedEnv` class as an argument
so that bringing your own `IsolatedEnv` won't require re-implementing
the builder.~~