### PR TITLE
chore: more small changes from #361

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,8 +1,6 @@
 API Documentation
 =================
 
-This project exposes 2 modules:
-
 ``build`` module
 ----------------
 

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -509,6 +509,7 @@ class ProjectBuilder:
 
 __all__ = [
     '__version__',
+    'BuildSystemTableValidationError',
     'BuildBackendException',
     'BuildException',
     'ConfigSettingsType',

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -279,7 +279,7 @@ class ProjectBuilder:
         The default runner simply calls the backend hooks in a subprocess, writing backend output
         to stdout/stderr.
         """
-        self.srcdir: str = os.path.abspath(srcdir)
+        self._srcdir: str = os.path.abspath(srcdir)
         _validate_source_directory(srcdir)
 
         spec_file = os.path.join(srcdir, 'pyproject.toml')
@@ -318,6 +318,11 @@ class ProjectBuilder:
             extra_environ = {} if extra_environ is None else dict(extra_environ)
             extra_environ['PATH'] = os.pathsep.join(paths)
         self._hook_runner(cmd, cwd, extra_environ)
+
+    @property
+    def srcdir(self) -> str:
+        """Project source directory."""
+        return self._srcdir
 
     @property
     def python_executable(self) -> str:

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -21,9 +21,6 @@ from build import BuildBackendException, BuildException, ConfigSettingsType, Fai
 from build.env import IsolatedEnvBuilder
 
 
-__all__ = ['build', 'main', 'main_parser']
-
-
 _COLORS = {
     'red': '\33[91m',
     'green': '\33[92m',
@@ -386,3 +383,10 @@ def entrypoint() -> None:
 
 if __name__ == '__main__':  # pragma: no cover
     main(sys.argv[1:], 'python -m build')
+
+
+__all__ = [
+    'build',
+    'main',
+    'main_parser',
+]

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -386,7 +386,6 @@ if __name__ == '__main__':  # pragma: no cover
 
 
 __all__ = [
-    'build',
     'main',
     'main_parser',
 ]

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -29,7 +29,7 @@ except ModuleNotFoundError:
     virtualenv = None
 
 
-_logger = logging.getLogger('build.env')
+_logger = logging.getLogger(__name__)
 
 
 class IsolatedEnv(metaclass=abc.ABCMeta):

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -330,7 +330,7 @@ def _find_executable_and_scripts(path: str) -> Tuple[str, str, str]:
     return executable, paths['scripts'], paths['purelib']
 
 
-__all__ = (
+__all__ = [
     'IsolatedEnvBuilder',
     'IsolatedEnv',
-)
+]

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -55,4 +55,6 @@ def project_wheel_metadata(
         return _project_wheel_metadata(builder)
 
 
-__all__ = ('project_wheel_metadata',)
+__all__ = [
+    'project_wheel_metadata',
+]


### PR DESCRIPTION
Pulling a few more changes out of #361 to make rebasing / merging easier.


- build: add `BuildSystemTableValidationError` to module exports
- multi: use same `__all__` style and placement in all modules
- main: remove redundant re-export
- multi: use module names for loggers
- docs: remove API doc blurb
- build: make srcdir read-only
- ~~docs: normalize formatting~~
