### PR TITLE
infra: replace flake8 with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.227
+    rev: v0.0.228
     hooks:
       - id: ruff
         args: [--fix, --format, grouped]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,12 +43,11 @@ repos:
     rev: 5.11.4
     hooks:
       - id: isort
-  - repo: https://github.com/PyCQA/flake8
-    rev: "6.0.0"
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.226
     hooks:
-      - id: flake8
-        additional_dependencies: ["flake8-bugbear==22.7.1"]
-        language_version: python3.9
+      - id: ruff
+        args: [--force-exclude, --format, grouped, --show-source]
   - repo: https://github.com/codespell-project/codespell
     rev: "v2.2.2"
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
     rev: v0.0.226
     hooks:
       - id: ruff
-        args: [--force-exclude, --format, grouped]
+        args: [--fix, --format, grouped]
   - repo: https://github.com/codespell-project/codespell
     rev: "v2.2.2"
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.226
+    rev: v0.0.227
     hooks:
       - id: ruff
         args: [--fix, --format, grouped]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
     rev: v0.0.226
     hooks:
       - id: ruff
-        args: [--force-exclude, --format, grouped, --show-source]
+        args: [--force-exclude, --format, grouped]
   - repo: https://github.com/codespell-project/codespell
     rev: "v2.2.2"
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,7 @@ select = [
   "E",    # pycodestyle
   "F",    # pyflakes
   "W",    # pycodestyle
-  "RUF",  # ruff
+  "RUF100",  # ruff
 ]
 
 [tool.ruff.mccabe]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,3 +142,19 @@ lines_after_imports = 2
 line_length = 127
 known_first_party = "build"
 skip = []  # "build" is included in the default skip list
+
+[tool.ruff]
+line-length = 127
+target-version = "py37"
+select = [
+  "B",    # flake8-bugbear
+  "C4",   # flake8-comprehensions
+  "C9",   # mccabe
+  "E",    # pycodestyle
+  "F",    # pyflakes
+  "W",    # pycodestyle
+  "RUF",  # ruff
+]
+
+[tool.ruff.mccabe]
+max-complexity = 10

--- a/tests/packages/test-bad-wheel/backend_bad_wheel.py
+++ b/tests/packages/test-bad-wheel/backend_bad_wheel.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 
-from setuptools.build_meta import build_sdist  # noqa: F401
+from setuptools.build_meta import build_sdist as build_sdist
 
 
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):

--- a/tests/packages/test-no-prepare/backend_no_prepare.py
+++ b/tests/packages/test-no-prepare/backend_no_prepare.py
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: MIT
 
-from setuptools.build_meta import build_sdist, build_wheel  # noqa: F401
+from setuptools.build_meta import build_sdist as build_sdist
+from setuptools.build_meta import build_wheel as build_wheel

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -124,7 +124,7 @@ def test_build(monkeypatch, project, args, call, tmp_path):
 
 def test_isolation(tmp_dir, package_test_flit, mocker):
     try:
-        import flit_core  # noqa: F401
+        import flit_core  # noqa: F401  # imported but unused
     except ModuleNotFoundError:
         pass
     else:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -17,7 +17,7 @@ def test_wheel_metadata(package_test_setuptools, isolated):
 @pytest.mark.pypy3323bug
 def test_wheel_metadata_isolation(package_test_flit):
     try:
-        import flit_core  # noqa: F401
+        import flit_core  # noqa: F401  # imported but unused
     except ModuleNotFoundError:
         pass
     else:

--- a/tox.ini
+++ b/tox.ini
@@ -101,9 +101,3 @@ commands =
     coverage html -d {toxworkdir}/htmlcov -i
     python -m diff_cover.diff_cover_tool --compare-branch {env:DIFF_AGAINST:origin/main} {toxworkdir}/coverage.xml
 depends = {py311, py310, py39, py38, py37, pypy37, pypy38, pypy39}{,-min}, path
-
-[flake8]
-max-line-length = 127
-max-complexity = 10
-extend-ignore = E203
-extend-select = B9


### PR DESCRIPTION
As a first step, this ports all of our existing flake8 rules to Ruff. I have omitted pyupgrade for which Ruff has partial support.