### PR TITLE
Run slower PyPy/Windows/macOS first for faster builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu
-          - macos
           - windows
+          - macos
+          - ubuntu
         py:
           - 'pypy-3.7'
           - '3.11-dev'


### PR DESCRIPTION
This would help towards the problems mentioned in https://github.com/pypa/build/issues/380.

Running the slower ones first gives them a head start, so when the quick ones have finished, we haven't wasted time waiting for the slow one to even begin.

It especially helps when there's a queue and not all build runners are initially available.