### PR TITLE
config: support running Ruff 0.258+ directly on source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,7 @@ target-version = ["py311", "py310", "py39", "py38", "py37"]
 
 [tool.ruff]
 line-length = 127
-exclude = []
+exclude = ["tests/packages/test-bad-syntax"]
 select = [
   "B",    # flake8-bugbear
   "C4",   # flake8-comprehensions


### PR DESCRIPTION
See https://github.com/charliermarsh/ruff/pull/3569.
