### PR TITLE
Introduce a centralized GHA check/gate job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,16 @@ jobs:
           - "tox"
           - "min"
 
+    continue-on-error: >- # jobs not required in branch protection
+      ${{
+        (
+          startsWith(matrix.py, 'pypy-')
+          && (!endsWith(matrix.py, '-3.7') || matrix.os == 'windows')
+        )
+        && true
+        || false
+      }}
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -128,3 +138,19 @@ jobs:
 
       - name: Run check for type
         run: tox -e type --skip-pkg-install
+
+  # https://github.com/marketplace/actions/alls-green#why
+  required-checks-pass: # This job does nothing and is only used for the branch protection
+    if: always()
+
+    needs:
+      - pytest
+      - type
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
This patch is intended to lower the maintenance burden of having to manually go through each matrix subjob name in the branch protection repository settings. It allows to only include the `check` job in the branch protection and it will robustly determine if the dependencies have succeeded or not.

It is currently mostly serves the Python ecosystem in projects like aiohttp, attrs, cryptography, pydantic, open edX, pip etc. But I've also seen other communities picking it up lately, like the AWS Rust SDK and even the engine powering https://dev.to, to my surprise. Strictly speaking, it is agnostic.

Ref: https://github.com/marketplace/actions/alls-green#why