### PR TITLE
Specify encoding.

### DIFF
--- a/src/build/env.py
+++ b/src/build/env.py
@@ -130,7 +130,7 @@ class DefaultIsolatedEnv(IsolatedEnv):
 
         # pip does not honour environment markers in command line arguments
         # but it does for requirements from a file
-        with tempfile.NamedTemporaryFile('w', prefix='build-reqs-', suffix='.txt', delete=False) as req_file:
+        with tempfile.NamedTemporaryFile('w', prefix='build-reqs-', suffix='.txt', delete=False, encoding='utf-8') as req_file:
             req_file.write(os.linesep.join(requirements))
         try:
             cmd = [

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -120,7 +120,9 @@ def test_isolated_env_log(mocker, caplog, package_test_flit):
 def test_default_pip_is_never_too_old():
     with build.env.DefaultIsolatedEnv() as env:
         version = subprocess.check_output(
-            [env.python_executable, '-c', 'import pip; print(pip.__version__)'], text=True
+            [env.python_executable, '-c', 'import pip; print(pip.__version__)'],
+            text=True,
+            encoding='utf-8',
         ).strip()
         assert Version(version) >= Version('19.1')
 

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -363,7 +363,7 @@ def test_build_not_dir_outdir(mocker, tmp_dir, package_test_flit):
     builder._hook.build_sdist.return_value = 'dist.tar.gz'
     out = os.path.join(tmp_dir, 'out')
 
-    open(out, 'a').close()  # create empty file
+    open(out, 'a', encoding='utf-8').close()  # create empty file
 
     with pytest.raises(build.BuildException):
         builder.build('sdist', out)
@@ -410,7 +410,7 @@ def test_build_with_dep_on_console_script(tmp_path, demo_pkg_inline, capfd, mock
         '''
     )
     (tmp_path / 'pyproject.toml').write_text(toml, encoding='UTF-8')
-    (tmp_path / 'build.py').write_text(code)
+    (tmp_path / 'build.py').write_text(code, encoding='utf-8')
 
     deps = {str(demo_pkg_inline)}  # we patch the requires demo_pkg_inline to refer to the wheel -> we don't need index
     mocker.patch('build.ProjectBuilder.build_system_requires', new_callable=mocker.PropertyMock, return_value=deps)
@@ -462,7 +462,7 @@ def test_prepare_not_dir_outdir(mocker, tmp_dir, package_test_flit):
     builder = build.ProjectBuilder(package_test_flit)
 
     out = os.path.join(tmp_dir, 'out')
-    with open(out, 'w') as f:
+    with open(out, 'w', encoding='utf-8') as f:
         f.write('Not a directory')
     with pytest.raises(build.BuildException, match='Build path .* exists and is not a directory'):
         builder.prepare('wheel', out)

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ setenv =
     COVERAGE_FILE = {toxworkdir}/.coverage.{envname}
     TEST_STATUS_DIR = {envtmpdir}
     PYPY3323BUG = 1
+    PYTHONWARNDEFAULTENCODING = 1
 extras =
     test
 commands =


### PR DESCRIPTION
Fixes failures when PYTHONWARNDEFAULTENCODING=1. Fixes #577.