### PR TITLE
Replaced term `package builder` by term from PEP517

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
 build
 *****
 
-A simple, correct :pep:`517` package builder.
+A simple, correct :pep:`517` build frontend.
 
 build will invoke the :pep:`517` hooks to build a distribution package.
 It is a simple build tool and does not perform any dependency management.


### PR DESCRIPTION
There's no mention of "package builder" in PEP517. PEP517, however, defines the term "build frontend". As a novel user I would find it much easier to place PyPA build into my mental picture of the "official" term was used.