### PR TITLE
tests: use a relative lineno assert in test_log

### DIFF
--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -570,7 +570,9 @@ def test_log(mocker, caplog, package_test_flit):
         ('INFO', 'something'),
     ]
     if sys.version_info >= (3, 8):  # stacklevel
-        assert caplog.records[-1].lineno == 562
+        from inspect import currentframe, getframeinfo
+
+        assert caplog.records[-1].lineno == getframeinfo(currentframe()).lineno - 13
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This should prevent spurious test failures when changing unrelated tests.