### PR TITLE
ci: use supported version of PyPy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           - '3.8'
           - '3.7'
           - '3.6'
-          - 'pypy3'
+          - 'pypy-3.7'
         include:
           - os: ubuntu
             py: '3.11-dev'


### PR DESCRIPTION
For backward compatibility reasons, `pypy3` is stuck on an unsupported PyPy version. Using the modern spelling here instead.
