### PR TITLE
tests: include Python 3.10 in tox by default

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     fix
     type
     docs
-    {py39, py38, py37, py36, pypy3}{, -path, -sdist, -wheel, -min}
+    {py310, py39, py38, py37, py36, pypy3}{, -path, -sdist, -wheel, -min}
 isolated_build = true
 skip_missing_interpreters = true
 minversion = 3.14
@@ -53,7 +53,7 @@ extras = typing
 commands =
     mypy --show-error-codes --python-version 3.6 src/build
 
-[testenv:{py39, py38, py37, py36, pypy3}-min]
+[testenv:{py310, py39, py38, py37, py36, pypy3}-min]
 description = check minimum versions required of all dependencies
 skip_install = true
 commands =
@@ -98,4 +98,4 @@ commands =
     coverage xml -o {toxworkdir}/coverage.xml -i
     coverage html -d {toxworkdir}/htmlcov -i
     python -m diff_cover.diff_cover_tool --compare-branch {env:DIFF_AGAINST:origin/main} {toxworkdir}/coverage.xml
-depends = {py39, py38, py37, py36, pypy3}{, -path, -sdist, -wheel}
+depends = {py310, py39, py38, py37, py36, pypy3}{, -path, -sdist, -wheel}


### PR DESCRIPTION
Pretending I understand tox long enough to make a PR, I think these are missing. :P