### PR TITLE
Don't require toml in [test] on Python 3.11+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,10 +54,10 @@ test = [
   "pytest-mock >= 2",
   "pytest-rerunfailures >= 9.1",
   "pytest-xdist >= 1.34",
-  "toml >= 0.10.0",
   "wheel >= 0.36.0",
   'setuptools >= 42.0.0; python_version < "3.10"',
   'setuptools >= 56.0.0; python_version >= "3.10"',
+  'toml >= 0.10.0; python_version < "3.11"'
 ]
 typing = [
   "importlib-metadata >= 5.1",


### PR DESCRIPTION
The test_toml_instead_of_tomli test is skipped on Python 3.11 anyway.