### PR TITLE
Only import importlib_metadata when needed

### DIFF
--- a/src/build/env.py
+++ b/src/build/env.py
@@ -18,11 +18,6 @@ from typing import Callable, Collection, List, Optional, Tuple, Type
 import build
 
 
-if sys.version_info < (3, 8):
-    import importlib_metadata as metadata
-else:
-    from importlib import metadata
-
 try:
     import virtualenv
 except ModuleNotFoundError:
@@ -259,6 +254,11 @@ def _create_isolated_env_venv(path: str) -> Tuple[str, str]:
     import venv
 
     import packaging.version
+
+    if sys.version_info < (3, 8):
+        import importlib_metadata as metadata
+    else:
+        from importlib import metadata
 
     symlinks = _fs_supports_symlink()
     try:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -117,7 +117,11 @@ def test_isolated_env_log(mocker, caplog, package_test_flit):
         ('INFO', 'Installing packages in isolated environment... (something)'),
     ]
     if sys.version_info >= (3, 8):  # stacklevel
-        assert [(record.lineno) for record in caplog.records] == [frameinfo.lineno + 1, 107, 198]
+        assert [(record.lineno) for record in caplog.records] == [
+            frameinfo.lineno + 1,
+            frameinfo.lineno - 7,
+            frameinfo.lineno + 84,
+        ]
 
 
 @pytest.mark.isolated
@@ -140,7 +144,7 @@ def test_pip_needs_upgrade_mac_os_11(mocker, pip_version, arch):
     mocker.patch('platform.machine', return_value=arch)
     mocker.patch('platform.mac_ver', return_value=('11.0', ('', '', ''), ''))
     metadata_name = 'importlib_metadata' if sys.version_info < (3, 8) else 'importlib.metadata'
-    mocker.patch(metadata_name+'.distributions', return_value=(SimpleNamespace(version=pip_version),))
+    mocker.patch(metadata_name + '.distributions', return_value=(SimpleNamespace(version=pip_version),))
 
     min_version = Version('20.3' if arch == 'x86_64' else '21.0.1')
     with build.env.IsolatedEnvBuilder():

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -139,7 +139,8 @@ def test_pip_needs_upgrade_mac_os_11(mocker, pip_version, arch):
     mocker.patch('platform.system', return_value='Darwin')
     mocker.patch('platform.machine', return_value=arch)
     mocker.patch('platform.mac_ver', return_value=('11.0', ('', '', ''), ''))
-    mocker.patch('build.env.metadata.distributions', return_value=(SimpleNamespace(version=pip_version),))
+    metadata_name = 'importlib_metadata' if sys.version_info < (3, 8) else 'importlib.metadata'
+    mocker.patch(metadata_name+'.distributions', return_value=(SimpleNamespace(version=pip_version),))
 
     min_version = Version('20.3' if arch == 'x86_64' else '21.0.1')
     with build.env.IsolatedEnvBuilder():


### PR DESCRIPTION
Similar to #395, this helps with bootstrap issues with python < 3.8.