### PR TITLE
Fix test_executable_missing_post_creation for Python 3.11, PyPy

### DIFF
--- a/src/build/env.py
+++ b/src/build/env.py
@@ -289,10 +289,6 @@ def _create_isolated_env_venv(path: str) -> Tuple[str, str]:
     return executable, script_dir
 
 
-# Alias is used for mocking in tests
-_sysconfig_get_paths = sysconfig.get_paths
-
-
 def _find_executable_and_scripts(path: str) -> Tuple[str, str, str]:
     """
     Detect the Python executable and script folder of a virtual environment.
@@ -310,16 +306,16 @@ def _find_executable_and_scripts(path: str) -> Tuple[str, str, str]:
         # The distributors are encouraged to set a "venv" scheme to be used for this.
         # See https://bugs.python.org/issue45413
         # and https://github.com/pypa/virtualenv/issues/2208
-        paths = _sysconfig_get_paths(scheme='venv', vars=config_vars)
+        paths = sysconfig.get_paths(scheme='venv', vars=config_vars)
     elif 'osx_framework_library' in scheme_names:
         # The Python that ships with the macOS developer tools varies the
         # default scheme depending on whether the ``sys.prefix`` is part of a framework.
         # But it does not (yet) set the "venv" scheme.
         # If the Apple-custom "osx_framework_library" scheme is available but "venv"
         # is not, we use "posix_prefix" instead which is venv-compatible there.
-        paths = _sysconfig_get_paths(scheme='posix_prefix', vars=config_vars)
+        paths = sysconfig.get_paths(scheme='posix_prefix', vars=config_vars)
     else:
-        paths = _sysconfig_get_paths(vars=config_vars)
+        paths = sysconfig.get_paths(vars=config_vars)
     executable = os.path.join(paths['scripts'], 'python.exe' if sys.platform.startswith('win') else 'python')
     if not os.path.exists(executable):
         raise RuntimeError(f'Virtual environment creation failed, executable {executable} missing')

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -289,6 +289,9 @@ def _create_isolated_env_venv(path: str) -> Tuple[str, str]:
     return executable, script_dir
 
 
+_sysconfig_get_paths = sysconfig.get_paths
+
+
 def _find_executable_and_scripts(path: str) -> Tuple[str, str, str]:
     """
     Detect the Python executable and script folder of a virtual environment.
@@ -306,16 +309,16 @@ def _find_executable_and_scripts(path: str) -> Tuple[str, str, str]:
         # The distributors are encouraged to set a "venv" scheme to be used for this.
         # See https://bugs.python.org/issue45413
         # and https://github.com/pypa/virtualenv/issues/2208
-        paths = sysconfig.get_paths(scheme='venv', vars=config_vars)
+        paths = _sysconfig_get_paths(scheme='venv', vars=config_vars)
     elif 'osx_framework_library' in scheme_names:
         # The Python that ships with the macOS developer tools varies the
         # default scheme depending on whether the ``sys.prefix`` is part of a framework.
         # But it does not (yet) set the "venv" scheme.
         # If the Apple-custom "osx_framework_library" scheme is available but "venv"
         # is not, we use "posix_prefix" instead which is venv-compatible there.
-        paths = sysconfig.get_paths(scheme='posix_prefix', vars=config_vars)
+        paths = _sysconfig_get_paths(scheme='posix_prefix', vars=config_vars)
     else:
-        paths = sysconfig.get_paths(vars=config_vars)
+        paths = _sysconfig_get_paths(vars=config_vars)
     executable = os.path.join(paths['scripts'], 'python.exe' if sys.platform.startswith('win') else 'python')
     if not os.path.exists(executable):
         raise RuntimeError(f'Virtual environment creation failed, executable {executable} missing')

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -289,6 +289,7 @@ def _create_isolated_env_venv(path: str) -> Tuple[str, str]:
     return executable, script_dir
 
 
+# Alias is used for mocking in tests
 _sysconfig_get_paths = sysconfig.get_paths
 
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -3,10 +3,8 @@ import collections
 import inspect
 import logging
 import platform
-import shutil
 import subprocess
 import sys
-import sysconfig
 
 import pytest
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -58,7 +58,6 @@ def test_can_get_venv_paths_with_conflicting_default_scheme(mocker):
     assert get_scheme_names.call_count == 1
 
 
-@pytest.mark.skipif(IS_PYPY3, reason='PyPy3 uses get path to create and provision venv')
 def test_executable_missing_post_creation(mocker):
     def _get_paths(*args, **kwargs):  # noqa
         bound = inspect.signature(sysconfig.get_paths).bind(*args, **kwargs)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -59,16 +59,11 @@ def test_can_get_venv_paths_with_conflicting_default_scheme(mocker):
 
 
 def test_executable_missing_post_creation(mocker):
-    def _get_paths(*args, **kwargs):  # noqa
-        bound = inspect.signature(sysconfig.get_paths).bind(*args, **kwargs)
-        shutil.rmtree(bound.arguments['vars']['base'], ignore_errors=True)
-        return sysconfig.get_paths(*args, **kwargs)
-
-    get_paths = mocker.patch('build.env._sysconfig_get_paths', side_effect=_get_paths)
+    venv_create = mocker.patch('venv.EnvBuilder.create')
     with pytest.raises(RuntimeError, match='Virtual environment creation failed, executable .* missing'):
         with build.env.IsolatedEnvBuilder():
             pass
-    assert get_paths.call_count == 1
+    assert venv_create.call_count == 1
 
 
 def test_isolated_env_abstract():


### PR DESCRIPTION
As a result of https://github.com/python/cpython/pull/31034,
venv now calls sysconfig.get_paths. This messes up the mock call
count.

The change to using Signature.bind isn't strictly necessary, but fixes
the initial symptom (since venv calls sysconfig.get_paths without
kwargs). This also means we can use sysconfig.get_paths however we want.