### PR TITLE
ci: fix broken tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ markers = [
 ]
 filterwarnings = [
   "error",
+  "ignore:path is deprecated.:DeprecationWarning",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ junit_family = "xunit2"
 norecursedirs = "tests/integration/*"
 markers = [
   "isolated",
+  "pypy3323bug",
 ]
 filterwarnings = [
   "error",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,8 @@ def pytest_collection_modifyitems(config, items):
         return
     for item in items:
         is_integration_file = is_integration(item)
+        if PYPY3_WIN_VENV_BAD and item.get_closest_marker('pypy3323bug') and os.environ.get('PYPY3323BUG', None):
+            item.add_marker(pytest.mark.xfail(reason=PYPY3_WIN_M, strict=False))
         if PYPY3_WIN_VENV_BAD and item.get_closest_marker('isolated'):
             if not (is_integration_file and item.originalname == 'test_build') or (
                 hasattr(item, 'callspec') and '--no-isolation' not in item.callspec.params.get('args', [])

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -97,6 +97,7 @@ def test_isolated_env_has_install_still_abstract():
         Env()
 
 
+@pytest.mark.pypy3323bug
 def test_isolated_env_log(mocker, caplog, package_test_flit):
     mocker.patch('build.env._subprocess')
     caplog.set_level(logging.DEBUG)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -103,8 +103,8 @@ def test_isolated_env_log(mocker, caplog, package_test_flit):
     caplog.set_level(logging.DEBUG)
 
     builder = build.env.IsolatedEnvBuilder()
-    builder.log('something')
-    with builder as env:
+    builder.log('something')  # line number 106
+    with builder as env:  # line number 107
         env.install(['something'])
 
     assert [(record.levelname, record.message) for record in caplog.records] == [
@@ -113,7 +113,7 @@ def test_isolated_env_log(mocker, caplog, package_test_flit):
         ('INFO', 'Installing packages in isolated environment... (something)'),
     ]
     if sys.version_info >= (3, 8):  # stacklevel
-        assert [(record.lineno) for record in caplog.records] == [105, 107, 198]
+        assert [(record.lineno) for record in caplog.records] == [106, 107, 198]
 
 
 @pytest.mark.isolated

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -184,6 +184,7 @@ def test_build_raises_build_backend_exception(mocker, package_test_flit):
         build.__main__.build_package(package_test_flit, '.', ['sdist'])
 
 
+@pytest.mark.pypy3323bug
 def test_build_package(tmp_dir, package_test_setuptools):
     build.__main__.build_package(package_test_setuptools, tmp_dir, ['sdist', 'wheel'])
 
@@ -193,6 +194,7 @@ def test_build_package(tmp_dir, package_test_setuptools):
     ]
 
 
+@pytest.mark.pypy3323bug
 def test_build_package_via_sdist(tmp_dir, package_test_setuptools):
     build.__main__.build_package_via_sdist(package_test_setuptools, tmp_dir, ['wheel'])
 
@@ -202,6 +204,7 @@ def test_build_package_via_sdist(tmp_dir, package_test_setuptools):
     ]
 
 
+@pytest.mark.pypy3323bug
 def test_build_package_via_sdist_cant_build(tmp_dir, package_test_cant_build_via_sdist):
     with pytest.raises(build.BuildBackendException):
         build.__main__.build_package_via_sdist(package_test_cant_build_via_sdist, tmp_dir, ['wheel'])
@@ -212,6 +215,7 @@ def test_build_package_via_sdist_invalid_distribution(tmp_dir, package_test_setu
         build.__main__.build_package_via_sdist(package_test_setuptools, tmp_dir, ['sdist'])
 
 
+@pytest.mark.pypy3323bug
 @pytest.mark.parametrize(
     ('args', 'output'),
     [
@@ -300,6 +304,7 @@ def main_reload_styles():
         importlib.reload(build.__main__)
 
 
+@pytest.mark.pypy3323bug
 @pytest.mark.parametrize(
     ('color', 'stdout_error', 'stdout_body'),
     [

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -5,6 +5,7 @@ import pytest
 import build.util
 
 
+@pytest.mark.pypy3323bug
 @pytest.mark.parametrize('isolated', [False, True])
 def test_wheel_metadata(package_test_setuptools, isolated):
     metadata = build.util.project_wheel_metadata(package_test_setuptools, isolated)
@@ -13,6 +14,7 @@ def test_wheel_metadata(package_test_setuptools, isolated):
     assert metadata['version'] == '1.0.0'
 
 
+@pytest.mark.pypy3323bug
 def test_wheel_metadata_isolation(package_test_flit):
     try:
         import flit_core  # noqa: F401
@@ -33,6 +35,7 @@ def test_wheel_metadata_isolation(package_test_flit):
         build.util.project_wheel_metadata(package_test_flit, isolated=False)
 
 
+@pytest.mark.pypy3323bug
 def test_with_get_requires(package_test_metadata):
     metadata = build.util.project_wheel_metadata(package_test_metadata)
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ setenv =
 extras =
     test
 commands =
-    pytest -rsx --cov --cov-config pyproject.toml \
+    pytest -ra --cov --cov-config pyproject.toml \
       --cov-report=html:{envdir}/htmlcov --cov-context=test \
       --cov-report=xml:{toxworkdir}/coverage.{envname}.xml \
       tests {posargs:-n auto}
@@ -58,7 +58,7 @@ description = check minimum versions required of all dependencies
 skip_install = true
 commands =
     pip install .[test] -c tests/constraints.txt
-    pytest -rsx tests {posargs:-n auto}
+    pytest -ra tests {posargs:-n auto}
 
 [testenv:docs]
 description = build documentations

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ passenv =
 setenv =
     COVERAGE_FILE = {toxworkdir}/.coverage.{envname}
     TEST_STATUS_DIR = {envtmpdir}
+    PYPY3323BUG = 1
     path: TEST_MODE = path
     sdist: TEST_MODE = sdist
     wheel: TEST_MODE = wheel


### PR DESCRIPTION
WIP at the moment. These are the 11 Windows PyPy failures:

```
FAILED tests/test_env.py::test_isolated_env_log - subprocess.CalledProcessErr...
FAILED tests/test_main.py::test_build_package - subprocess.CalledProcessError...
FAILED tests/test_main.py::test_build_package_via_sdist - subprocess.CalledPr...
FAILED tests/test_main.py::test_build_package_via_sdist_cant_build - subproce...
FAILED tests/test_main.py::test_output[via-sdist-isolation] - SystemExit: 1
FAILED tests/test_main.py::test_output[wheel-direct-isolation] - SystemExit: 1
FAILED tests/test_util.py::test_wheel_metadata[True] - subprocess.CalledProce...
FAILED tests/test_util.py::test_wheel_metadata_isolation - subprocess.CalledP...
FAILED tests/test_util.py::test_with_get_requires - subprocess.CalledProcessE...
FAILED tests/test_main.py::test_output_env_subprocess_error[no-color] - asser...
FAILED tests/test_main.py::test_output_env_subprocess_error[color] - assert [...
```