### PR TITLE
ci: refactor tox targets into matrix for faster builds via more parallelism

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,15 +32,22 @@ jobs:
           - macos
           - windows
         py:
+          - 'pypy-3.7'
+          - '3.11-dev'
           - '3.10'
           - '3.9'
           - '3.8'
           - '3.7'
           - '3.6'
-          - 'pypy-3.7'
-        include:
-          - os: ubuntu
-            py: '3.11-dev'
+        tox-target:
+          - 'tox'
+          - 'path'
+          - 'sdist'
+          - 'wheel'
+          - 'min'
+        exclude:
+          - { py: '3.11-dev', os: macos }
+          - { py: '3.11-dev', os: windows }
 
     steps:
       - uses: actions/checkout@v2
@@ -74,25 +81,24 @@ jobs:
       - name: Install tox
         run: python -m pip install tox
 
-      - name: Setup test suite
-        run: tox -vv --notest -e ${{env.BASE}},${{env.BASE}}-path,${{env.BASE}}-sdist,${{env.BASE}}-wheel
-
       - name: Run test suite via tox
-        run: tox -e ${{env.BASE}} --skip-pkg-install
+        if: matrix.tox-target == 'tox'
+        run: |
+          tox -vv --notest -e ${{env.BASE}}
+          tox -e ${{env.BASE}} --skip-pkg-install
 
-      - name: Run test suite via path
-        run: tox -e ${{env.BASE}}-path --skip-pkg-install
-
-      - name: Run test suite via sdist
-        run: tox -e ${{env.BASE}}-sdist --skip-pkg-install
-
-      - name: Run test suite via wheel
-        run: tox -e ${{env.BASE}}-wheel --skip-pkg-install
+      - name: Run test suite via ${{ matrix.tox-target }}
+        if: matrix.tox-target != 'tox' && matrix.tox-target != 'min'
+        run: |
+          tox -vv --notest -e ${{env.BASE}}-${{ matrix.tox-target }}
+          tox -e ${{env.BASE}}-${{ matrix.tox-target }} --skip-pkg-install
 
       - name: Run minimum version test
-        run: tox -e ${{env.BASE}}-min
+        if: matrix.tox-target == 'min'
+        run: tox -e ${{env.BASE}}-${{ matrix.tox-target }}
 
       - name: Rename coverage report file
+        if: matrix.tox-target == 'tox'
         run: mv ".tox/coverage.${BASE}.xml" .tox/coverage.xml
         shell: bash
 


### PR DESCRIPTION
This would help towards the problems mentioned in #380, as suggested at https://github.com/pypa/build/pull/386#issuecomment-948738999:

Another option to get it down from [~1h 13m](https://github.com/pypa/build/actions/runs/1367055009) is to factor out the five tox runs (tox, path, sdist, wheel, min) into the test matrix.

So instead of (say):

* 4m + 4m + 4m + 4m + 4m in sequence = 20m for a good case (Ubuntu/3.6), and
* 9m + 9m + 9m + 9m + 9m = 45m for a bad case (macOS/PyPy),

let those run in parallel. The main pre/post steps are only a few seconds, so not much overhead.

Here's an example which took [32m 37s](https://github.com/hugovk/build/actions/runs/1367752095) - https://github.com/hugovk/build/commit/36e2540f28cb28f3795058d8fa8038b69ce1adec.

Quick illustration!

* Before: two jobs before with five sequential tox runs each.
* After: ten jobs with one tox run each, shown here with a maximum four runners in parallel.

![image](https://user-images.githubusercontent.com/1324225/138311187-e383aabd-df4e-4cbc-8c3b-059ae0445273.png)

