### PR TITLE
Refactor `IsolatedEnv`, take two

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,21 @@ Changelog
 +++++++++
 
 
+Unreleased
+==========
+
+- Modified ``ProjectBuilder`` constructor signature,
+  added alternative ``ProjectBuilder.from_env`` constructor,
+  redefined ``env.IsolatedEnv`` interface, and exposed ``env.DefaultIsolatedEnv``,
+  replacing ``env.IsolatedEnvBuilder``.  The aim has been to shift
+  responsibility for modifying the environment from the project builder
+  to the ``IsolatedEnv`` entirely and to ensure that the builder will be initialised
+  from an ``IsolatedEnv`` in a consistent manner.  Mutating the project builder is no longer supported.
+  (`PR #537`_)
+
+.. _PR #537: https://github.com/pypa/build/pull/537
+
+
 0.10.0 (2023-01-11)
 ===================
 

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -13,7 +13,6 @@ import contextlib
 import difflib
 import logging
 import os
-import re
 import subprocess
 import sys
 import warnings
@@ -32,7 +31,7 @@ from ._exceptions import (
     FailedProcessError,
     TypoWarning,
 )
-from ._util import check_dependency
+from ._util import check_dependency, parse_wheel_filename
 
 
 TOMLDecodeError: type[Exception]
@@ -53,13 +52,6 @@ else:
 RunnerType = Callable[[Sequence[str], Optional[str], Optional[Mapping[str, str]]], None]
 ConfigSettingsType = Mapping[str, Union[str, Sequence[str]]]
 PathType = Union[str, 'os.PathLike[str]']
-
-
-_WHEEL_NAME_REGEX = re.compile(
-    r'(?P<distribution>.+)-(?P<version>.+)'
-    r'(-(?P<build_tag>.+))?-(?P<python_tag>.+)'
-    r'-(?P<abi_tag>.+)-(?P<platform_tag>.+)\.whl'
-)
 
 
 _DEFAULT_BACKEND = {
@@ -325,7 +317,7 @@ class ProjectBuilder:
 
         # fallback to build_wheel hook
         wheel = self.build('wheel', output_directory)
-        match = _WHEEL_NAME_REGEX.match(os.path.basename(wheel))
+        match = parse_wheel_filename(os.path.basename(wheel))
         if not match:
             raise ValueError('Invalid wheel')
         distinfo = f"{match['distribution']}-{match['version']}.dist-info"

--- a/src/build/_exceptions.py
+++ b/src/build/_exceptions.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import subprocess
+import textwrap
+import types
+
+
+class BuildException(Exception):
+    """
+    Exception raised by :class:`build.ProjectBuilder`.
+    """
+
+
+class BuildBackendException(Exception):
+    """
+    Exception raised when a backend operation fails.
+    """
+
+    def __init__(
+        self,
+        exception: Exception,
+        description: str | None = None,
+        exc_info: tuple[type[BaseException], BaseException, types.TracebackType]
+        | tuple[None, None, None] = (None, None, None),
+    ) -> None:
+        super().__init__()
+        self.exception = exception
+        self.exc_info = exc_info
+        self._description = description
+
+    def __str__(self) -> str:
+        if self._description:
+            return self._description
+        return f'Backend operation failed: {self.exception!r}'
+
+
+class BuildSystemTableValidationError(BuildException):
+    """
+    Exception raised when the ``[build-system]`` table in pyproject.toml is invalid.
+    """
+
+    def __str__(self) -> str:
+        return f'Failed to validate `build-system` in pyproject.toml: {self.args[0]}'
+
+
+class FailedProcessError(Exception):
+    """
+    Exception raised when a setup or preparation operation fails.
+    """
+
+    def __init__(self, exception: subprocess.CalledProcessError, description: str) -> None:
+        super().__init__()
+        self.exception = exception
+        self._description = description
+
+    def __str__(self) -> str:
+        cmd = ' '.join(self.exception.cmd)
+        description = f"{self._description}\n  Command '{cmd}' failed with return code {self.exception.returncode}"
+        for stream_name in ('stdout', 'stderr'):
+            stream = getattr(self.exception, stream_name)
+            if stream:
+                description += f'\n  {stream_name}:\n'
+                description += textwrap.indent(stream.decode(), '    ')
+        return description
+
+
+class TypoWarning(Warning):
+    """
+    Warning raised when a possible typo is found.
+    """

--- a/src/build/_util.py
+++ b/src/build/_util.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
+import re
 import sys
 
 from collections.abc import Iterator, Set
+
+
+_WHEEL_FILENAME_REGEX = re.compile(
+    r'(?P<distribution>.+)-(?P<version>.+)'
+    r'(-(?P<build_tag>.+))?-(?P<python_tag>.+)'
+    r'-(?P<abi_tag>.+)-(?P<platform_tag>.+)\.whl'
+)
 
 
 def check_dependency(
@@ -53,3 +61,7 @@ def check_dependency(
             for other_req_string in dist.requires:
                 # yields transitive dependencies that are not satisfied.
                 yield from check_dependency(other_req_string, ancestral_req_strings + (normalised_req_string,), req.extras)
+
+
+def parse_wheel_filename(filename: str) -> re.Match[str] | None:
+    return _WHEEL_FILENAME_REGEX.match(filename)

--- a/src/build/_util.py
+++ b/src/build/_util.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import sys
+
+from collections.abc import Iterator, Set
+
+
+def check_dependency(
+    req_string: str, ancestral_req_strings: tuple[str, ...] = (), parent_extras: Set[str] = frozenset()
+) -> Iterator[tuple[str, ...]]:
+    """
+    Verify that a dependency and all of its dependencies are met.
+
+    :param req_string: Requirement string
+    :param parent_extras: Extras (eg. "test" in myproject[test])
+    :yields: Unmet dependencies
+    """
+    import packaging.requirements
+
+    if sys.version_info >= (3, 8):
+        import importlib.metadata as importlib_metadata
+    else:
+        import importlib_metadata
+
+    req = packaging.requirements.Requirement(req_string)
+    normalised_req_string = str(req)
+
+    # ``Requirement`` doesn't implement ``__eq__`` so we cannot compare reqs for
+    # equality directly but the string representation is stable.
+    if normalised_req_string in ancestral_req_strings:
+        # cyclical dependency, already checked.
+        return
+
+    if req.marker:
+        extras = frozenset(('',)).union(parent_extras)
+        # a requirement can have multiple extras but ``evaluate`` can
+        # only check one at a time.
+        if all(not req.marker.evaluate(environment={'extra': e}) for e in extras):
+            # if the marker conditions are not met, we pretend that the
+            # dependency is satisfied.
+            return
+
+    try:
+        dist = importlib_metadata.distribution(req.name)  # type: ignore[no-untyped-call]
+    except importlib_metadata.PackageNotFoundError:
+        # dependency is not installed in the environment.
+        yield ancestral_req_strings + (normalised_req_string,)
+    else:
+        if req.specifier and not req.specifier.contains(dist.version, prereleases=True):
+            # the installed version is incompatible.
+            yield ancestral_req_strings + (normalised_req_string,)
+        elif dist.requires:
+            for other_req_string in dist.requires:
+                # yields transitive dependencies that are not satisfied.
+                yield from check_dependency(other_req_string, ancestral_req_strings + (normalised_req_string,), req.extras)

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -19,7 +19,8 @@ import warnings
 from collections.abc import Callable, Collection
 from types import TracebackType
 
-import build
+from ._exceptions import FailedProcessError
+from ._util import check_dependency
 
 
 try:
@@ -65,7 +66,7 @@ def _should_use_virtualenv() -> bool:
     # dependencies are installed as specified by build.
     return virtualenv is not None and not any(
         packaging.requirements.Requirement(d[1]).name == 'virtualenv'
-        for d in build.check_dependency('build[virtualenv]')
+        for d in check_dependency('build[virtualenv]')
         if len(d) > 1
     )
 
@@ -271,7 +272,7 @@ def _create_isolated_env_venv(path: str) -> tuple[str, str]:
                 warnings.filterwarnings('ignore', 'check_home argument is deprecated and ignored.', DeprecationWarning)
             venv.EnvBuilder(with_pip=True, symlinks=symlinks).create(path)
     except subprocess.CalledProcessError as exc:
-        raise build.FailedProcessError(exc, 'Failed to create venv. Maybe try installing virtualenv.') from None
+        raise FailedProcessError(exc, 'Failed to create venv. Maybe try installing virtualenv.') from None
 
     executable, script_dir, purelib = _find_executable_and_scripts(path)
 

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -16,7 +16,7 @@ import sysconfig
 import tempfile
 import warnings
 
-from collections.abc import Callable, Collection
+from collections.abc import Callable, Collection, Mapping
 from types import TracebackType
 
 from ._exceptions import FailedProcessError
@@ -33,28 +33,16 @@ _logger = logging.getLogger(__name__)
 
 
 class IsolatedEnv(metaclass=abc.ABCMeta):
-    """Abstract base of isolated build environments, as required by the build project."""
+    """Isolated build environment ABC."""
 
     @property
     @abc.abstractmethod
-    def executable(self) -> str:
-        """The executable of the isolated build environment."""
-        raise NotImplementedError
-
-    @property
-    @abc.abstractmethod
-    def scripts_dir(self) -> str:
-        """The scripts directory of the isolated build environment."""
-        raise NotImplementedError
+    def python_executable(self) -> str:
+        """The Python executable of the isolated environment."""
 
     @abc.abstractmethod
-    def install(self, requirements: Collection[str]) -> None:
-        """
-        Install packages from PEP 508 requirements in the isolated build environment.
-
-        :param requirements: PEP 508 requirements
-        """
-        raise NotImplementedError
+    def make_extra_environ(self) -> Mapping[str, str] | None:
+        """Generate additional env vars specific to the isolated environment."""
 
 
 @functools.lru_cache(maxsize=None)

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -1,7 +1,3 @@
-"""
-Creates and manages isolated build environments.
-"""
-
 from __future__ import annotations
 
 import abc
@@ -17,8 +13,7 @@ import tempfile
 import typing
 import warnings
 
-from collections.abc import Callable, Collection, Mapping
-from types import TracebackType
+from collections.abc import Collection, Mapping
 
 from ._exceptions import FailedProcessError
 from ._util import check_dependency
@@ -76,54 +71,81 @@ def _subprocess(cmd: list[str]) -> None:
         raise e
 
 
-class IsolatedEnvBuilder:
-    """Builder object for isolated environments."""
+class DefaultIsolatedEnv(IsolatedEnv):
+    """An isolated environment which combines venv and virtualenv with pip."""
 
-    def __init__(self) -> None:
-        self._path: str | None = None
-
-    def __enter__(self) -> IsolatedEnv:
-        """
-        Create an isolated build environment.
-
-        :return: The isolated build environment
-        """
-        # Call ``realpath`` to prevent spurious warning from being emitted
-        # that the venv location has changed on Windows. The username is
-        # DOS-encoded in the output of tempfile - the location is the same
-        # but the representation of it is different, which confuses venv.
-        # Ref: https://bugs.python.org/issue46171
-        self._path = os.path.realpath(tempfile.mkdtemp(prefix='build-env-'))
+    def __enter__(self) -> DefaultIsolatedEnv:
         try:
+            self._path = tempfile.mkdtemp(prefix='build-env-')
             # use virtualenv when available (as it's faster than venv)
             if _should_use_virtualenv():
                 self.log('Creating virtualenv isolated environment...')
-                executable, scripts_dir = _create_isolated_env_virtualenv(self._path)
+                self._python_executable, self._scripts_dir = _create_isolated_env_virtualenv(self._path)
             else:
                 self.log('Creating venv isolated environment...')
-                executable, scripts_dir = _create_isolated_env_venv(self._path)
-            return _IsolatedEnvVenvPip(
-                path=self._path,
-                python_executable=executable,
-                scripts_dir=scripts_dir,
-                log=self.log,
-            )
+
+                # Call ``realpath`` to prevent spurious warning from being emitted
+                # that the venv location has changed on Windows. The username is
+                # DOS-encoded in the output of tempfile - the location is the same
+                # but the representation of it is different, which confuses venv.
+                # Ref: https://bugs.python.org/issue46171
+                self._path = os.path.realpath(tempfile.mkdtemp(prefix='build-env-'))
+                self._python_executable, self._scripts_dir = _create_isolated_env_venv(self._path)
+            return self
         except Exception:  # cleanup folder if creation fails
             self.__exit__(*sys.exc_info())
             raise
 
-    def __exit__(
-        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
-    ) -> None:
-        """
-        Delete the created isolated build environment.
-
-        :param exc_type: The type of exception raised (if any)
-        :param exc_val: The value of exception raised (if any)
-        :param exc_tb: The traceback of exception raised (if any)
-        """
-        if self._path is not None and os.path.exists(self._path):  # in case the user already deleted skip remove
+    def __exit__(self, *args: object) -> None:
+        if os.path.exists(self._path):  # in case the user already deleted skip remove
             shutil.rmtree(self._path)
+
+    @property
+    def path(self) -> str:
+        """The location of the isolated build environment."""
+        return self._path
+
+    @property
+    def python_executable(self) -> str:
+        """The python executable of the isolated build environment."""
+        return self._python_executable
+
+    def make_extra_environ(self) -> dict[str, str]:
+        path = os.environ.get('PATH')
+        return {'PATH': os.pathsep.join([self._scripts_dir, path]) if path is not None else self._scripts_dir}
+
+    def install(self, requirements: Collection[str]) -> None:
+        """
+        Install packages from PEP 508 requirements in the isolated build environment.
+
+        :param requirements: PEP 508 requirement specification to install
+
+        :note: Passing non-PEP 508 strings will result in undefined behavior, you *should not* rely on it. It is
+               merely an implementation detail, it may change any time without warning.
+        """
+        if not requirements:
+            return
+
+        self.log(f'Installing packages in isolated environment... ({", ".join(sorted(requirements))})')
+
+        # pip does not honour environment markers in command line arguments
+        # but it does for requirements from a file
+        with tempfile.NamedTemporaryFile('w', prefix='build-reqs-', suffix='.txt', delete=False) as req_file:
+            req_file.write(os.linesep.join(requirements))
+        try:
+            cmd = [
+                self.python_executable,
+                '-Im',
+                'pip',
+                'install',
+                '--use-pep517',
+                '--no-warn-script-location',
+                '-r',
+                os.path.abspath(req_file.name),
+            ]
+            _subprocess(cmd)
+        finally:
+            os.unlink(req_file.name)
 
     @staticmethod
     def log(message: str) -> None:
@@ -139,78 +161,6 @@ class IsolatedEnvBuilder:
             _logger.log(logging.INFO, message, stacklevel=2)
         else:
             _logger.log(logging.INFO, message)
-
-
-class _IsolatedEnvVenvPip(IsolatedEnv):
-    """
-    Isolated build environment context manager
-
-    Non-standard paths injected directly to sys.path will still be passed to the environment.
-    """
-
-    def __init__(
-        self,
-        path: str,
-        python_executable: str,
-        scripts_dir: str,
-        log: Callable[[str], None],
-    ) -> None:
-        """
-        :param path: The path where the environment exists
-        :param python_executable: The python executable within the environment
-        :param log: Log function
-        """
-        self._path = path
-        self._python_executable = python_executable
-        self._scripts_dir = scripts_dir
-        self._log = log
-
-    @property
-    def path(self) -> str:
-        """The location of the isolated build environment."""
-        return self._path
-
-    @property
-    def executable(self) -> str:
-        """The python executable of the isolated build environment."""
-        return self._python_executable
-
-    @property
-    def scripts_dir(self) -> str:
-        return self._scripts_dir
-
-    def install(self, requirements: Collection[str]) -> None:
-        """
-        Install packages from PEP 508 requirements in the isolated build environment.
-
-        :param requirements: PEP 508 requirement specification to install
-
-        :note: Passing non-PEP 508 strings will result in undefined behavior, you *should not* rely on it. It is
-               merely an implementation detail, it may change any time without warning.
-        """
-        if not requirements:
-            return
-
-        self._log('Installing packages in isolated environment... ({})'.format(', '.join(sorted(requirements))))
-
-        # pip does not honour environment markers in command line arguments
-        # but it does for requirements from a file
-        with tempfile.NamedTemporaryFile('w+', prefix='build-reqs-', suffix='.txt', delete=False) as req_file:
-            req_file.write(os.linesep.join(requirements))
-        try:
-            cmd = [
-                self.executable,
-                '-Im',
-                'pip',
-                'install',
-                '--use-pep517',
-                '--no-warn-script-location',
-                '-r',
-                os.path.abspath(req_file.name),
-            ]
-            _subprocess(cmd)
-        finally:
-            os.unlink(req_file.name)
 
 
 def _create_isolated_env_virtualenv(path: str) -> tuple[str, str]:
@@ -335,6 +285,6 @@ def _find_executable_and_scripts(path: str) -> tuple[str, str, str]:
 
 
 __all__ = [
-    'IsolatedEnvBuilder',
     'IsolatedEnv',
+    'DefaultIsolatedEnv',
 ]

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import sysconfig
 import tempfile
+import typing
 import warnings
 
 from collections.abc import Callable, Collection, Mapping
@@ -28,11 +29,18 @@ try:
 except ModuleNotFoundError:
     virtualenv = None
 
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+elif typing.TYPE_CHECKING:
+    from typing_extensions import Protocol
+else:
+    Protocol = abc.ABC
+
 
 _logger = logging.getLogger(__name__)
 
 
-class IsolatedEnv(metaclass=abc.ABCMeta):
+class IsolatedEnv(Protocol):
     """Isolated build environment ABC."""
 
     @property

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -2,15 +2,14 @@
 
 from __future__ import annotations
 
-import os
 import pathlib
 import sys
 import tempfile
 
 import pyproject_hooks
 
-import build
-import build.env
+from . import PathType, ProjectBuilder
+from .env import DefaultIsolatedEnv
 
 
 if sys.version_info >= (3, 8):
@@ -19,14 +18,14 @@ else:
     import importlib_metadata
 
 
-def _project_wheel_metadata(builder: build.ProjectBuilder) -> importlib_metadata.PackageMetadata:
+def _project_wheel_metadata(builder: ProjectBuilder) -> importlib_metadata.PackageMetadata:
     with tempfile.TemporaryDirectory() as tmpdir:
         path = pathlib.Path(builder.metadata_path(tmpdir))
         return importlib_metadata.PathDistribution(path).metadata
 
 
 def project_wheel_metadata(
-    srcdir: build.PathType,
+    source_dir: PathType,
     isolated: bool = True,
 ) -> importlib_metadata.PackageMetadata:
     """
@@ -35,24 +34,27 @@ def project_wheel_metadata(
     Uses the ``prepare_metadata_for_build_wheel`` hook if available,
     otherwise ``build_wheel``.
 
-    :param srcdir: Project source directory
+    :param source_dir: Project source directory
     :param isolated: Whether or not to run invoke the backend in the current
                      environment or to create an isolated one and invoke it
                      there.
     """
-    builder = build.ProjectBuilder(
-        os.fspath(srcdir),
-        runner=pyproject_hooks.quiet_subprocess_runner,
-    )
 
-    if not isolated:
-        return _project_wheel_metadata(builder)
-
-    with build.env.IsolatedEnvBuilder() as env:
-        builder.python_executable = env.executable
-        builder.scripts_dir = env.scripts_dir
-        env.install(builder.build_system_requires)
-        env.install(builder.get_requires_for_build('wheel'))
+    if isolated:
+        with DefaultIsolatedEnv() as env:
+            builder = ProjectBuilder.from_isolated_env(
+                env,
+                source_dir,
+                runner=pyproject_hooks.quiet_subprocess_runner,
+            )
+            env.install(builder.build_system_requires)
+            env.install(builder.get_requires_for_build('wheel'))
+            return _project_wheel_metadata(builder)
+    else:
+        builder = ProjectBuilder(
+            source_dir,
+            runner=pyproject_hooks.quiet_subprocess_runner,
+        )
         return _project_wheel_metadata(builder)
 
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -19,15 +19,15 @@ IS_PYPY3 = platform.python_implementation() == 'PyPy'
 @pytest.mark.isolated
 def test_isolation():
     subprocess.check_call([sys.executable, '-c', 'import build.env'])
-    with build.env.IsolatedEnvBuilder() as env:
+    with build.env.DefaultIsolatedEnv() as env:
         with pytest.raises(subprocess.CalledProcessError):
             debug = 'import sys; import os; print(os.linesep.join(sys.path));'
-            subprocess.check_call([env.executable, '-c', f'{debug} import build.env'])
+            subprocess.check_call([env.python_executable, '-c', f'{debug} import build.env'])
 
 
 @pytest.mark.isolated
 def test_isolated_environment_install(mocker):
-    with build.env.IsolatedEnvBuilder() as env:
+    with build.env.DefaultIsolatedEnv() as env:
         mocker.patch('build.env._subprocess')
 
         env.install([])
@@ -37,7 +37,7 @@ def test_isolated_environment_install(mocker):
         build.env._subprocess.assert_called()
         args = build.env._subprocess.call_args[0][0][:-1]
         assert args == [
-            env.executable,
+            env.python_executable,
             '-Im',
             'pip',
             'install',
@@ -51,7 +51,7 @@ def test_isolated_environment_install(mocker):
 @pytest.mark.skipif(sys.platform != 'darwin', reason='workaround for Apple Python')
 def test_can_get_venv_paths_with_conflicting_default_scheme(mocker):
     get_scheme_names = mocker.patch('sysconfig.get_scheme_names', return_value=('osx_framework_library',))
-    with build.env.IsolatedEnvBuilder():
+    with build.env.DefaultIsolatedEnv():
         pass
     assert get_scheme_names.call_count == 1
 
@@ -61,7 +61,7 @@ def test_can_get_venv_paths_with_posix_local_default_scheme(mocker):
     get_paths = mocker.spy(sysconfig, 'get_paths')
     # We should never call this, but we patch it to ensure failure if we do
     get_default_scheme = mocker.patch('sysconfig.get_default_scheme', return_value='posix_local')
-    with build.env.IsolatedEnvBuilder():
+    with build.env.DefaultIsolatedEnv():
         pass
     get_paths.assert_called_once_with(scheme='posix_prefix', vars=mocker.ANY)
     assert get_default_scheme.call_count == 0
@@ -70,7 +70,7 @@ def test_can_get_venv_paths_with_posix_local_default_scheme(mocker):
 def test_executable_missing_post_creation(mocker):
     venv_create = mocker.patch('venv.EnvBuilder.create')
     with pytest.raises(RuntimeError, match='Virtual environment creation failed, executable .* missing'):
-        with build.env.IsolatedEnvBuilder():
+        with build.env.DefaultIsolatedEnv():
             pass
     assert venv_create.call_count == 1
 
@@ -104,7 +104,7 @@ def test_isolated_env_log(mocker, caplog, package_test_flit):
     mocker.patch('build.env._subprocess')
     caplog.set_level(logging.DEBUG)
 
-    builder = build.env.IsolatedEnvBuilder()
+    builder = build.env.DefaultIsolatedEnv()
     builder.log('something')  # line number 106
     with builder as env:
         env.install(['something'])
@@ -118,8 +118,10 @@ def test_isolated_env_log(mocker, caplog, package_test_flit):
 
 @pytest.mark.isolated
 def test_default_pip_is_never_too_old():
-    with build.env.IsolatedEnvBuilder() as env:
-        version = subprocess.check_output([env.executable, '-c', 'import pip; print(pip.__version__)'], text=True).strip()
+    with build.env.DefaultIsolatedEnv() as env:
+        version = subprocess.check_output(
+            [env.python_executable, '-c', 'import pip; print(pip.__version__)'], text=True
+        ).strip()
         assert Version(version) >= Version('19.1')
 
 
@@ -137,7 +139,7 @@ def test_pip_needs_upgrade_mac_os_11(mocker, pip_version, arch):
     mocker.patch(metadata_name + '.distributions', return_value=(SimpleNamespace(version=pip_version),))
 
     min_version = Version('20.3' if arch == 'x86_64' else '21.0.1')
-    with build.env.IsolatedEnvBuilder():
+    with build.env.DefaultIsolatedEnv():
         if Version(pip_version) < min_version:
             print(_subprocess.call_args_list)
             upgrade_call, uninstall_call = _subprocess.call_args_list

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -127,7 +127,7 @@ def test_build_isolated(mocker, package_test_flit):
         ],
     )
     mocker.patch('build.__main__._error')
-    install = mocker.patch('build.env._IsolatedEnvVenvPip.install')
+    install = mocker.patch('build.env.DefaultIsolatedEnv.install')
 
     build.__main__.build_package(package_test_flit, '.', ['sdist'])
 
@@ -170,7 +170,7 @@ def test_build_no_isolation_with_check_deps(mocker, package_test_flit, missing_d
 @pytest.mark.isolated
 def test_build_raises_build_exception(mocker, package_test_flit):
     mocker.patch('build.ProjectBuilder.get_requires_for_build', side_effect=build.BuildException)
-    mocker.patch('build.env._IsolatedEnvVenvPip.install')
+    mocker.patch('build.env.DefaultIsolatedEnv.install')
 
     with pytest.raises(build.BuildException):
         build.__main__.build_package(package_test_flit, '.', ['sdist'])
@@ -179,7 +179,7 @@ def test_build_raises_build_exception(mocker, package_test_flit):
 @pytest.mark.isolated
 def test_build_raises_build_backend_exception(mocker, package_test_flit):
     mocker.patch('build.ProjectBuilder.get_requires_for_build', side_effect=build.BuildBackendException(Exception('a')))
-    mocker.patch('build.env._IsolatedEnvVenvPip.install')
+    mocker.patch('build.env.DefaultIsolatedEnv.install')
 
     msg = f"Backend operation failed: Exception('a'{',' if sys.version_info < (3, 7) else ''})"
     with pytest.raises(build.BuildBackendException, match=re.escape(msg)):

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -221,20 +221,11 @@ def test_init(mocker, package_test_flit, package_legacy, test_no_permission, pac
         build.ProjectBuilder(package_test_bad_syntax)
 
 
-def test_init_makes_srcdir_absolute(package_test_flit):
+def test_init_makes_source_dir_absolute(package_test_flit):
     rel_dir = os.path.relpath(package_test_flit, os.getcwd())
     assert not os.path.isabs(rel_dir)
     builder = build.ProjectBuilder(rel_dir)
-    assert os.path.isabs(builder.srcdir)
-
-
-@pytest.mark.parametrize('value', [b'something', 'something_else'])
-def test_python_executable(package_test_flit, value):
-    builder = build.ProjectBuilder(package_test_flit)
-
-    builder.python_executable = value
-    assert builder.python_executable == value
-    assert builder._hook.python_executable == value
+    assert os.path.isabs(builder.source_dir)
 
 
 @pytest.mark.parametrize('distribution', ['wheel', 'sdist'])
@@ -383,7 +374,7 @@ def test_build_not_dir_outdir(mocker, tmp_dir, package_test_flit):
 def demo_pkg_inline(tmp_path_factory):
     # builds a wheel without any dependencies and with a console script demo-pkg-inline
     tmp_path = tmp_path_factory.mktemp('demo-pkg-inline')
-    builder = build.ProjectBuilder(srcdir=os.path.join(os.path.dirname(__file__), 'packages', 'inline'))
+    builder = build.ProjectBuilder(source_dir=os.path.join(os.path.dirname(__file__), 'packages', 'inline'))
     out = tmp_path / 'dist'
     builder.build('wheel', str(out))
     return next(out.iterdir())
@@ -501,7 +492,7 @@ def test_no_outdir_multiple(mocker, tmp_dir, package_test_flit):
 
 
 def test_runner_user_specified(tmp_dir, package_test_flit):
-    def dummy_runner(cmd, cwd=None, env=None):
+    def dummy_runner(cmd, cwd=None, extra_environ=None):
         raise RuntimeError('Runner was called')
 
     builder = build.ProjectBuilder(package_test_flit, runner=dummy_runner)

--- a/tests/test_self_packaging.py
+++ b/tests/test_self_packaging.py
@@ -20,6 +20,8 @@ sdist_files = {
     'pyproject.toml',
     'src/build/__init__.py',
     'src/build/__main__.py',
+    'src/build/_exceptions.py',
+    'src/build/_util.py',
     'src/build/env.py',
     'src/build/py.typed',
     'src/build/util.py',
@@ -28,6 +30,8 @@ sdist_files = {
 wheel_files = {
     'build/__init__.py',
     'build/__main__.py',
+    'build/_exceptions.py',
+    'build/_util.py',
     'build/env.py',
     'build/py.typed',
     'build/util.py',


### PR DESCRIPTION
This is a more modest set of changes than I had in #361.  Changing the runner's signature to make removing variables from the environ possible can come in a follow-up PR.  Just as #361, this removes the env builder, redefines the isolated env interface, and adds an isolated env constructor to the project builder.