### PR TITLE
tests: report installed versions of common packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ docs = [
 ]
 test = [
   "filelock >= 3",
+  'importlib-metadata; python_version<"3.8"',
   "pytest >= 6.2.4",
   "pytest-cov >= 2.12",
   "pytest-mock >= 2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ docs = [
 ]
 test = [
   "filelock >= 3",
-  'importlib-metadata; python_version<"3.8"',
   "pytest >= 6.2.4",
   "pytest-cov >= 2.12",
   "pytest-mock >= 2",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,9 +132,8 @@ def pytest_report_header() -> str:
     ]
     valid = []
     for package in interesting_packages:
+        # Old versions of importlib_metadata made this FileNotFoundError
         with contextlib.suppress(ModuleNotFoundError, FileNotFoundError):
             valid.append(f'{package}=={metadata.version(package)}')
     reqs = ' '.join(valid)
-    pkg_line = f'installed packages of interest: {reqs}'
-
-    return pkg_line
+    return f'installed packages of interest: {reqs}'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 
+import contextlib
 import os
 import os.path
 import shutil
@@ -11,6 +12,11 @@ import tempfile
 import pytest
 
 import build.env
+
+if sys.version_info < (3, 8):
+    import importlib_metadata as metadata
+else:
+    from importlib import metadata
 
 
 def pytest_addoption(parser):
@@ -109,3 +115,26 @@ def tmp_dir():
 @pytest.fixture(autouse=True)
 def force_venv(mocker):
     mocker.patch.object(build.env, '_should_use_virtualenv', lambda: False)
+
+
+def pytest_report_header() -> str:
+    interesting_packages = [
+        'build',
+        'colorama',
+        'filelock',
+        'packaging',
+        'pip',
+        'pyproject_hooks',
+        'setuptools',
+        'tomli',
+        'virtualenv',
+        'wheel',
+    ]
+    valid = []
+    for package in interesting_packages:
+        with contextlib.suppress(ModuleNotFoundError):
+            valid.append(f'{package}=={metadata.version(package)}')
+    reqs = ' '.join(valid)
+    pkg_line = f'installed packages of interest: {reqs}'
+
+    return '\n'.join([pkg_line])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,9 +132,9 @@ def pytest_report_header() -> str:
     ]
     valid = []
     for package in interesting_packages:
-        with contextlib.suppress(ModuleNotFoundError):
+        with contextlib.suppress(ImportError):
             valid.append(f'{package}=={metadata.version(package)}')
     reqs = ' '.join(valid)
     pkg_line = f'installed packages of interest: {reqs}'
 
-    return '\n'.join([pkg_line])
+    return pkg_line

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,7 +132,7 @@ def pytest_report_header() -> str:
     ]
     valid = []
     for package in interesting_packages:
-        with contextlib.suppress(ImportError):
+        with contextlib.suppress(ModuleNotFoundError, FileNotFoundError):
             valid.append(f'{package}=={metadata.version(package)}')
     reqs = ' '.join(valid)
     pkg_line = f'installed packages of interest: {reqs}'


### PR DESCRIPTION
In https://github.com/pypa/build/issues/587, the exact version of pip would help debug why our CI isn't seeing this issue (at least I think it would). Let's report the versions of things we care about in our test header to make such debugging easier.
