### PR TITLE
git: unignore src/build in case user ignores build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ tests/integration/
 .integration-sources
 .tox
 Dockerfile
+
+# Restore src/build in case user ignores 'build'
+!src/build


### PR DESCRIPTION
After checking out this project, I found that files in src/build weren't being tracked and that src appeared empty in my editor. Turns out, I used a common pattern of ignoring `build` in my global gitignore (which I manage centrally rather than copying and mutating boilerplate across hundreds of projects).

This change ensures that if the user has ignored `build`, the `src/build` folder won't be ignored in this project.
