### PR TITLE
ci: add Python 3.11 dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,9 @@ jobs:
           - '3.7'
           - '3.6'
           - 'pypy3'
+        include:
+          - os: ubuntu
+            py: '3.11-dev'
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Followup to https://github.com/pypa/build/pull/374.