### PR TITLE
Wrap CLI options in description with backticks

### DIFF
--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -262,15 +262,15 @@ def main_parser() -> argparse.ArgumentParser:
                 '''
                 A simple, correct PEP 517 build frontend.
 
-                By default, a source distribution (sdist) is built from {srcdir}
+                By default, a source distribution (sdist) is built from ``{srcdir}``
                 and a binary distribution (wheel) is built from the sdist.
                 This is recommended as it will ensure the sdist can be used
                 to build wheels.
 
-                Pass -s/--sdist and/or -w/--wheel to build a specific distribution.
+                Pass ``-s/--sdist`` and/or ``-w/--wheel`` to build a specific distribution.
                 If you do this, the default behavior will be disabled, and all
-                artifacts will be built from {srcdir} (even if you combine
-                -w/--wheel with -s/--sdist, the wheel will be built from {srcdir}).
+                artifacts will be built from ``{srcdir}`` (even if you combine
+                ``-w``/``--wheel`` with ``-s``/``--sdist``, the wheel will be built from ``{srcdir}``).
                 '''
             ).strip(),
             '    ',


### PR DESCRIPTION
This is necessary to make Sphinx display them as inline code and so it stops converting double dashes (`--`) to M-dashes (`—`).