### PR TITLE
Fixup mock in test_executable_missing_post_creation to work with "ven…

### DIFF
--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -62,9 +62,9 @@ def test_can_get_venv_paths_with_conflicting_default_scheme(mocker):
 def test_executable_missing_post_creation(mocker):
     original_get_paths = sysconfig.get_paths
 
-    def _get_paths(vars):  # noqa
-        shutil.rmtree(vars['base'])
-        return original_get_paths(vars=vars)
+    def _get_paths(*args, **kwargs):  # noqa
+        shutil.rmtree(kwargs['vars']['base'])
+        return original_get_paths(*args, **kwargs)
 
     get_paths = mocker.patch('sysconfig.get_paths', side_effect=_get_paths)
     with pytest.raises(RuntimeError, match='Virtual environment creation failed, executable .* missing'):


### PR DESCRIPTION
…v" scheme

After https://github.com/pypa/build/pull/434 the test would error:

    ____________________ test_executable_missing_post_creation _____________________

    mocker = <pytest_mock.plugin.MockerFixture object at 0x7f9a75401a80>

        @pytest.mark.skipif(IS_PYPY3, reason='PyPy3 uses get path to create and provision venv')
        def test_executable_missing_post_creation(mocker):
            mocker.patch.object(build.env, '_should_use_virtualenv', lambda: False)
            original_get_paths = sysconfig.get_paths

            def _get_paths(vars):  # noqa
                shutil.rmtree(vars['base'])
                return original_get_paths(vars=vars)

            get_paths = mocker.patch('sysconfig.get_paths', side_effect=_get_paths)
            with pytest.raises(RuntimeError, match='Virtual environment creation failed, executable .* missing'):
    >           with build.env.IsolatedEnvBuilder():

    tests/test_env.py:73:
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
    .../site-packages/build/env.py:104: in __enter__
        executable, scripts_dir = _create_isolated_env_venv(self._path)
    .../site-packages/build/env.py:258: in _create_isolated_env_venv
        executable, script_dir, purelib = _find_executable_and_scripts(path)
    .../site-packages/build/env.py:298: in _find_executable_and_scripts
        paths = sysconfig.get_paths(scheme='venv', vars=config_vars)
    /usr/lib64/python3.10/unittest/mock.py:1104: in __call__
        return self._mock_call(*args, **kwargs)
    /usr/lib64/python3.10/unittest/mock.py:1108: in _mock_call
        return self._execute_mock_call(*args, **kwargs)
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    self = <MagicMock name='get_paths' id='140301368829136'>, args = ()
    kwargs = {'scheme': 'venv', 'vars': {'ABIFLAGS': '', 'AC_APPLE_UNIVERSAL_BUILD': 0, 'AIX_BUILDDATE': 0, 'AIX_GENUINE_CPLUSPLUS': 0, ...}}
    effect = <function test_executable_missing_post_creation.<locals>._get_paths at 0x7f9a754ac5e0>

        def _execute_mock_call(self, /, *args, **kwargs):
            # separate from _increment_mock_call so that awaited functions are
            # executed separately from their call, also AsyncMock overrides this method

            effect = self.side_effect
            if effect is not None:
                if _is_exception(effect):
                    raise effect
                elif not _callable(effect):
                    result = next(effect)
                    if _is_exception(result):
                        raise result
                else:
    >               result = effect(*args, **kwargs)
    E               TypeError: test_executable_missing_post_creation.<locals>._get_paths() got an unexpected keyword argument 'scheme'

    /usr/lib64/python3.10/unittest/mock.py:1169: TypeError

That only happens when not installed in a virtual environment,
so it was not discovered on CI or via tox.