### PR TITLE
env: prevent warning from being emitted on venv creation

### DIFF
--- a/src/build/env.py
+++ b/src/build/env.py
@@ -92,7 +92,9 @@ class IsolatedEnvBuilder:
 
         :return: The isolated build environment
         """
-        self._path = tempfile.mkdtemp(prefix='build-env-')
+        # ``realpath`` is used to prevent warning from being emitted that
+        # the venv location has moved on Windows.
+        self._path = os.path.realpath(tempfile.mkdtemp(prefix='build-env-'))
         try:
             # use virtualenv when available (as it's faster than venv)
             if _should_use_virtualenv():

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -92,8 +92,11 @@ class IsolatedEnvBuilder:
 
         :return: The isolated build environment
         """
-        # ``realpath`` is used to prevent warning from being emitted that
-        # the venv location has moved on Windows.
+        # Call ``realpath`` to prevent spurious warning from being emitted
+        # that the venv location has changed on Windows. The username is
+        # DOS-encoded in the output of tempfile - the location is the same
+        # but the representation of it is different, which confuses venv.
+        # Ref: https://bugs.python.org/issue46171
         self._path = os.path.realpath(tempfile.mkdtemp(prefix='build-env-'))
         try:
             # use virtualenv when available (as it's faster than venv)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -112,7 +112,7 @@ def test_isolated_env_log(mocker, caplog, package_test_flit):
         ('INFO', 'Installing packages in isolated environment... (something)'),
     ]
     if sys.version_info >= (3, 8):  # stacklevel
-        assert [(record.lineno) for record in caplog.records] == [105, 104, 195]
+        assert [(record.lineno) for record in caplog.records] == [105, 107, 198]
 
 
 @pytest.mark.isolated

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -112,7 +112,7 @@ def test_isolated_env_log(mocker, caplog, package_test_flit):
         ('INFO', 'Installing packages in isolated environment... (something)'),
     ]
     if sys.version_info >= (3, 8):  # stacklevel
-        assert [(record.lineno) for record in caplog.records] == [105, 102, 193]
+        assert [(record.lineno) for record in caplog.records] == [105, 104, 195]
 
 
 @pytest.mark.isolated


### PR DESCRIPTION
After https://github.com/python/cpython/commit/6811fdaec825bd6ab64e358a4b480108f5634d2d
the venv module produces spurious warnings for venv paths which contain
DOS-encoded parts e.g. "USER\~1" in "C:\Users\USER~1".
`tempfile.gettempdir()` returns legacy paths like these for
user temp dirs.

MRE:

    python -c "import tempfile
    import venv

    venv.create(tempfile.mkdtemp())"

    Actual environment location may have moved due to redirects, links or junctions.
    Requested location: "C:\Users\RUNNER~1\AppData\Local\Temp\tmpfoobar\Scripts\python.exe"
    Actual location:    "C:\Users\runneradmin\AppData\Local\Temp\tmpfoobar\Scripts\python.exe"

Closes #413.