### PR TITLE
Docs: Use code formatting

### DIFF
--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -259,15 +259,16 @@ def main_parser() -> argparse.ArgumentParser:
                 '''
                 A simple, correct PEP 517 build frontend.
 
-                By default, a source distribution (sdist) is built from {srcdir}
-                and a binary distribution (wheel) is built from the sdist.
-                This is recommended as it will ensure the sdist can be used
+                By default, a source distribution (``sdist``) is built from ``{srcdir}``
+                and a binary distribution (``wheel``) is built from the ``sdist``.
+                This is recommended as it will ensure the ``sdist`` can be used
                 to build wheels.
 
-                Pass -s/--sdist and/or -w/--wheel to build a specific distribution.
-                If you do this, the default behavior will be disabled, and all
-                artifacts will be built from {srcdir} (even if you combine
-                -w/--wheel with -s/--sdist, the wheel will be built from {srcdir}).
+                Pass ``-s``/``--sdist`` and/or ``-w``/``--wheel`` to build a specific
+                distribution. If you do this, the default behavior will be disabled, and
+                all artifacts will be built from ``{srcdir}`` (even if you combine
+                ``-w``/``--wheel`` with ``-s``/``--sdist``, the wheel will be built from
+                ``{srcdir}``).
                 '''
             ).strip(),
             '    ',


### PR DESCRIPTION
Right now https://pypa-build.readthedocs.io/en/latest/ converts double dash `––` into a longer, single dash `–`:

> A simple, correct PEP 517 build frontend. By default, a source distribution (sdist) is built from {srcdir} and a binary distribution (wheel) is built from the sdist. This is recommended as it will ensure the sdist can be used to build wheels. Pass -s/–sdist and/or -w/–wheel to build a specific distribution. If you do this, the default behavior will be disabled, and all artifacts will be built from {srcdir} (even if you combine -w/–wheel with -s/–sdist, the wheel will be built from {srcdir}).

---

By the way, how does `--sdist` differ from `setup.py sdist` with regard to formats? For `setup.py sdist`:

> The default format is a gzip’ed tar file (`.tar.gz`) on Unix, and ZIP file on Windows. ... You can specify as many formats as you like using the `--formats` option, for example: ...

https://docs.python.org/3/distutils/sourcedist.html

