### PR TITLE
types: include color in tox output

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ passenv =
     LC_ALL
     PIP_*
     PYTEST_*
+    TERM
 setenv =
     COVERAGE_FILE = {toxworkdir}/.coverage.{envname}
     TEST_STATUS_DIR = {envtmpdir}


### PR DESCRIPTION
The output from MyPy is currently missing color.
