### PR TITLE
tests: require latest py for Python 3.11

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,6 @@ test =
     setuptools>=42.0.0
     toml>=0.10.0
     wheel>=0.36.0
-    py@git+https://github.com/pytest-dev/py;python_version>="3.11"
 typing =
     importlib-metadata>=4.6.4
     mypy==0.910

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,8 @@ setenv =
     wheel: TEST_MODE = wheel
 extras =
     test
+deps =
+    py@git+https://github.com/pytest-dev/py@master;python_version>="3.11"
 commands =
     pytest -rsx --cov --cov-config setup.cfg \
       --cov-report=html:{envdir}/htmlcov --cov-context=test \
@@ -74,6 +76,7 @@ description = generate a DEV environment
 usedevelop = true
 deps =
     virtualenv>=20.0.34
+    py@git+https://github.com/pytest-dev/py@master;python_version>="3.11"
 extras =
     doc
     test


### PR DESCRIPTION
This should fix the errors we are seeing in the tests for Python 3.11 by using the latest master for py, which includes the needed fixes.
