### PR TITLE
util: return distribution from `project_wheel_metadata`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,5 +29,5 @@ jobs:
       - name: Setup run environment
         run: tox -vv --notest -e docs
 
-      - name: Run check for type
+      - name: Run check for docs
         run: tox -e docs --skip-pkg-install

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,10 +8,21 @@ Unreleased
 
 - Accept ``os.PathLike[str]`` in addition to ``str`` for paths in public
   API (`PR #392`_, Fixes `#372`_)
-
 - Add schema validation for ``build-system`` table to check conformity
   with PEP 517 and PEP 518 (`PR #365`_, Fixes `#364`_)
 
+Breaking changes
+----------------
+
+- The isolated environment interface has been redesigned for ``IsolatedEnv``\s
+  to subsume virtual environment creation (`PR #361`_)
+
+  - The runner callback's signature has changed
+  - ``IsolatedEnvBuilder`` was renamed to ``IsolatedEnvManager``
+  - The ``ProjectBuiler.from_isolated_env`` constructor was added to
+    initialise a builder from an isolated environment
+
+.. _PR #361: https://github.com/pypa/build/pull/361
 .. _PR #365: https://github.com/pypa/build/pull/365
 .. _PR #392: https://github.com/pypa/build/pull/392
 .. _#364: https://github.com/pypa/build/issues/364

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,9 +22,13 @@ Breaking changes
   - The ``ProjectBuiler.from_isolated_env`` constructor was added to
     initialise a builder from an isolated environment
 
+- ``project_wheel_metadata`` now returns an ``importlib.metadata.Distribution``
+  object (`PR #XXX`_)
+
 .. _PR #361: https://github.com/pypa/build/pull/361
 .. _PR #365: https://github.com/pypa/build/pull/365
 .. _PR #392: https://github.com/pypa/build/pull/392
+.. _PR #XXX: https://github.com/pypa/build/pull/XXX
 .. _#364: https://github.com/pypa/build/issues/364
 .. _#372: https://github.com/pypa/build/issues/372
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,8 +1,6 @@
 API Documentation
 =================
 
-This project exposes 2 modules:
-
 ``build`` module
 ----------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,6 +10,7 @@ This project exposes 2 modules:
    :members:
    :undoc-members:
    :show-inheritance:
+   :special-members: __call__
 
 ``build.env`` module
 --------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,7 @@ html_title = f'build {version}'
 # html_static_path = ['_static']
 
 autoclass_content = 'both'
-
+autodoc_member_order = 'bysource'
 autodoc_preserve_defaults = True
 
 set_type_checking_flag = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,19 +10,20 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
-import build
-
 
 # -- Project information -----------------------------------------------------
+
+import importlib.metadata
+
 
 project = 'build'
 copyright = '2020, Filipe Laíns'
 author = 'Filipe Laíns'
 
 # The short X.Y version
-version = build.__version__
+version = importlib.metadata.version('build')
 # The full version, including alpha/beta/rc tags
-release = build.__version__
+release = version
 
 
 # -- General configuration ---------------------------------------------------
@@ -67,3 +68,5 @@ html_title = f'build {version}'
 autoclass_content = 'both'
 
 autodoc_preserve_defaults = True
+
+set_type_checking_flag = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,3 +65,5 @@ html_title = f'build {version}'
 # html_static_path = ['_static']
 
 autoclass_content = 'both'
+
+autodoc_preserve_defaults = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ source = [
 exclude_lines = [
   '\#\s*pragma: no cover',
   '^\s*raise NotImplementedError\b',
+  "if TYPE_CHECKING:",
 ]
 
 [tool.coverage.paths]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ exclude_lines = [
   '\#\s*pragma: no cover',
   '^\s*raise NotImplementedError\b',
   "if TYPE_CHECKING:",
+  "@overload",
 ]
 
 [tool.coverage.paths]

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ pipx.run =
 
 [options.extras_require]
 docs =
+    build[typing]
     furo>=2021.08.31
     sphinx~=4.0
     sphinx-argparse-cli>=1.5

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -19,7 +19,6 @@ import zipfile
 
 from typing import (
     TYPE_CHECKING,
-    AbstractSet,
     Any,
     Callable,
     Dict,
@@ -27,7 +26,6 @@ from typing import (
     Mapping,
     MutableMapping,
     Optional,
-    Sequence,
     Set,
     Tuple,
     Type,
@@ -36,10 +34,12 @@ from typing import (
 
 import pep517.wrappers
 
+from . import env
+from ._helpers import ConfigSettingsType, PathType, check_dependency
+
 
 if TYPE_CHECKING:
-    # Avoid import cycle.
-    from . import env
+    from ._helpers import RunnerType
 
 
 TOMLDecodeError: Type[Exception]
@@ -54,27 +54,7 @@ except ModuleNotFoundError:  # pragma: no cover
     from toml import loads as toml_loads  # type: ignore
 
 
-ConfigSettingsType = Mapping[str, Union[str, Sequence[str]]]
-PathType = Union[str, 'os.PathLike[str]']
 _ExcInfoType = Union[Tuple[Type[BaseException], BaseException, types.TracebackType], Tuple[None, None, None]]
-
-
-if TYPE_CHECKING:
-    from typing_extensions import Protocol
-
-    class RunnerType(Protocol):
-        def __call__(
-            self, cmd: Sequence[str], cwd: Optional[PathType] = None, extra_environ: Optional[Mapping[str, str]] = None
-        ) -> None:
-            """
-            Run a command in a Python subprocess.
-
-            The parameters mirror those of ``subprocess.run``.
-
-            :param cmd: The command to execute
-            :param cwd: The working directory
-            :param extra_environ: Variables to be exported to the environment
-            """
 
 
 _WHEEL_NAME_REGEX = re.compile(
@@ -143,49 +123,6 @@ def _working_directory(path: str) -> Iterator[None]:
         yield
     finally:
         os.chdir(current)
-
-
-def check_dependency(
-    req_string: str, ancestral_req_strings: Tuple[str, ...] = (), parent_extras: AbstractSet[str] = frozenset()
-) -> Iterator[Tuple[str, ...]]:
-    """
-    Verify that a dependency and all of its dependencies are met.
-
-    :param req_string: Requirement string
-    :param parent_extras: Extras (eg. "test" in myproject[test])
-    :yields: Unmet dependencies
-    """
-    import packaging.requirements
-
-    if sys.version_info >= (3, 8):
-        import importlib.metadata as importlib_metadata
-    else:
-        import importlib_metadata
-
-    req = packaging.requirements.Requirement(req_string)
-
-    if req.marker:
-        extras = frozenset(('',)).union(parent_extras)
-        # a requirement can have multiple extras but ``evaluate`` can
-        # only check one at a time.
-        if all(not req.marker.evaluate(environment={'extra': e}) for e in extras):
-            # if the marker conditions are not met, we pretend that the
-            # dependency is satisfied.
-            return
-
-    try:
-        dist = importlib_metadata.distribution(req.name)  # type: ignore[no-untyped-call]
-    except importlib_metadata.PackageNotFoundError:
-        # dependency is not installed in the environment.
-        yield ancestral_req_strings + (req_string,)
-    else:
-        if req.specifier and not req.specifier.contains(dist.version, prereleases=True):
-            # the installed version is incompatible.
-            yield ancestral_req_strings + (req_string,)
-        elif dist.requires:
-            for other_req_string in dist.requires:
-                # yields transitive dependencies that are not satisfied.
-                yield from check_dependency(other_req_string, ancestral_req_strings + (req_string,), req.extras)
 
 
 def _parse_source_dir(source_dir: PathType) -> str:

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -17,20 +17,7 @@ import types
 import warnings
 import zipfile
 
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Iterator,
-    Mapping,
-    MutableMapping,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, Mapping, MutableMapping, Optional, Set, Tuple, Type, Union
 
 import pep517.wrappers
 
@@ -39,7 +26,7 @@ from ._helpers import ConfigSettingsType, PathType, check_dependency
 
 
 if TYPE_CHECKING:
-    from ._helpers import RunnerType
+    from ._helpers import Distribution, RunnerType, WheelDistribution
 
 
 TOMLDecodeError: Type[Exception]
@@ -260,12 +247,14 @@ class ProjectBuilder:
         """
         return self._requires
 
-    def get_requires_for_build(self, distribution: str, config_settings: Optional[ConfigSettingsType] = None) -> Set[str]:
+    def get_requires_for_build(
+        self, distribution: 'Distribution', config_settings: Optional[ConfigSettingsType] = None
+    ) -> Set[str]:
         """
         Get the build dependencies requested by the backend for
         a given distribution.
 
-        :param distribution: Distribution (``sdist`` or ``wheel``)
+        :param distribution: Distribution to build
         :param config_settings: Config settings passed to the backend
         """
         self.log(f'Getting dependencies for {distribution}...')
@@ -276,14 +265,14 @@ class ProjectBuilder:
             return set(get_requires(config_settings))
 
     def check_dependencies(
-        self, distribution: str, config_settings: Optional[ConfigSettingsType] = None
+        self, distribution: 'Distribution', config_settings: Optional[ConfigSettingsType] = None
     ) -> Set[Tuple[str, ...]]:
         """
         Check that the :attr:`build_system_requires` and :meth:`get_requires_for_build`
         dependencies for a given distribution are satisfied and return the dependency
         chain of those which aren't.  The unmet dependency is the last value in the chain.
 
-        :param distribution: Distribution (``sdist`` or ``wheel``)
+        :param distribution: Distribution to build
         :param config_settings: Config settings passed to the backend
         :returns: Unmet dependencies in the PEP 508 format
         """
@@ -291,12 +280,15 @@ class ProjectBuilder:
         return {u for d in dependencies for u in check_dependency(d)}
 
     def prepare(
-        self, distribution: str, output_directory: PathType, config_settings: Optional[ConfigSettingsType] = None
+        self,
+        distribution: 'WheelDistribution',
+        output_directory: PathType,
+        config_settings: Optional[ConfigSettingsType] = None,
     ) -> Optional[str]:
         """
         Prepare metadata for a distribution.
 
-        :param distribution: Distribution (must be ``wheel``)
+        :param distribution: Distribution to build
         :param output_directory: Directory to put the prepared metadata in
         :param config_settings: Config settings passed to the backend
         :returns: The path of the metadata directory
@@ -316,7 +308,7 @@ class ProjectBuilder:
 
     def build(
         self,
-        distribution: str,
+        distribution: 'Distribution',
         output_directory: PathType,
         config_settings: Optional[ConfigSettingsType] = None,
         metadata_directory: Optional[str] = None,
@@ -324,7 +316,7 @@ class ProjectBuilder:
         """
         Build a distribution.
 
-        :param distribution: Distribution (``sdist`` or ``wheel``)
+        :param distribution: Distribution to build
         :param output_directory: Directory to put the built distribution in
         :param config_settings: Config settings passed to the backend
         :param metadata_directory: If provided, should be the return value of a

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -479,7 +479,7 @@ class ProjectBuilder:
             _logger.log(logging.INFO, message)
 
 
-__all__ = (
+__all__ = [
     '__version__',
     'ConfigSettingsType',
     'RunnerType',
@@ -489,4 +489,4 @@ __all__ = (
     'TypoWarning',
     'check_dependency',
     'ProjectBuilder',
-)
+]

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -73,7 +73,7 @@ _DEFAULT_BACKEND = {
 }
 
 
-_logger = logging.getLogger('build')
+_logger = logging.getLogger(__name__)
 
 
 class BuildException(Exception):

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -484,6 +484,7 @@ __all__ = (
     'ConfigSettingsType',
     'RunnerType',
     'BuildException',
+    'BuildSystemTableValidationError',
     'BuildBackendException',
     'TypoWarning',
     'check_dependency',

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -17,7 +17,7 @@ import types
 import warnings
 import zipfile
 
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, Mapping, MutableMapping, Optional, Set, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Mapping, Optional, Set, Tuple, Type, Union
 
 import pep517.wrappers
 
@@ -28,18 +28,12 @@ from ._helpers import ConfigSettingsType, PathType, check_dependency
 if TYPE_CHECKING:
     from ._helpers import Distribution, RunnerType, WheelDistribution
 
-
-TOMLDecodeError: Type[Exception]
-toml_loads: Callable[[str], MutableMapping[str, Any]]
-
-
 try:
     from tomli import TOMLDecodeError
     from tomli import loads as toml_loads
 except ModuleNotFoundError:  # pragma: no cover
     from toml import TomlDecodeError as TOMLDecodeError  # type: ignore
     from toml import loads as toml_loads  # type: ignore
-
 
 _ExcInfoType = Union[Tuple[Type[BaseException], BaseException, types.TracebackType], Tuple[None, None, None]]
 

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -197,7 +197,7 @@ class ProjectBuilder:
             PEP 517 hooks
         :param runner: Callback for executing PEP 517 hooks in a subprocess
         """
-        self.srcdir = _parse_source_dir(srcdir)
+        self._srcdir = _parse_source_dir(srcdir)
         self._python_executable = python_executable
         self._build_system = _parse_build_system_table(_load_pyproject_toml(self.srcdir))
         self._requires = set(self._build_system['requires'])
@@ -227,6 +227,10 @@ class ProjectBuilder:
             subprocess.check_call(cmd, cwd=cwd, env=env)
 
         return cls(srcdir, python_executable=isolated_env.python_executable, runner=runner)
+
+    @property
+    def srcdir(self) -> str:
+        return self._srcdir
 
     @property
     def python_executable(self) -> str:

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -79,7 +79,7 @@ def _error(msg: str, code: int = 1) -> None:  # pragma: no cover
     :param msg: Error message
     :param code: Error code
     """
-    print('{red}ERROR{reset} {}'.format(msg, **_STYLES))
+    print('{red}ERROR{reset} {}'.format(msg, **_STYLES), file=sys.stderr)
     exit(code)
 
 
@@ -163,7 +163,11 @@ def _handle_build_error() -> Iterator[None]:
                 tb = ''.join(tb_lines)
             else:
                 tb = traceback.format_exc(-1)
-            print('\n{dim}{}{reset}\n'.format(tb.strip('\n'), **_STYLES))
+            print('\n{dim}{}{reset}\n'.format(tb.strip('\n'), **_STYLES), file=sys.stderr)
+        _error(str(e))
+    except Exception as e:  # pragma: no cover
+        tb = traceback.format_exc().strip('\n')
+        print('\n{dim}{}{reset}\n'.format(tb, **_STYLES), file=sys.stderr)
         _error(str(e))
 
 
@@ -372,19 +376,14 @@ def main(cli_args: Sequence[str], prog: Optional[str] = None) -> None:  # noqa: 
     else:
         build_call = build_package_via_sdist
         distributions = ['wheel']
-    try:
-        with _handle_build_error():
-            built = build_call(
-                args.srcdir, outdir, distributions, config_settings, not args.no_isolation, args.skip_dependency_check
-            )
-            artifact_list = _natural_language_list(
-                ['{underline}{}{reset}{bold}{green}'.format(artifact, **_STYLES) for artifact in built]
-            )
-            print('{bold}{green}Successfully built {}{reset}'.format(artifact_list, **_STYLES))
-    except Exception as e:  # pragma: no cover
-        tb = traceback.format_exc().strip('\n')
-        print('\n{dim}{}{reset}\n'.format(tb, **_STYLES))
-        _error(str(e))
+    with _handle_build_error():
+        built = build_call(
+            args.srcdir, outdir, distributions, config_settings, not args.no_isolation, args.skip_dependency_check
+        )
+        artifact_list = _natural_language_list(
+            ['{underline}{}{reset}{bold}{green}'.format(artifact, **_STYLES) for artifact in built]
+        )
+        print('{bold}{green}Successfully built {}{reset}'.format(artifact_list, **_STYLES))
 
 
 def entrypoint() -> None:

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -186,7 +186,7 @@ def build_package(
     config_settings: Optional[ConfigSettingsType] = None,
     isolation: bool = True,
     skip_dependency_check: bool = False,
-) -> Sequence[str]:
+) -> List[str]:
     """
     Run the build process.
 
@@ -211,7 +211,7 @@ def build_package_via_sdist(
     config_settings: Optional[ConfigSettingsType] = None,
     isolation: bool = True,
     skip_dependency_check: bool = False,
-) -> Sequence[str]:
+) -> List[str]:
     """
     Build a sdist and then the specified distributions from it.
 

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -18,7 +18,7 @@ import build
 
 from build import BuildBackendException, BuildException, ProjectBuilder
 from build._helpers import ConfigSettingsType, PathType
-from build.env import IsolatedEnvManager
+from build.env import IsolatedEnvManager, _DefaultIsolatedEnv
 
 
 if TYPE_CHECKING:
@@ -89,7 +89,7 @@ class _ProjectBuilder(ProjectBuilder):
         print('{bold}* {}{reset}'.format(message, **_STYLES))
 
 
-class _IsolatedEnvManager(IsolatedEnvManager):
+class _IsolatedEnv(_DefaultIsolatedEnv):
     @staticmethod
     def log(message: str) -> None:
         print('{bold}* {}{reset}'.format(message, **_STYLES))
@@ -102,7 +102,7 @@ def _format_dep_chain(dep_chain: Sequence[str]) -> str:
 def _build_in_isolated_env(
     srcdir: PathType, outdir: PathType, distribution: 'Distribution', config_settings: Optional[ConfigSettingsType]
 ) -> str:
-    with _IsolatedEnvManager() as env:
+    with IsolatedEnvManager(_IsolatedEnv()) as env:
         builder = _ProjectBuilder.from_isolated_env(env, srcdir)
         # first install the build dependencies
         env.install_packages(builder.build_system_requires)

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -21,9 +21,6 @@ from build import BuildBackendException, BuildException, ConfigSettingsType, Pat
 from build.env import IsolatedEnvBuilder
 
 
-__all__ = ['build', 'main', 'main_parser']
-
-
 _COLORS = {
     'red': '\33[91m',
     'green': '\33[92m',
@@ -388,3 +385,10 @@ def entrypoint() -> None:
 
 if __name__ == '__main__':  # pragma: no cover
     main(sys.argv[1:], 'python -m build')
+
+
+__all__ = [
+    'build',
+    'main',
+    'main_parser',
+]

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -16,7 +16,8 @@ from typing import Dict, Iterable, Iterator, List, Optional, Sequence, TextIO, T
 
 import build
 
-from build import BuildBackendException, BuildException, ConfigSettingsType, PathType, ProjectBuilder
+from build import BuildBackendException, BuildException, ProjectBuilder
+from build._helpers import ConfigSettingsType, PathType
 from build.env import IsolatedEnvManager
 
 

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -12,13 +12,17 @@ import textwrap
 import traceback
 import warnings
 
-from typing import Dict, Iterable, Iterator, List, Optional, Sequence, TextIO, Type, Union
+from typing import TYPE_CHECKING, Dict, Iterable, Iterator, List, Optional, Sequence, TextIO, Type, Union
 
 import build
 
 from build import BuildBackendException, BuildException, ProjectBuilder
 from build._helpers import ConfigSettingsType, PathType
 from build.env import IsolatedEnvManager
+
+
+if TYPE_CHECKING:
+    from ._helpers import Distribution
 
 
 _COLORS = {
@@ -96,7 +100,7 @@ def _format_dep_chain(dep_chain: Sequence[str]) -> str:
 
 
 def _build_in_isolated_env(
-    srcdir: PathType, outdir: PathType, distribution: str, config_settings: Optional[ConfigSettingsType]
+    srcdir: PathType, outdir: PathType, distribution: 'Distribution', config_settings: Optional[ConfigSettingsType]
 ) -> str:
     with _IsolatedEnvManager() as env:
         builder = _ProjectBuilder.from_isolated_env(env, srcdir)
@@ -110,7 +114,7 @@ def _build_in_isolated_env(
 def _build_in_current_env(
     srcdir: PathType,
     outdir: PathType,
-    distribution: str,
+    distribution: 'Distribution',
     config_settings: Optional[ConfigSettingsType],
     skip_dependency_check: bool = False,
 ) -> str:
@@ -129,7 +133,7 @@ def _build(
     isolation: bool,
     srcdir: PathType,
     outdir: PathType,
-    distribution: str,
+    distribution: 'Distribution',
     config_settings: Optional[ConfigSettingsType],
     skip_dependency_check: bool,
 ) -> str:
@@ -178,7 +182,7 @@ def _natural_language_list(elements: Sequence[str]) -> str:
 def build_package(
     srcdir: PathType,
     outdir: PathType,
-    distributions: Sequence[str],
+    distributions: Sequence['Distribution'],
     config_settings: Optional[ConfigSettingsType] = None,
     isolation: bool = True,
     skip_dependency_check: bool = False,
@@ -203,7 +207,7 @@ def build_package(
 def build_package_via_sdist(
     srcdir: PathType,
     outdir: PathType,
-    distributions: Sequence[str],
+    distributions: Sequence['Distribution'],
     config_settings: Optional[ConfigSettingsType] = None,
     isolation: bool = True,
     skip_dependency_check: bool = False,
@@ -341,7 +345,7 @@ def main(cli_args: Sequence[str], prog: Optional[str] = None) -> None:  # noqa: 
         parser.prog = prog
     args = parser.parse_args(cli_args)
 
-    distributions = []
+    distributions: List['Distribution'] = []
     config_settings = {}
 
     if args.config_setting:

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -388,7 +388,6 @@ if __name__ == '__main__':  # pragma: no cover
 
 
 __all__ = [
-    'build',
     'main',
     'main_parser',
 ]

--- a/src/build/_helpers.py
+++ b/src/build/_helpers.py
@@ -8,7 +8,10 @@ ConfigSettingsType = Mapping[str, Union[str, Sequence[str]]]
 PathType = Union[str, 'os.PathLike[str]']
 
 if TYPE_CHECKING:
-    from typing_extensions import Protocol
+    from typing_extensions import Literal, Protocol
+
+    Distribution = Literal['sdist', 'wheel']
+    WheelDistribution = Literal['wheel']
 
     class RunnerType(Protocol):
         def __call__(

--- a/src/build/_helpers.py
+++ b/src/build/_helpers.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import sys
 
-from typing import TYPE_CHECKING, AbstractSet, Iterator, Mapping, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, AbstractSet, Callable, Iterator, Mapping, Optional, Sequence, Tuple, TypeVar, Union
 
 
 ConfigSettingsType = Mapping[str, Union[str, Sequence[str]]]
@@ -106,3 +106,12 @@ def check_dependency(
             for other_req_string in dist.requires:
                 # yields transitive dependencies that are not satisfied.
                 yield from check_dependency(other_req_string, ancestral_req_strings + (req_string,), req.extras)
+
+
+if sys.version_info >= (3, 9):
+    cache = functools.cache
+else:
+    _C = TypeVar('_C', bound=Callable[..., object])
+
+    def cache(fn: _C) -> _C:
+        return functools.lru_cache(maxsize=None)(fn)  # type: ignore

--- a/src/build/_helpers.py
+++ b/src/build/_helpers.py
@@ -1,0 +1,69 @@
+import os
+import sys
+
+from typing import TYPE_CHECKING, AbstractSet, Iterator, Mapping, Optional, Sequence, Tuple, Union
+
+
+ConfigSettingsType = Mapping[str, Union[str, Sequence[str]]]
+PathType = Union[str, 'os.PathLike[str]']
+
+if TYPE_CHECKING:
+    from typing_extensions import Protocol
+
+    class RunnerType(Protocol):
+        def __call__(
+            self, cmd: Sequence[str], cwd: Optional[PathType] = None, extra_environ: Optional[Mapping[str, str]] = None
+        ) -> None:
+            """
+            Run a command in a Python subprocess.
+
+            The parameters mirror those of ``subprocess.run``.
+
+            :param cmd: The command to execute
+            :param cwd: The working directory
+            :param extra_environ: Variables to be exported to the environment
+            """
+
+
+def check_dependency(
+    req_string: str, ancestral_req_strings: Tuple[str, ...] = (), parent_extras: AbstractSet[str] = frozenset()
+) -> Iterator[Tuple[str, ...]]:
+    """
+    Verify that a dependency and all of its dependencies are met.
+
+    :param req_string: Requirement string
+    :param ancestral_req_strings: The dependency chain leading to this ``req_string``
+    :param parent_extras: Extras (eg. "test" in ``myproject[test]``)
+    :yields: Unmet dependencies
+    """
+    import packaging.requirements
+
+    if sys.version_info >= (3, 8):
+        import importlib.metadata as importlib_metadata
+    else:
+        import importlib_metadata
+
+    req = packaging.requirements.Requirement(req_string)
+
+    if req.marker:
+        extras = frozenset(('',)).union(parent_extras)
+        # a requirement can have multiple extras but ``evaluate`` can
+        # only check one at a time.
+        if all(not req.marker.evaluate(environment={'extra': e}) for e in extras):
+            # if the marker conditions are not met, we pretend that the
+            # dependency is satisfied.
+            return
+
+    try:
+        dist = importlib_metadata.distribution(req.name)  # type: ignore[no-untyped-call]
+    except importlib_metadata.PackageNotFoundError:
+        # dependency is not installed in the environment.
+        yield ancestral_req_strings + (req_string,)
+    else:
+        if req.specifier and not req.specifier.contains(dist.version, prereleases=True):
+            # the installed version is incompatible.
+            yield ancestral_req_strings + (req_string,)
+        elif dist.requires:
+            for other_req_string in dist.requires:
+                # yields transitive dependencies that are not satisfied.
+                yield from check_dependency(other_req_string, ancestral_req_strings + (req_string,), req.extras)

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -137,6 +137,27 @@ def _should_use_virtualenv() -> bool:
     )
 
 
+@_cache()
+def _get_min_pip_version() -> str:
+    if platform.system() == 'Darwin':
+        release, _, machine = platform.mac_ver()
+
+        # Apple Silicon support for wheels shipped with packaging 20.9,
+        # vendored in pip 21.0.1.
+        if machine == 'arm64':
+            return '21.0.1'
+
+        # macOS 11+ name scheme change requires 20.3. Intel macOS 11.0 can
+        # be told to report 10.16 for backwards compatibility;
+        # but that also fixes earlier versions of pip so this is only needed for 11+.
+        major_version = int(release[: release.find('.')])
+        if major_version >= 11:
+            return '20.3'
+
+    # PEP 517 and manylinux1 were first implemented in 19.1
+    return '19.1'
+
+
 class _DefaultIsolatedEnv(IsolatedEnv):
     """An isolated environment which combines venv or virtualenv with pip."""
 
@@ -163,28 +184,18 @@ class _DefaultIsolatedEnv(IsolatedEnv):
         import packaging.version
 
         if sys.version_info >= (3, 8):
-            from importlib import metadata
+            from importlib.metadata import distributions
         else:
-            import importlib_metadata as metadata
+            from importlib_metadata import distributions
 
-        # Get the version of pip in the environment
-        pip_distribution = next(iter(metadata.distributions(name='pip', path=[version])))  # type: ignore[no-untyped-call]
-        current_pip_version = packaging.version.Version(pip_distribution.version)
+        cur_pip_version = next(
+            d.version for d in distributions(name='pip', path=[venv_purelib])  # type: ignore[no-untyped-call]
+        )
+        min_pip_version = _get_min_pip_version()
+        if packaging.version.Version(cur_pip_version) < packaging.version.Version(min_pip_version):
+            _subprocess([self.python_executable, '-m', 'pip', 'install', f'pip>={min_pip_version}'])
 
-        if platform.system() == 'Darwin' and int(platform.mac_ver()[0].split('.')[0]) >= 11:
-            # macOS 11+ name scheme change requires 20.3. Intel macOS 11.0 can be told to report 10.16 for backwards
-            # compatibility; but that also fixes earlier versions of pip so this is only needed for 11+.
-            is_apple_silicon_python = platform.machine() != 'x86_64'
-            minimum_pip_version = '21.0.1' if is_apple_silicon_python else '20.3.0'
-        else:
-            # PEP-517 and manylinux1 was first implemented in 19.1
-            minimum_pip_version = '19.1.0'
-
-        if current_pip_version < packaging.version.Version(minimum_pip_version):
-            _subprocess([self.python_executable, '-m', 'pip', 'install', f'pip>={minimum_pip_version}'])
-
-        # Avoid the setuptools from ensurepip to break the isolation
-        _subprocess([self.python_executable, '-m', 'pip', 'uninstall', 'setuptools', '-y'])
+        _subprocess([self.python_executable, '-m', 'pip', 'uninstall', '-y', 'setuptools'])
 
     def install_packages(self, requirements: Iterable[str]) -> None:
         """

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -3,7 +3,6 @@ Creates and manages isolated build environments.
 """
 
 import abc
-import functools
 import logging
 import os
 import platform
@@ -14,12 +13,10 @@ import tempfile
 
 from typing import Dict, Iterable, Sequence, Tuple
 
-from ._helpers import check_dependency, default_runner
+from ._helpers import cache, check_dependency, default_runner
 
 
 _logger = logging.getLogger(__name__)
-
-_cache = functools.partial(functools.lru_cache, maxsize=None)
 
 
 class IsolatedEnv(metaclass=abc.ABCMeta):
@@ -47,7 +44,7 @@ class IsolatedEnv(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
 
-@_cache()
+@cache
 def _fs_supports_symlinks() -> bool:
     """Check if symlinks are supported."""
     # Using definition used by venv.main()
@@ -115,7 +112,7 @@ def _create_isolated_env_virtualenv(path: str) -> Tuple[str, str]:
     return executable, script_dir
 
 
-@_cache()
+@cache
 def _should_use_virtualenv() -> bool:
     import packaging.requirements
 
@@ -127,7 +124,7 @@ def _should_use_virtualenv() -> bool:
     )
 
 
-@_cache()
+@cache
 def _get_min_pip_version() -> str:
     if platform.system() == 'Darwin':
         release, _, machine = platform.mac_ver()

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -1,6 +1,7 @@
 """
 Creates and manages isolated build environments.
 """
+
 import abc
 import functools
 import logging
@@ -12,63 +13,39 @@ import sys
 import sysconfig
 import tempfile
 
-from types import TracebackType
-from typing import Callable, Iterable, List, Optional, Tuple, Type
+from typing import Dict, Iterable, List, Tuple
 
-import build
-
-
-if sys.version_info < (3, 8):
-    import importlib_metadata as metadata
-else:
-    from importlib import metadata
-
-try:
-    import virtualenv
-except ModuleNotFoundError:
-    virtualenv = None
+from . import check_dependency
 
 
 _logger = logging.getLogger('build.env')
 
+_cache = functools.partial(functools.lru_cache, maxsize=None)
+
 
 class IsolatedEnv(metaclass=abc.ABCMeta):
-    """Abstract base of isolated build environments, as required by the build project."""
-
-    @property
-    @abc.abstractmethod
-    def executable(self) -> str:
-        """The executable of the isolated build environment."""
-        raise NotImplementedError
-
-    @property
-    @abc.abstractmethod
-    def scripts_dir(self) -> str:
-        """The scripts directory of the isolated build environment."""
-        raise NotImplementedError
+    """ABC for isolated build environments."""
 
     @abc.abstractmethod
-    def install(self, requirements: Iterable[str]) -> None:
+    def create(self, path: str) -> None:
         """
-        Install packages from PEP 508 requirements in the isolated build environment.
+        Create the isolated environment.
 
-        :param requirements: PEP 508 requirements
+        This method should be idempotent.
         """
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def prepare_environ(self) -> Dict[str, str]:
+        """
+        Modify environment variables.
+        """
+        raise NotImplementedError
 
-@functools.lru_cache(maxsize=None)
-def _should_use_virtualenv() -> bool:
-    import packaging.requirements
-
-    # virtualenv might be incompatible if it was installed separately
-    # from build. This verifies that virtualenv and all of its
-    # dependencies are installed as specified by build.
-    return virtualenv is not None and not any(
-        packaging.requirements.Requirement(d[1]).name == 'virtualenv'
-        for d in build.check_dependency('build[virtualenv]')
-        if len(d) > 1
-    )
+    @abc.abstractproperty
+    def python_executable(self) -> str:
+        """The isolated environment's Python executable."""
+        raise NotImplementedError
 
 
 def _subprocess(cmd: List[str]) -> None:
@@ -80,211 +57,29 @@ def _subprocess(cmd: List[str]) -> None:
         raise e
 
 
-class IsolatedEnvBuilder:
-    """Builder object for isolated environments."""
-
-    def __init__(self) -> None:
-        self._path: Optional[str] = None
-
-    def __enter__(self) -> IsolatedEnv:
-        """
-        Create an isolated build environment.
-
-        :return: The isolated build environment
-        """
-        self._path = tempfile.mkdtemp(prefix='build-env-')
-        try:
-            # use virtualenv when available (as it's faster than venv)
-            if _should_use_virtualenv():
-                self.log('Creating virtualenv isolated environment...')
-                executable, scripts_dir = _create_isolated_env_virtualenv(self._path)
-            else:
-                self.log('Creating venv isolated environment...')
-                executable, scripts_dir = _create_isolated_env_venv(self._path)
-            return _IsolatedEnvVenvPip(
-                path=self._path,
-                python_executable=executable,
-                scripts_dir=scripts_dir,
-                log=self.log,
-            )
-        except Exception:  # cleanup folder if creation fails
-            self.__exit__(*sys.exc_info())
-            raise
-
-    def __exit__(
-        self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
-    ) -> None:
-        """
-        Delete the created isolated build environment.
-
-        :param exc_type: The type of exception raised (if any)
-        :param exc_val: The value of exception raised (if any)
-        :param exc_tb: The traceback of exception raised (if any)
-        """
-        if self._path is not None and os.path.exists(self._path):  # in case the user already deleted skip remove
-            shutil.rmtree(self._path)
-
-    @staticmethod
-    def log(message: str) -> None:
-        """
-        Prints message
-
-        The default implementation uses the logging module but this function can be
-        overwritten by users to have a different implementation.
-
-        :param msg: Message to output
-        """
-        if sys.version_info >= (3, 8):
-            _logger.log(logging.INFO, message, stacklevel=2)
-        else:
-            _logger.log(logging.INFO, message)
-
-
-class _IsolatedEnvVenvPip(IsolatedEnv):
-    """
-    Isolated build environment context manager
-
-    Non-standard paths injected directly to sys.path will still be passed to the environment.
-    """
-
-    def __init__(
-        self,
-        path: str,
-        python_executable: str,
-        scripts_dir: str,
-        log: Callable[[str], None],
-    ) -> None:
-        """
-        :param path: The path where the environment exists
-        :param python_executable: The python executable within the environment
-        :param log: Log function
-        """
-        self._path = path
-        self._python_executable = python_executable
-        self._scripts_dir = scripts_dir
-        self._log = log
-
-    @property
-    def path(self) -> str:
-        """The location of the isolated build environment."""
-        return self._path
-
-    @property
-    def executable(self) -> str:
-        """The python executable of the isolated build environment."""
-        return self._python_executable
-
-    @property
-    def scripts_dir(self) -> str:
-        return self._scripts_dir
-
-    def install(self, requirements: Iterable[str]) -> None:
-        """
-        Install packages from PEP 508 requirements in the isolated build environment.
-
-        :param requirements: PEP 508 requirement specification to install
-
-        :note: Passing non-PEP 508 strings will result in undefined behavior, you *should not* rely on it. It is
-               merely an implementation detail, it may change any time without warning.
-        """
-        if not requirements:
-            return
-
-        self._log('Installing packages in isolated environment... ({})'.format(', '.join(sorted(requirements))))
-
-        # pip does not honour environment markers in command line arguments
-        # but it does for requirements from a file
-        with tempfile.NamedTemporaryFile('w+', prefix='build-reqs-', suffix='.txt', delete=False) as req_file:
-            req_file.write(os.linesep.join(requirements))
-        try:
-            cmd = [
-                self.executable,
-                '-Im',
-                'pip',
-                'install',
-                '--use-pep517',
-                '--no-warn-script-location',
-                '-r',
-                os.path.abspath(req_file.name),
-            ]
-            _subprocess(cmd)
-        finally:
-            os.unlink(req_file.name)
-
-
-def _create_isolated_env_virtualenv(path: str) -> Tuple[str, str]:
-    """
-    On Python 2 we use the virtualenv package to provision a virtual environment.
-
-    :param path: The path where to create the isolated build environment
-    :return: The Python executable and script folder
-    """
-    cmd = [str(path), '--no-setuptools', '--no-wheel', '--activators', '']
-    result = virtualenv.cli_run(cmd, setup_logging=False)
-    executable = str(result.creator.exe)
-    script_dir = str(result.creator.script_dir)
-    return executable, script_dir
-
-
-@functools.lru_cache(maxsize=None)
-def _fs_supports_symlink() -> bool:
-    """Return True if symlinks are supported"""
+@_cache()
+def _fs_supports_symlinks() -> bool:
+    """Check if symlinks are supported."""
     # Using definition used by venv.main()
     if os.name != 'nt':
         return True
 
     # Windows may support symlinks (setting in Windows 10)
-    with tempfile.NamedTemporaryFile(prefix='build-symlink-') as tmp_file:
-        dest = f'{tmp_file}-b'
+    with tempfile.TemporaryDirectory(prefix='build-try-symlink-') as temp_dir:
         try:
-            os.symlink(tmp_file.name, dest)
-            os.unlink(dest)
+            os.symlink(
+                os.path.join(temp_dir, 'foo'),
+                os.path.join(temp_dir, 'bar'),
+            )
             return True
         except (OSError, NotImplementedError, AttributeError):
             return False
 
 
-def _create_isolated_env_venv(path: str) -> Tuple[str, str]:
+def _get_isolated_env_executable_and_paths(path: str) -> Tuple[str, Dict[str, str]]:
     """
-    On Python 3 we use the venv package from the standard library.
-
-    :param path: The path where to create the isolated build environment
-    :return: The Python executable and script folder
-    """
-    import venv
-
-    import packaging.version
-
-    venv.EnvBuilder(with_pip=True, symlinks=_fs_supports_symlink()).create(path)
-    executable, script_dir, purelib = _find_executable_and_scripts(path)
-
-    # Get the version of pip in the environment
-    pip_distribution = next(iter(metadata.distributions(name='pip', path=[purelib])))  # type: ignore[no-untyped-call]
-    current_pip_version = packaging.version.Version(pip_distribution.version)
-
-    if platform.system() == 'Darwin' and int(platform.mac_ver()[0].split('.')[0]) >= 11:
-        # macOS 11+ name scheme change requires 20.3. Intel macOS 11.0 can be told to report 10.16 for backwards
-        # compatibility; but that also fixes earlier versions of pip so this is only needed for 11+.
-        is_apple_silicon_python = platform.machine() != 'x86_64'
-        minimum_pip_version = '21.0.1' if is_apple_silicon_python else '20.3.0'
-    else:
-        # PEP-517 and manylinux1 was first implemented in 19.1
-        minimum_pip_version = '19.1.0'
-
-    if current_pip_version < packaging.version.Version(minimum_pip_version):
-        _subprocess([executable, '-m', 'pip', 'install', f'pip>={minimum_pip_version}'])
-
-    # Avoid the setuptools from ensurepip to break the isolation
-    _subprocess([executable, '-m', 'pip', 'uninstall', 'setuptools', '-y'])
-    return executable, script_dir
-
-
-def _find_executable_and_scripts(path: str) -> Tuple[str, str, str]:
-    """
-    Detect the Python executable and script folder of a virtual environment.
-
-    :param path: The location of the virtual environment
-    :return: The Python executable, script folder, and purelib folder
+    :param path: venv path on disk
+    :returns: The Python executable and scripts folder
     """
     config_vars = sysconfig.get_config_vars().copy()  # globally cached, copy before altering it
     config_vars['base'] = path
@@ -302,11 +97,188 @@ def _find_executable_and_scripts(path: str) -> Tuple[str, str, str]:
     executable = os.path.join(paths['scripts'], 'python.exe' if os.name == 'nt' else 'python')
     if not os.path.exists(executable):
         raise RuntimeError(f'Virtual environment creation failed, executable {executable} missing')
+    return executable, paths
 
-    return executable, paths['scripts'], paths['purelib']
+
+def _create_isolated_env_venv(path: str) -> Tuple[str, Dict[str, str]]:
+    """
+    :param path: venv path on disk
+    :returns: The Python executable and scripts folder
+    """
+    import venv
+
+    venv.EnvBuilder(symlinks=_fs_supports_symlinks(), with_pip=True).create(path)
+    return _get_isolated_env_executable_and_paths(path)
+
+
+def _create_isolated_env_virtualenv(path: str) -> Tuple[str, str]:
+    """
+    :param path: virtualenv path on disk
+    :returns: The Python executable and scripts folder
+    """
+    import virtualenv
+
+    cmd = [str(path), '--no-setuptools', '--no-wheel', '--activators', '']
+    result = virtualenv.cli_run(cmd, setup_logging=False)
+    executable = str(result.creator.exe)
+    script_dir = str(result.creator.script_dir)
+    return executable, script_dir
+
+
+@_cache()
+def _should_use_virtualenv() -> bool:
+    import packaging.requirements
+
+    # virtualenv might be incompatible if it was installed separately
+    # from build. This verifies that virtualenv and all of its
+    # dependencies are installed as specified by build.
+    return not any(
+        packaging.requirements.Requirement(u).name == 'virtualenv' for d in check_dependency('build[virtualenv]') for u in d
+    )
+
+
+class _DefaultIsolatedEnv(IsolatedEnv):
+    """An isolated environment which combines venv or virtualenv with pip."""
+
+    def __init__(self, isolated_env_manager: 'IsolatedEnvManager') -> None:
+        self._log = isolated_env_manager.log
+        self._env_created = False
+
+    def create(self, path: str) -> None:
+        if self._env_created:
+            return
+
+        if _should_use_virtualenv():
+            self._log('Creating isolated environment (virtualenv)...')
+            self._python_executable, self._scripts_dir = _create_isolated_env_virtualenv(path)
+        else:
+            self._log('Creating isolated environment (venv)...')
+            self._python_executable, paths = _create_isolated_env_venv(path)
+            self._scripts_dir = paths['scripts']
+            self._patch_up_venv(paths['purelib'])
+
+        self._env_created = True
+
+    def _patch_up_venv(self, venv_purelib: str) -> None:
+        import packaging.version
+
+        if sys.version_info >= (3, 8):
+            from importlib import metadata
+        else:
+            import importlib_metadata as metadata
+
+        # Get the version of pip in the environment
+        pip_distribution = next(iter(metadata.distributions(name='pip', path=[version])))  # type: ignore[no-untyped-call]
+        current_pip_version = packaging.version.Version(pip_distribution.version)
+
+        if platform.system() == 'Darwin' and int(platform.mac_ver()[0].split('.')[0]) >= 11:
+            # macOS 11+ name scheme change requires 20.3. Intel macOS 11.0 can be told to report 10.16 for backwards
+            # compatibility; but that also fixes earlier versions of pip so this is only needed for 11+.
+            is_apple_silicon_python = platform.machine() != 'x86_64'
+            minimum_pip_version = '21.0.1' if is_apple_silicon_python else '20.3.0'
+        else:
+            # PEP-517 and manylinux1 was first implemented in 19.1
+            minimum_pip_version = '19.1.0'
+
+        if current_pip_version < packaging.version.Version(minimum_pip_version):
+            _subprocess([self.python_executable, '-m', 'pip', 'install', f'pip>={minimum_pip_version}'])
+
+        # Avoid the setuptools from ensurepip to break the isolation
+        _subprocess([self.python_executable, '-m', 'pip', 'uninstall', 'setuptools', '-y'])
+
+    def install_packages(self, requirements: Iterable[str]) -> None:
+        """
+        Install packages in the isolated environment.
+
+        :param requirements: PEP 508-style requirements
+        """
+        req_list = sorted(requirements)
+        if not req_list:
+            return
+
+        # pip does not honour environment markers in command line arguments;
+        # it does for requirements from a file.
+        with tempfile.NamedTemporaryFile(
+            'w',
+            prefix='build-reqs-',
+            suffix='.txt',
+            # On Windows the temp file can't be opened by pip while it is kept open by build
+            # so we defer deleting it.
+            delete=False,
+        ) as req_file:
+            req_file.write(os.linesep.join(req_list))
+
+        try:
+            self._log(f'Installing build dependencies... ({", ".join(req_list)})')
+            _subprocess(
+                [
+                    self.python_executable,
+                    '-m',
+                    'pip',
+                    'install',
+                    # Enforce PEP 517 because "legacy" builds won't work for build dependencies
+                    # of a project which does not use setuptools.
+                    '--use-pep517',
+                    '-r',
+                    req_file.name,
+                ]
+            )
+        finally:
+            os.unlink(req_file.name)
+
+    def prepare_environ(self) -> Dict[str, str]:
+        environ = os.environ.copy()
+
+        # Make the virtual environment's scripts available to the project's build dependecies.
+        path = environ.get('PATH')
+        environ['PATH'] = os.pathsep.join([self._scripts_dir, path]) if path is not None else self._scripts_dir
+
+        return environ
+
+    @property
+    def python_executable(self) -> str:
+        return self._python_executable
+
+
+class IsolatedEnvManager:
+    """Create and dispose of isolated build environments."""
+
+    def __enter__(self) -> _DefaultIsolatedEnv:
+        """
+        Create an isolated build environment.
+
+        :returns: The isolated environment
+        """
+        self._path = tempfile.mkdtemp(prefix='build-env-')
+        try:
+            isolated_env = _DefaultIsolatedEnv(self)
+            isolated_env.create(self._path)
+            return isolated_env
+        except Exception:  # Delete folder if creation fails
+            self.__exit__(*sys.exc_info())
+            raise
+
+    def __exit__(self, *exc_info: object) -> None:
+        if os.path.exists(self._path):
+            shutil.rmtree(self._path)
+
+    @staticmethod
+    def log(message: str) -> None:
+        """
+        Log a message.
+
+        The default implementation uses the logging module but this function can be
+        overridden by users to have a different implementation.
+
+        :param message: Message to log
+        """
+        if sys.version_info >= (3, 8):
+            _logger.log(logging.INFO, message, stacklevel=2)
+        else:
+            _logger.log(logging.INFO, message)
 
 
 __all__ = [
-    'IsolatedEnvBuilder',
+    'IsolatedEnvManager',
     'IsolatedEnv',
 ]

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -18,7 +18,7 @@ from typing import Dict, Iterable, List, Tuple
 from . import check_dependency
 
 
-_logger = logging.getLogger('build.env')
+_logger = logging.getLogger(__name__)
 
 _cache = functools.partial(functools.lru_cache, maxsize=None)
 

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -11,12 +11,14 @@ import sys
 import sysconfig
 import tempfile
 
-from typing import Dict, Iterable, Optional, Sequence, Tuple
+from typing import Dict, Generic, Iterable, Optional, Sequence, Tuple, TypeVar, cast, overload
 
 from ._helpers import cache, check_dependency, default_runner
 
 
 _logger = logging.getLogger(__name__)
+
+IsolatedEnvType = TypeVar('IsolatedEnvType', bound='IsolatedEnv')  #: :class:`IsolatedEnv` type alias.
 
 
 class IsolatedEnv(metaclass=abc.ABCMeta):
@@ -148,8 +150,7 @@ def _get_min_pip_version() -> str:
 class _DefaultIsolatedEnv(IsolatedEnv):
     """An isolated environment which combines venv or virtualenv with pip."""
 
-    def __init__(self, isolated_env_manager: 'IsolatedEnvManager') -> None:
-        self._log = isolated_env_manager.log
+    def __init__(self) -> None:
         self._env_created = False
 
     def _run(self, cmd: Sequence[str]) -> None:
@@ -160,10 +161,10 @@ class _DefaultIsolatedEnv(IsolatedEnv):
             return
 
         if _should_use_virtualenv():
-            self._log('Creating isolated environment (virtualenv)...')
+            self.log('Creating isolated environment (virtualenv)...')
             self._python_executable, self._scripts_dir = _create_isolated_env_virtualenv(path)
         else:
-            self._log('Creating isolated environment (venv)...')
+            self.log('Creating isolated environment (venv)...')
             self._python_executable, paths = _create_isolated_env_venv(path)
             self._scripts_dir = paths['scripts']
             self._patch_up_venv(paths['purelib'])
@@ -210,7 +211,7 @@ class _DefaultIsolatedEnv(IsolatedEnv):
             req_file.write(os.linesep.join(req_list))
 
         try:
-            self._log(f'Installing build dependencies... ({", ".join(req_list)})')
+            self.log(f'Installing build dependencies... ({", ".join(req_list)})')
             self._run(
                 [
                     self.python_executable,
@@ -240,11 +241,32 @@ class _DefaultIsolatedEnv(IsolatedEnv):
     def python_executable(self) -> str:
         return self._python_executable
 
+    @staticmethod
+    def log(message: str) -> None:
+        if sys.version_info >= (3, 8):
+            _logger.log(logging.INFO, message, stacklevel=2)
+        else:
+            _logger.log(logging.INFO, message)
 
-class IsolatedEnvManager:
+
+class IsolatedEnvManager(Generic[IsolatedEnvType]):
     """Create and dispose of isolated build environments."""
 
-    def __enter__(self) -> _DefaultIsolatedEnv:
+    @overload
+    def __init__(self: 'IsolatedEnvManager[_DefaultIsolatedEnv]', isolated_env: None = None) -> None:
+        ...
+
+    @overload
+    def __init__(self, isolated_env: IsolatedEnvType) -> None:
+        ...
+
+    def __init__(self, isolated_env: Optional[IsolatedEnvType] = None) -> None:
+        """
+        :param isolated_env: The isolated environment
+        """
+        self._isolated_env = isolated_env
+
+    def __enter__(self) -> IsolatedEnvType:
         """
         Create an isolated build environment.
 
@@ -252,7 +274,7 @@ class IsolatedEnvManager:
         """
         self._path = tempfile.mkdtemp(prefix='build-env-')
         try:
-            isolated_env = _DefaultIsolatedEnv(self)
+            isolated_env = cast(IsolatedEnvType, _DefaultIsolatedEnv()) if self._isolated_env is None else self._isolated_env
             isolated_env.create(self._path)
             return isolated_env
         except Exception:  # Delete folder if creation fails
@@ -263,23 +285,9 @@ class IsolatedEnvManager:
         if os.path.exists(self._path):
             shutil.rmtree(self._path)
 
-    @staticmethod
-    def log(message: str) -> None:
-        """
-        Log a message.
-
-        The default implementation uses the logging module but this function can be
-        overridden by users to have a different implementation.
-
-        :param message: Message to log
-        """
-        if sys.version_info >= (3, 8):
-            _logger.log(logging.INFO, message, stacklevel=2)
-        else:
-            _logger.log(logging.INFO, message)
-
 
 __all__ = [
-    'IsolatedEnvManager',
     'IsolatedEnv',
+    'IsolatedEnvType',
+    'IsolatedEnvManager',
 ]

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -306,7 +306,7 @@ def _find_executable_and_scripts(path: str) -> Tuple[str, str, str]:
     return executable, paths['scripts'], paths['purelib']
 
 
-__all__ = (
+__all__ = [
     'IsolatedEnvBuilder',
     'IsolatedEnv',
-)
+]

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -11,7 +11,7 @@ import sys
 import sysconfig
 import tempfile
 
-from typing import Dict, Iterable, Sequence, Tuple
+from typing import Dict, Iterable, Optional, Sequence, Tuple
 
 from ._helpers import cache, check_dependency, default_runner
 
@@ -32,7 +32,7 @@ class IsolatedEnv(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def prepare_environ(self) -> Dict[str, str]:
+    def prepare_environ(self) -> Optional[Dict[str, str]]:
         """
         Modify environment variables.
         """

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -18,8 +18,8 @@ else:
 def _project_wheel_metadata(builder: ProjectBuilder) -> 'importlib_metadata.PackageMetadata':
     with tempfile.TemporaryDirectory() as tmpdir:
         path = pathlib.Path(builder.metadata_path(tmpdir))
-        # https://github.com/python/importlib_metadata/pull/343
-        return importlib_metadata.PathDistribution(path).metadata  # type: ignore
+        # https://github.com/python/importlib_metadata/pull/342
+        return importlib_metadata.PathDistribution(path).metadata  # type: ignore[arg-type]
 
 
 def project_wheel_metadata(

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: MIT
 
-import pathlib
+import contextlib
+import os
 import sys
 import tempfile
+
+from typing import Iterator, Optional, Tuple
 
 from . import ProjectBuilder
 from ._helpers import PathType, quiet_runner
@@ -15,17 +18,27 @@ else:
     import importlib_metadata
 
 
-def _project_wheel_metadata(builder: ProjectBuilder) -> 'importlib_metadata.PackageMetadata':
-    with tempfile.TemporaryDirectory() as tmpdir:
-        path = pathlib.Path(builder.metadata_path(tmpdir))
-        # https://github.com/python/importlib_metadata/pull/342
-        return importlib_metadata.PathDistribution(path).metadata  # type: ignore[arg-type]
+def _read_files(path: str) -> Iterator[Tuple[str, bytes]]:
+    for dir_entry in os.scandir(path):
+        if dir_entry.is_file():
+            with open(dir_entry.path, 'rb') as file:
+                yield (dir_entry.path, file.read())
+        elif dir_entry.is_dir():
+            yield from _read_files(dir_entry.path)
 
 
-def project_wheel_metadata(
-    srcdir: PathType,
-    isolated: bool = True,
-) -> 'importlib_metadata.PackageMetadata':
+class _InMemoryDistribution(importlib_metadata.Distribution):
+    def __init__(self, metadata_path: str) -> None:
+        self._files = {os.path.relpath(p, metadata_path): f for p, f in _read_files(metadata_path)}
+
+    def read_text(self, filename: str) -> str:
+        return self._files[filename].decode()
+
+    def locate_file(self, path: PathType) -> 'os.PathLike[str]':
+        raise NotImplementedError
+
+
+def project_wheel_metadata(srcdir: PathType, isolated: bool = True) -> importlib_metadata.Distribution:
     """
     Return the wheel metadata for a project.
 
@@ -36,15 +49,21 @@ def project_wheel_metadata(
     :param isolated: Whether to invoke the backend in the current environment
         or create an isolated environment and invoke it there
     """
-    if not isolated:
-        builder = ProjectBuilder(srcdir, runner=quiet_runner)
-        return _project_wheel_metadata(builder)
 
-    with IsolatedEnvManager() as env:
-        builder = ProjectBuilder.from_isolated_env(env, srcdir, runner=quiet_runner)
-        env.install_packages(builder.build_system_requires)
-        env.install_packages(builder.get_requires_for_build('wheel'))
-        return _project_wheel_metadata(builder)
+    @contextlib.contextmanager
+    def prepare_builder() -> Iterator[ProjectBuilder]:
+        if not isolated:
+            yield ProjectBuilder(srcdir, runner=quiet_runner)
+            return
+
+        with IsolatedEnvManager() as env:
+            builder = ProjectBuilder.from_isolated_env(env, srcdir, runner=quiet_runner)
+            env.install_packages(builder.build_system_requires)
+            env.install_packages(builder.get_requires_for_build('wheel'))
+            yield builder
+
+    with prepare_builder() as builder, tempfile.TemporaryDirectory(prefix='build-wheel-metadata-') as temp_dir:
+        return _InMemoryDistribution(builder.metadata_path(temp_dir))
 
 
 __all__ = [

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -4,10 +4,8 @@ import pathlib
 import sys
 import tempfile
 
-import pep517
-
 from . import ProjectBuilder
-from ._helpers import PathType
+from ._helpers import PathType, quiet_runner
 from .env import IsolatedEnvManager
 
 
@@ -40,7 +38,7 @@ def project_wheel_metadata(
                      there.
     """
     if not isolated:
-        builder = ProjectBuilder(srcdir, runner=pep517.quiet_subprocess_runner)
+        builder = ProjectBuilder(srcdir, runner=quiet_runner)
         return _project_wheel_metadata(builder)
 
     with IsolatedEnvManager() as env:

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -6,7 +6,8 @@ import tempfile
 
 import pep517
 
-from . import PathType, ProjectBuilder
+from . import ProjectBuilder
+from ._helpers import PathType
 from .env import IsolatedEnvManager
 
 

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -55,4 +55,6 @@ def project_wheel_metadata(
         return _project_wheel_metadata(builder)
 
 
-__all__ = ('project_wheel_metadata',)
+__all__ = [
+    'project_wheel_metadata',
+]

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -29,13 +29,12 @@ def project_wheel_metadata(
     """
     Return the wheel metadata for a project.
 
-    Uses the ``prepare_metadata_for_build_wheel`` hook if availablable,
+    Uses the ``prepare_metadata_for_build_wheel`` hook if available,
     otherwise ``build_wheel``.
 
     :param srcdir: Project source directory
-    :param isolated: Wether or not to run invoke the backend in the current
-                     environment or to create an isolated one and invoke it
-                     there.
+    :param isolated: Whether to invoke the backend in the current environment
+        or create an isolated environment and invoke it there
     """
     if not isolated:
         builder = ProjectBuilder(srcdir, runner=quiet_runner)

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -42,7 +42,7 @@ def project_wheel_metadata(
         return _project_wheel_metadata(builder)
 
     with IsolatedEnvManager() as env:
-        builder = ProjectBuilder.from_isolated_env(env, srcdir)
+        builder = ProjectBuilder.from_isolated_env(env, srcdir, runner=quiet_runner)
         env.install_packages(builder.build_system_requires)
         env.install_packages(builder.get_requires_for_build('wheel'))
         return _project_wheel_metadata(builder)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: MIT
-import collections
 import logging
 import os
 import platform
@@ -7,6 +6,7 @@ import shutil
 import subprocess
 import sys
 import sysconfig
+import types
 
 import pytest
 
@@ -21,30 +21,29 @@ IS_PYPY3 = platform.python_implementation() == 'PyPy'
 @pytest.mark.isolated
 def test_isolation():
     subprocess.check_call([sys.executable, '-c', 'import build.env'])
-    with build.env.IsolatedEnvBuilder() as env:
+    with build.env.IsolatedEnvManager() as env:
         with pytest.raises(subprocess.CalledProcessError):
             debug = 'import sys; import os; print(os.linesep.join(sys.path));'
-            subprocess.check_call([env.executable, '-c', f'{debug} import build.env'])
+            subprocess.check_call([env.python_executable, '-c', f'{debug} import build.env'])
 
 
 @pytest.mark.isolated
 def test_isolated_environment_install(mocker):
-    with build.env.IsolatedEnvBuilder() as env:
+    with build.env.IsolatedEnvManager() as env:
         mocker.patch('build.env._subprocess')
 
-        env.install([])
+        env.install_packages([])
         build.env._subprocess.assert_not_called()
 
-        env.install(['some', 'requirements'])
+        env.install_packages(['some', 'requirements'])
         build.env._subprocess.assert_called()
         args = build.env._subprocess.call_args[0][0][:-1]
         assert args == [
-            env.executable,
-            '-Im',
+            env.python_executable,
+            '-m',
             'pip',
             'install',
             '--use-pep517',
-            '--no-warn-script-location',
             '-r',
         ]
 
@@ -53,7 +52,7 @@ def test_isolated_environment_install(mocker):
 @pytest.mark.skipif(sys.platform != 'darwin', reason='workaround for Apple Python')
 def test_can_get_venv_paths_with_conflicting_default_scheme(mocker):
     get_scheme_names = mocker.patch('sysconfig.get_scheme_names', return_value=('osx_framework_library',))
-    with build.env.IsolatedEnvBuilder():
+    with build.env.IsolatedEnvManager():
         pass
     assert get_scheme_names.call_count == 1
 
@@ -68,7 +67,7 @@ def test_executable_missing_post_creation(mocker):
 
     get_paths = mocker.patch('sysconfig.get_paths', side_effect=_get_paths)
     with pytest.raises(RuntimeError, match='Virtual environment creation failed, executable .* missing'):
-        with build.env.IsolatedEnvBuilder():
+        with build.env.IsolatedEnvManager():
             pass
     assert get_paths.call_count == 1
 
@@ -101,15 +100,15 @@ def test_isolated_env_log(mocker, caplog, package_test_flit):
     mocker.patch('build.env._subprocess')
     caplog.set_level(logging.DEBUG)
 
-    builder = build.env.IsolatedEnvBuilder()
+    builder = build.env.IsolatedEnvManager()
     builder.log('something')
     with builder as env:
-        env.install(['something'])
+        env.install_packages(['something'])
 
     assert [(record.levelname, record.message) for record in caplog.records] == [
         ('INFO', 'something'),
-        ('INFO', 'Creating venv isolated environment...'),
-        ('INFO', 'Installing packages in isolated environment... (something)'),
+        ('INFO', 'Creating isolated environment (venv)...'),
+        ('INFO', 'Installing build dependencies... (something)'),
     ]
     if sys.version_info >= (3, 8):  # stacklevel
         assert [(record.lineno) for record in caplog.records] == [105, 102, 193]
@@ -117,36 +116,39 @@ def test_isolated_env_log(mocker, caplog, package_test_flit):
 
 @pytest.mark.isolated
 def test_default_pip_is_never_too_old():
-    with build.env.IsolatedEnvBuilder() as env:
+    with build.env.IsolatedEnvManager() as env:
         version = subprocess.check_output(
-            [env.executable, '-c', 'import pip; print(pip.__version__)'], universal_newlines=True
+            [env.python_executable, '-c', 'import pip; print(pip.__version__)'], universal_newlines=True
         ).strip()
         assert Version(version) >= Version('19.1')
 
 
 @pytest.mark.isolated
-@pytest.mark.parametrize('pip_version', ['20.2.0', '20.3.0', '21.0.0', '21.0.1'])
 @pytest.mark.parametrize('arch', ['x86_64', 'arm64'])
-def test_pip_needs_upgrade_mac_os_11(mocker, pip_version, arch):
-    SimpleNamespace = collections.namedtuple('SimpleNamespace', 'version')
-
+@pytest.mark.parametrize('pip_version', ['20.2.0', '20.3.0', '21.0.0', '21.0.1'])
+@pytest.mark.skipif(sys.platform != 'darwin', reason='mac only')
+def test_pip_needs_upgrade_mac_os_11(mocker, arch, pip_version):
     _subprocess = mocker.patch('build.env._subprocess')
     mocker.patch('platform.system', return_value='Darwin')
-    mocker.patch('platform.machine', return_value=arch)
-    mocker.patch('platform.mac_ver', return_value=('11.0', ('', '', ''), ''))
-    mocker.patch('build.env.metadata.distributions', return_value=(SimpleNamespace(version=pip_version),))
+    mocker.patch('platform.mac_ver', return_value=('11.0', ('', '', ''), arch))
 
-    min_version = Version('20.3' if arch == 'x86_64' else '21.0.1')
-    with build.env.IsolatedEnvBuilder():
-        if Version(pip_version) < min_version:
+    target = 'importlib.metadata' if sys.version_info >= (3, 8) else 'importlib_metadata'
+    mocker.patch(f'{target}.distributions', return_value=iter((types.SimpleNamespace(version=pip_version),)))
+
+    # Cache must be cleared to rerun
+    build.env._get_min_pip_version.cache_clear()
+    min_version = build.env._get_min_pip_version()
+
+    with build.env.IsolatedEnvManager():
+        if Version(pip_version) < Version(min_version):
             print(_subprocess.call_args_list)
             upgrade_call, uninstall_call = _subprocess.call_args_list
-            answer = 'pip>=20.3.0' if arch == 'x86_64' else 'pip>=21.0.1'
+            answer = 'pip>=20.3' if arch == 'x86_64' else 'pip>=21.0.1'
             assert upgrade_call[0][0][1:] == ['-m', 'pip', 'install', answer]
-            assert uninstall_call[0][0][1:] == ['-m', 'pip', 'uninstall', 'setuptools', '-y']
+            assert uninstall_call[0][0][1:] == ['-m', 'pip', 'uninstall', '-y', 'setuptools']
         else:
             (uninstall_call,) = _subprocess.call_args_list
-            assert uninstall_call[0][0][1:] == ['-m', 'pip', 'uninstall', 'setuptools', '-y']
+            assert uninstall_call[0][0][1:] == ['-m', 'pip', 'uninstall', '-y', 'setuptools']
 
 
 @pytest.mark.isolated
@@ -160,8 +162,8 @@ def test_venv_symlink(mocker, has_symlink):
         mocker.patch('os.symlink', side_effect=OSError())
 
     # Cache must be cleared to rerun
-    build.env._fs_supports_symlink.cache_clear()
-    supports_symlink = build.env._fs_supports_symlink()
-    build.env._fs_supports_symlink.cache_clear()
+    build.env._fs_supports_symlinks.cache_clear()
+    supports_symlinks = build.env._fs_supports_symlinks()
+    build.env._fs_supports_symlinks.cache_clear()
 
-    assert supports_symlink is has_symlink
+    assert supports_symlinks is has_symlink

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -92,7 +92,11 @@ def test_isolated_env_log(mocker, caplog, package_test_flit):
         ('INFO', 'Installing build dependencies... (something)'),
     ]
     if sys.version_info >= (3, 8):  # stacklevel
-        assert [(record.lineno) for record in caplog.records] == [105, 102, 193]
+        assert [record.lineno for record in caplog.records] == [
+            build.env._DefaultIsolatedEnv.create.__code__.co_firstlineno + 8,
+            test_isolated_env_log.__code__.co_firstlineno + 6,
+            build.env._DefaultIsolatedEnv.install_packages.__code__.co_firstlineno + 23,
+        ]
 
 
 @pytest.mark.isolated

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -30,14 +30,14 @@ def test_isolation():
 @pytest.mark.isolated
 def test_isolated_environment_install(mocker):
     with build.env.IsolatedEnvManager() as env:
-        mocker.patch('build.env._subprocess')
+        mocker.patch('build.env._DefaultIsolatedEnv._run')
 
         env.install_packages([])
-        build.env._subprocess.assert_not_called()
+        build.env._DefaultIsolatedEnv._run.assert_not_called()
 
         env.install_packages(['some', 'requirements'])
-        build.env._subprocess.assert_called()
-        args = build.env._subprocess.call_args[0][0][:-1]
+        build.env._DefaultIsolatedEnv._run.assert_called()
+        args = build.env._DefaultIsolatedEnv._run.call_args[0][0][:-1]
         assert args == [
             env.python_executable,
             '-m',
@@ -97,7 +97,7 @@ def test_isolated_env_has_install_still_abstract():
 
 
 def test_isolated_env_log(mocker, caplog, package_test_flit):
-    mocker.patch('build.env._subprocess')
+    mocker.patch('build.env._DefaultIsolatedEnv._run')
     caplog.set_level(logging.DEBUG)
 
     builder = build.env.IsolatedEnvManager()
@@ -128,7 +128,7 @@ def test_default_pip_is_never_too_old():
 @pytest.mark.parametrize('pip_version', ['20.2.0', '20.3.0', '21.0.0', '21.0.1'])
 @pytest.mark.skipif(sys.platform != 'darwin', reason='mac only')
 def test_pip_needs_upgrade_mac_os_11(mocker, arch, pip_version):
-    _subprocess = mocker.patch('build.env._subprocess')
+    _subprocess = mocker.patch('build.env._DefaultIsolatedEnv._run')
     mocker.patch('platform.system', return_value='Darwin')
     mocker.patch('platform.mac_ver', return_value=('11.0', ('', '', ''), arch))
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -77,25 +77,6 @@ def test_isolated_env_abstract():
         build.env.IsolatedEnv()
 
 
-def test_isolated_env_has_executable_still_abstract():
-    class Env(build.env.IsolatedEnv):  # noqa
-        @property
-        def executable(self):
-            raise NotImplementedError
-
-    with pytest.raises(TypeError):
-        Env()
-
-
-def test_isolated_env_has_install_still_abstract():
-    class Env(build.env.IsolatedEnv):  # noqa
-        def install(self, requirements):
-            raise NotImplementedError
-
-    with pytest.raises(TypeError):
-        Env()
-
-
 def test_isolated_env_log(mocker, caplog, package_test_flit):
     mocker.patch('build.env._DefaultIsolatedEnv._run')
     caplog.set_level(logging.DEBUG)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -101,13 +101,13 @@ def test_isolated_env_log(mocker, caplog, package_test_flit):
     caplog.set_level(logging.DEBUG)
 
     builder = build.env.IsolatedEnvManager()
-    builder.log('something')
     with builder as env:
+        env.log('something')
         env.install_packages(['something'])
 
     assert [(record.levelname, record.message) for record in caplog.records] == [
-        ('INFO', 'something'),
         ('INFO', 'Creating isolated environment (venv)...'),
+        ('INFO', 'something'),
         ('INFO', 'Installing build dependencies... (something)'),
     ]
     if sys.version_info >= (3, 8):  # stacklevel

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -315,7 +315,7 @@ def main_reload_styles():
             True,
             [
                 '\33[1m* Creating isolated environment (venv)...\33[0m',
-                '\33[1m* Installing build dependencies... ' '(setuptools >= 42.0.0, this is invalid, wheel >= 0.36.0)\33[0m',
+                '\33[1m* Installing build dependencies... (setuptools >= 42.0.0, this is invalid, wheel >= 0.36.0)\33[0m',
             ],
             '\33[91mERROR\33[0m ',
         ),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -301,27 +301,23 @@ def main_reload_styles():
 
 
 @pytest.mark.parametrize(
-    ('color', 'stdout_error', 'stdout_body'),
+    ('color', 'stdout_content', 'stderr_content'),
     [
         (
             False,
-            'ERROR ',
             [
                 '* Creating isolated environment (venv)...',
                 '* Installing build dependencies... (setuptools >= 42.0.0, this is invalid, wheel >= 0.36.0)',
-                '',
-                'Traceback (most recent call last):',
             ],
+            'ERROR ',
         ),
         (
             True,
-            '\33[91mERROR\33[0m ',
             [
                 '\33[1m* Creating isolated environment (venv)...\33[0m',
                 '\33[1m* Installing build dependencies... ' '(setuptools >= 42.0.0, this is invalid, wheel >= 0.36.0)\33[0m',
-                '',
-                '\33[2mTraceback (most recent call last):',
             ],
+            '\33[91mERROR\33[0m ',
         ),
     ],
     ids=['no-color', 'color'],
@@ -334,8 +330,8 @@ def test_output_env_subprocess_error(
     tmp_dir,
     capsys,
     color,
-    stdout_body,
-    stdout_error,
+    stdout_content,
+    stderr_content,
 ):
     try:
         # do not inject hook to have clear output on capsys
@@ -353,11 +349,8 @@ def test_output_env_subprocess_error(
     stdout, stderr = capsys.readouterr()
     stdout, stderr = stdout.splitlines(), stderr.splitlines()
 
-    assert stdout[:6] == stdout_body
-    assert stdout[-1].startswith(stdout_error)
-
-    assert len(stderr) == 1
-    assert stderr[0].startswith('ERROR: Invalid requirement: ')
+    assert stdout == stdout_content
+    assert stderr[-1].startswith(stderr_content)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -151,14 +151,22 @@ def test_init(mocker, package_test_flit, package_legacy, test_no_permission, pac
     # correct flit pyproject.toml
     builder = build.ProjectBuilder(package_test_flit)
     pep517.wrappers.Pep517HookCaller.assert_called_with(
-        package_test_flit, 'flit_core.buildapi', backend_path=None, python_executable=sys.executable, runner=builder._runner
+        package_test_flit,
+        'flit_core.buildapi',
+        backend_path=None,
+        python_executable=sys.executable,
+        runner=pep517.wrappers.default_subprocess_runner,
     )
     pep517.wrappers.Pep517HookCaller.reset_mock()
 
     # custom python
     builder = build.ProjectBuilder(package_test_flit, python_executable='some-python')
     pep517.wrappers.Pep517HookCaller.assert_called_with(
-        package_test_flit, 'flit_core.buildapi', backend_path=None, python_executable='some-python', runner=builder._runner
+        package_test_flit,
+        'flit_core.buildapi',
+        backend_path=None,
+        python_executable='some-python',
+        runner=pep517.wrappers.default_subprocess_runner,
     )
     pep517.wrappers.Pep517HookCaller.reset_mock()
 
@@ -169,7 +177,7 @@ def test_init(mocker, package_test_flit, package_legacy, test_no_permission, pac
         'setuptools.build_meta:__legacy__',
         backend_path=None,
         python_executable=sys.executable,
-        runner=builder._runner,
+        runner=pep517.wrappers.default_subprocess_runner,
     )
 
     # PermissionError
@@ -180,15 +188,6 @@ def test_init(mocker, package_test_flit, package_legacy, test_no_permission, pac
     # TomlDecodeError
     with pytest.raises(build.BuildException):
         build.ProjectBuilder(package_test_bad_syntax)
-
-
-@pytest.mark.parametrize('value', [b'something', 'something_else'])
-def test_python_executable(package_test_flit, value):
-    builder = build.ProjectBuilder(package_test_flit)
-
-    builder.python_executable = value
-    assert builder.python_executable == value
-    assert builder._hook.python_executable == value
 
 
 @pytest.mark.parametrize('distribution', ['wheel', 'sdist'])
@@ -213,7 +212,7 @@ def test_build_missing_backend(packages_path, distribution, tmpdir):
     builder = build.ProjectBuilder(bad_backend_path)
 
     with pytest.raises(build.BuildBackendException):
-        builder.build(distribution, str(tmpdir))
+        builder.build(distribution, tmpdir)
 
 
 def test_check_dependencies(mocker, package_test_flit):
@@ -356,9 +355,9 @@ def test_build_not_dir_outdir(mocker, tmp_dir, package_test_flit):
 def demo_pkg_inline(tmp_path_factory):
     # builds a wheel without any dependencies and with a console script demo-pkg-inline
     tmp_path = tmp_path_factory.mktemp('demo-pkg-inline')
-    builder = build.ProjectBuilder(srcdir=os.path.join(os.path.dirname(__file__), 'packages', 'inline'))
+    builder = build.ProjectBuilder(os.path.join(os.path.dirname(__file__), 'packages', 'inline'))
     out = tmp_path / 'dist'
-    builder.build('wheel', str(out))
+    builder.build('wheel', out)
     return next(out.iterdir())
 
 

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -154,8 +154,8 @@ def test_init(mocker, package_test_flit, package_legacy, test_no_permission, pac
         package_test_flit,
         'flit_core.buildapi',
         backend_path=None,
+        runner=build.ProjectBuilder._default_rewrapped_runner,
         python_executable=sys.executable,
-        runner=pep517.wrappers.default_subprocess_runner,
     )
     pep517.wrappers.Pep517HookCaller.reset_mock()
 
@@ -165,8 +165,8 @@ def test_init(mocker, package_test_flit, package_legacy, test_no_permission, pac
         package_test_flit,
         'flit_core.buildapi',
         backend_path=None,
+        runner=build.ProjectBuilder._default_rewrapped_runner,
         python_executable='some-python',
-        runner=pep517.wrappers.default_subprocess_runner,
     )
     pep517.wrappers.Pep517HookCaller.reset_mock()
 
@@ -176,8 +176,8 @@ def test_init(mocker, package_test_flit, package_legacy, test_no_permission, pac
         package_legacy,
         'setuptools.build_meta:__legacy__',
         backend_path=None,
+        runner=build.ProjectBuilder._default_rewrapped_runner,
         python_executable=sys.executable,
-        runner=pep517.wrappers.default_subprocess_runner,
     )
 
     # PermissionError

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -597,7 +597,7 @@ def test_log(mocker, caplog, package_test_flit):
         ('INFO', 'something'),
     ]
     if sys.version_info >= (3, 8):  # stacklevel
-        assert caplog.records[-1].lineno == 562
+        assert caplog.records[-1].lineno == test_log.__code__.co_firstlineno + 11
 
 
 @pytest.mark.parametrize(

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -151,7 +151,7 @@ def test_init(mocker, package_test_flit, package_legacy, test_no_permission, pac
     mocker.patch('pep517.wrappers.Pep517HookCaller')
 
     # correct flit pyproject.toml
-    builder = build.ProjectBuilder(package_test_flit)
+    build.ProjectBuilder(package_test_flit)
     pep517.wrappers.Pep517HookCaller.assert_called_with(
         package_test_flit,
         'flit_core.buildapi',
@@ -162,7 +162,7 @@ def test_init(mocker, package_test_flit, package_legacy, test_no_permission, pac
     pep517.wrappers.Pep517HookCaller.reset_mock()
 
     # custom python
-    builder = build.ProjectBuilder(package_test_flit, python_executable='some-python')
+    build.ProjectBuilder(package_test_flit, python_executable='some-python')
     pep517.wrappers.Pep517HookCaller.assert_called_with(
         package_test_flit,
         'flit_core.buildapi',
@@ -173,7 +173,7 @@ def test_init(mocker, package_test_flit, package_legacy, test_no_permission, pac
     pep517.wrappers.Pep517HookCaller.reset_mock()
 
     # FileNotFoundError
-    builder = build.ProjectBuilder(package_legacy)
+    build.ProjectBuilder(package_legacy)
     pep517.wrappers.Pep517HookCaller.assert_called_with(
         package_legacy,
         'setuptools.build_meta:__legacy__',

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+import build
 import build.util
 
 
@@ -9,8 +10,8 @@ import build.util
 def test_wheel_metadata(package_test_setuptools, isolated):
     metadata = build.util.project_wheel_metadata(package_test_setuptools, isolated)
 
-    assert metadata['name'] == 'test-setuptools'
-    assert metadata['version'] == '1.0.0'
+    assert metadata.metadata['name'] == 'test-setuptools'
+    assert metadata.metadata['version'] == '1.0.0'
 
 
 def test_wheel_metadata_isolation(package_test_flit):
@@ -23,8 +24,8 @@ def test_wheel_metadata_isolation(package_test_flit):
 
     metadata = build.util.project_wheel_metadata(package_test_flit)
 
-    assert metadata['name'] == 'test_flit'
-    assert metadata['version'] == '1.0.0'
+    assert metadata.metadata['name'] == 'test_flit'
+    assert metadata.metadata['version'] == '1.0.0'
 
     with pytest.raises(
         build.BuildBackendException,
@@ -36,6 +37,7 @@ def test_wheel_metadata_isolation(package_test_flit):
 def test_with_get_requires(package_test_metadata):
     metadata = build.util.project_wheel_metadata(package_test_metadata)
 
-    assert metadata['name'] == 'test-metadata'
-    assert str(metadata['version']) == '1.0.0'
-    assert metadata['summary'] == 'hello!'
+    assert metadata.metadata['name'] == 'test-metadata'
+    assert metadata.metadata['version'] == '1.0.0'
+    assert metadata.version == '1.0.0'
+    assert metadata.metadata['summary'] == 'hello!'

--- a/tox.ini
+++ b/tox.ini
@@ -65,7 +65,7 @@ commands =
 
 [testenv:docs]
 description = build documentations
-basepython = python3.8
+basepython = python3.9
 extras =
     docs
 commands =


### PR DESCRIPTION
To provide access to all of the distribution folder's contents, e.g. entry points.

On top of #361.