### PR TITLE
build: clarify that dependencies are build dependencies

### DIFF
--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -373,7 +373,7 @@ class ProjectBuilder:
             (``sdist`` or ``wheel``)
         :param config_settings: Config settings for the build backend
         """
-        self.log(f'Getting dependencies for {distribution}...')
+        self.log(f'Getting build dependencies for {distribution}...')
         hook_name = f'get_requires_for_build_{distribution}'
         get_requires = getattr(self._hook, hook_name)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -226,12 +226,12 @@ def test_build_package_via_sdist_invalid_distribution(tmp_dir, package_test_setu
             [
                 '* Creating venv isolated environment...',
                 '* Installing packages in isolated environment... (setuptools >= 42.0.0, wheel >= 0.36.0)',
-                '* Getting dependencies for sdist...',
+                '* Getting build dependencies for sdist...',
                 '* Building sdist...',
                 '* Building wheel from sdist',
                 '* Creating venv isolated environment...',
                 '* Installing packages in isolated environment... (setuptools >= 42.0.0, wheel >= 0.36.0)',
-                '* Getting dependencies for wheel...',
+                '* Getting build dependencies for wheel...',
                 '* Installing packages in isolated environment... (wheel)',
                 '* Building wheel...',
                 'Successfully built test_setuptools-1.0.0.tar.gz and test_setuptools-1.0.0-py2.py3-none-any.whl',
@@ -240,10 +240,10 @@ def test_build_package_via_sdist_invalid_distribution(tmp_dir, package_test_setu
         (
             ['--no-isolation'],
             [
-                '* Getting dependencies for sdist...',
+                '* Getting build dependencies for sdist...',
                 '* Building sdist...',
                 '* Building wheel from sdist',
-                '* Getting dependencies for wheel...',
+                '* Getting build dependencies for wheel...',
                 '* Building wheel...',
                 'Successfully built test_setuptools-1.0.0.tar.gz and test_setuptools-1.0.0-py2.py3-none-any.whl',
             ],
@@ -253,7 +253,7 @@ def test_build_package_via_sdist_invalid_distribution(tmp_dir, package_test_setu
             [
                 '* Creating venv isolated environment...',
                 '* Installing packages in isolated environment... (setuptools >= 42.0.0, wheel >= 0.36.0)',
-                '* Getting dependencies for wheel...',
+                '* Getting build dependencies for wheel...',
                 '* Installing packages in isolated environment... (wheel)',
                 '* Building wheel...',
                 'Successfully built test_setuptools-1.0.0-py2.py3-none-any.whl',
@@ -262,21 +262,25 @@ def test_build_package_via_sdist_invalid_distribution(tmp_dir, package_test_setu
         (
             ['--wheel', '--no-isolation'],
             [
-                '* Getting dependencies for wheel...',
+                '* Getting build dependencies for wheel...',
                 '* Building wheel...',
                 'Successfully built test_setuptools-1.0.0-py2.py3-none-any.whl',
             ],
         ),
         (
             ['--sdist', '--no-isolation'],
-            ['* Getting dependencies for sdist...', '* Building sdist...', 'Successfully built test_setuptools-1.0.0.tar.gz'],
+            [
+                '* Getting build dependencies for sdist...',
+                '* Building sdist...',
+                'Successfully built test_setuptools-1.0.0.tar.gz',
+            ],
         ),
         (
             ['--sdist', '--wheel', '--no-isolation'],
             [
-                '* Getting dependencies for sdist...',
+                '* Getting build dependencies for sdist...',
                 '* Building sdist...',
-                '* Getting dependencies for wheel...',
+                '* Getting build dependencies for wheel...',
                 '* Building wheel...',
                 'Successfully built test_setuptools-1.0.0.tar.gz and test_setuptools-1.0.0-py2.py3-none-any.whl',
             ],

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -601,8 +601,8 @@ def test_log(mocker, caplog, package_test_flit):
     builder.log('something')
 
     assert [(record.levelname, record.message) for record in caplog.records] == [
-        ('INFO', 'Getting dependencies for sdist...'),
-        ('INFO', 'Getting dependencies for wheel...'),
+        ('INFO', 'Getting build dependencies for sdist...'),
+        ('INFO', 'Getting build dependencies for wheel...'),
         ('INFO', 'Getting metadata for wheel...'),
         ('INFO', 'Building sdist...'),
         ('INFO', 'Building wheel...'),


### PR DESCRIPTION
I would also change parameter `distribution` to `dist_type`, because it is not the actual package that is being meant here. Tell me if it is ok to do, and I'll add commits here.