### PR TITLE
docs: remove direct references to PEP 517 in docs landing page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,9 +4,10 @@
 build
 *****
 
-A simple, correct :pep:`517` build frontend.
+A simple, correct Python build frontend.
 
-build will invoke the :pep:`517` hooks to build a distribution package.
+build implements handling for pyproject.toml-based builds, invoking
+build-backend hooks as appropriate to build a distribution package.
 It is a simple build tool and does not perform any dependency management.
 
 .. sphinx_argparse_cli::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ build
 
 A simple, correct Python packaging build frontend.
 
-build manages pyproject.toml-based builds, invoking
+build manages ``pyproject.toml``-based builds, invoking
 build-backend hooks as appropriate to build a distribution package.
 It is a simple build tool and does not perform any dependency management.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,9 +4,9 @@
 build
 *****
 
-A simple, correct Python build frontend.
+A simple, correct Python packaging build frontend.
 
-build implements handling for pyproject.toml-based builds, invoking
+build manages pyproject.toml-based builds, invoking
 build-backend hooks as appropriate to build a distribution package.
 It is a simple build tool and does not perform any dependency management.
 


### PR DESCRIPTION
Toward #529 