### PR TITLE
env: include .path in the IsolatedEnv ABC

### DIFF
--- a/src/build/env.py
+++ b/src/build/env.py
@@ -43,6 +43,12 @@ class IsolatedEnv(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
+    def path(self) -> str:
+        """The base path of the isolated build environment."""
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
     def scripts_dir(self) -> str:
         """The scripts directory of the isolated build environment."""
         raise NotImplementedError

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -117,7 +117,7 @@ def test_isolated_env_log(mocker, caplog, package_test_flit):
         ('INFO', 'Installing packages in isolated environment... (something)'),
     ]
     if sys.version_info >= (3, 8):  # stacklevel
-        assert [(record.lineno) for record in caplog.records] == [frameinfo.lineno + 1, 107, 198]
+        assert [(record.lineno) for record in caplog.records] == [frameinfo.lineno + 1, 113, 204]
 
 
 @pytest.mark.isolated


### PR DESCRIPTION
This is needed by pyodide, and is already available on the return `_IsolatedEnvVenvPip`, but not public for typing. Technically pyodide wants the site-packages dir, but it can be computed from the path.

https://github.com/pyodide/pyodide/blob/7a9273dd6c893ab1273f8c5d22f62f60296f13d5/pyodide-build/pyodide_build/pypabuild.py#L27-L28 (Plain `.path` is available there, but not typed into `IsolatedEnv`).

Open to other options if this is not a good way to go.
