### PR TITLE
tests: better isolate test_venv_fail

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -415,6 +415,8 @@ def test_venv_fail(monkeypatch, package_test_flit, tmp_dir, capsys):
     monkeypatch.setattr(venv.EnvBuilder, 'create', raise_called_process_err)
     monkeypatch.setenv('NO_COLOR', '')
 
+    importlib.reload(build.__main__)  # reload module to set _STYLES
+
     with pytest.raises(SystemExit):
         build.__main__.main([package_test_flit, '-o', tmp_dir])
 


### PR DESCRIPTION
In [nixpkgs](https://github.com/NixOS/nixpkgs), we run the tests in parallel using `pytest-xdist`, and I can consistently see a failure on my M1 Mac machine in `test_main.py#test_venv_fail` related to the actual stdout containing color escape sequences when none were expected.

If I reload `build.__main__` as is done in other tests, the failure goes away for me.