### PR TITLE
build: remove redundant change of working directory

### DIFF
--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -221,6 +221,13 @@ def test_init(mocker, package_test_flit, package_legacy, test_no_permission, pac
         build.ProjectBuilder(package_test_bad_syntax)
 
 
+def test_init_makes_srcdir_absolute(package_test_flit):
+    rel_dir = os.path.relpath(package_test_flit, os.getcwd())
+    assert not os.path.isabs(rel_dir)
+    builder = build.ProjectBuilder(rel_dir)
+    assert os.path.isabs(builder.srcdir)
+
+
 @pytest.mark.parametrize('value', [b'something', 'something_else'])
 def test_python_executable(package_test_flit, value):
     builder = build.ProjectBuilder(package_test_flit)


### PR DESCRIPTION
As per https://github.com/pypa/build/pull/535#issuecomment-1321163124 changing the working directory seems to be redundant. So let's remove it. (This also makes build thread-safe.)

Closes #535