### PR TITLE
build: protect _working_directory with lock to make build thread-safe

### DIFF
--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -14,6 +14,7 @@ import re
 import subprocess
 import sys
 import textwrap
+import threading
 import types
 import warnings
 import zipfile
@@ -71,6 +72,9 @@ _DEFAULT_BACKEND = {
     'build-backend': 'setuptools.build_meta:__legacy__',
     'requires': ['setuptools >= 40.8.0', 'wheel'],
 }
+
+
+LOCK = threading.Lock()
 
 
 _logger = logging.getLogger(__name__)
@@ -139,14 +143,15 @@ class TypoWarning(Warning):
 
 @contextlib.contextmanager
 def _working_directory(path: str) -> Iterator[None]:
-    current = os.getcwd()
+    with LOCK:
+        current = os.getcwd()
 
-    os.chdir(path)
+        os.chdir(path)
 
-    try:
-        yield
-    finally:
-        os.chdir(current)
+        try:
+            yield
+        finally:
+            os.chdir(current)
 
 
 def _validate_source_directory(srcdir: PathType) -> None:


### PR DESCRIPTION
In python-poetry/poetry#6205, we noticed that running multiple builds in parallel is not thread-safe because build changes the working directory at some places. Of course, downstream users can protect calls to `build` with locks by themselves but it might be nice to not have to worry about it.