### PR TITLE
build: add circular dependency checker for build requirements

### DIFF
--- a/src/build/_exceptions.py
+++ b/src/build/_exceptions.py
@@ -43,6 +43,34 @@ class BuildSystemTableValidationError(BuildException):
         return f'Failed to validate `build-system` in pyproject.toml: {self.args[0]}'
 
 
+class ProjectNameValidationError(BuildException):
+    """
+    Exception raised when the project name is not consistent.
+    """
+
+    def __init__(self, existing: str, existing_source: str, new: str, new_source: str) -> None:
+        super().__init__()
+        self._existing = existing
+        self._existing_source = existing_source
+        self._new = new
+        self._new_source = new_source
+
+    def __str__(self) -> str:
+        return (
+            f'Failed to validate project name: `{self._new}` from `{self._new_source}` '
+            f'does not match `{self._existing}` from `{self._existing_source}`'
+        )
+
+
+class ProjectTableValidationError(BuildException):
+    """
+    Exception raised when the ``[project]`` table in pyproject.toml is invalid.
+    """
+
+    def __str__(self) -> str:
+        return f'Failed to validate `project` in pyproject.toml: {self.args[0]}'
+
+
 class FailedProcessError(Exception):
     """
     Exception raised when a setup or preparation operation fails.
@@ -62,6 +90,30 @@ class FailedProcessError(Exception):
                 description += f'\n  {stream_name}:\n'
                 description += textwrap.indent(stream.decode(), '    ')
         return description
+
+
+class CircularBuildDependencyError(BuildException):
+    """
+    Exception raised when a ``[build-system]`` requirement in pyproject.toml is circular.
+    """
+
+    def __init__(
+        self, project_name: str, ancestral_req_strings: tuple[str, ...], req_string: str, backend: str | None
+    ) -> None:
+        super().__init__()
+        self.project_name: str = project_name
+        self.ancestral_req_strings: tuple[str, ...] = ancestral_req_strings
+        self.req_string: str = req_string
+        self.backend: str | None = backend
+
+    def __str__(self) -> str:
+        cycle_err_str = f'`{self.project_name}`'
+        if self.backend:
+            cycle_err_str += f' -> `{self.backend}`'
+        for dep in self.ancestral_req_strings:
+            cycle_err_str += f' -> `{dep}`'
+        cycle_err_str += f' -> `{self.req_string}`'
+        return f'Failed to validate `build-system` in pyproject.toml, dependency cycle detected: {cycle_err_str}'
 
 
 class TypoWarning(Warning):

--- a/tests/packages/test-circular-get-requires/backend.py
+++ b/tests/packages/test-circular-get-requires/backend.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: MIT
+
+
+def get_requires_for_build_sdist(config_settings=None):
+    return ['recursive_dep']
+
+
+def get_requires_for_build_wheel(config_settings=None):
+    return ['recursive_dep']
+
+
+def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+    raise NotImplementedError
+
+
+def build_sdist(sdist_directory, config_settings=None):
+    raise NotImplementedError

--- a/tests/packages/test-circular-get-requires/pyproject.toml
+++ b/tests/packages/test-circular-get-requires/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = []
+build-backend = 'backend'
+backend-path = ['.']
+
+[project]
+name = "recursive_unmet_dep"
+version = "1.0.0"
+description = "circular project"

--- a/tests/packages/test-circular-metadata/backend.py
+++ b/tests/packages/test-circular-metadata/backend.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: MIT
+
+import pathlib
+import textwrap
+
+
+def get_requires_for_build_wheel(config_settings=None):
+    return ['recursive_dep']
+
+
+def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
+    metadata = {
+        'project': {
+            'name': 'recursive_unmet_dep',
+            'version': '1.0.0',
+            'description': 'circular project',
+        }
+    }
+
+    distinfo = pathlib.Path(
+        metadata_directory,
+        '{}-{}.dist-info'.format(
+            metadata['project']['name'].replace('-', '-'),
+            metadata['project']['version'],
+        ),
+    )
+    distinfo.mkdir(parents=True, exist_ok=True)
+    distinfo.joinpath('METADATA').write_text(
+        textwrap.dedent(
+            f'''
+            Metadata-Version: 2.2
+            Name: {metadata['project']['name']}
+            Version: {metadata['project']['version']}
+            Summary: {metadata['project']['description']}
+            '''
+        ).strip()
+    )
+    return distinfo.name
+
+
+def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+    raise NotImplementedError
+
+
+def build_sdist(sdist_directory, config_settings=None):
+    raise NotImplementedError

--- a/tests/packages/test-circular-metadata/pyproject.toml
+++ b/tests/packages/test-circular-metadata/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = []
+build-backend = 'backend'
+backend-path = ['.']

--- a/tests/packages/test-circular-requirements/pyproject.toml
+++ b/tests/packages/test-circular-requirements/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["recursive_dep"]
+
+[project]
+name = "recursive_unmet_dep"
+version = "1.0.0"
+description = "circular project"

--- a/tests/packages/test-circular-wheel/pyproject.toml
+++ b/tests/packages/test-circular-wheel/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ['setuptools >= 40.8.0']
+build-backend = "setuptools.build_meta"

--- a/tests/packages/test-circular-wheel/setup.cfg
+++ b/tests/packages/test-circular-wheel/setup.cfg
@@ -1,0 +1,7 @@
+[metadata]
+name = wheel
+version = 1.0.0
+
+
+[options]
+setup_requires = wheel

--- a/tests/packages/test-metadata-invalid-name/backend.py
+++ b/tests/packages/test-metadata-invalid-name/backend.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: MIT
+
+import pathlib
+import textwrap
+
+
+def get_requires_for_build_wheel(config_settings=None):
+    return []
+
+
+def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
+    metadata = {
+        'project': {
+            'name': 'test_metadata_prepare_metadata_name',
+            'version': '1.0.0',
+            'description': 'hello!',
+        }
+    }
+
+    distinfo = pathlib.Path(
+        metadata_directory,
+        '{}-{}.dist-info'.format(
+            metadata['project']['name'].replace('-', '-'),
+            metadata['project']['version'],
+        ),
+    )
+    distinfo.mkdir(parents=True, exist_ok=True)
+    distinfo.joinpath('METADATA').write_text(
+        textwrap.dedent(
+            f'''
+            Metadata-Version: 2.2
+            Name: {metadata['project']['name']}
+            Version: {metadata['project']['version']}
+            Summary: {metadata['project']['description']}
+            '''
+        ).strip()
+    )
+    return distinfo.name
+
+
+def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+    raise NotImplementedError
+
+
+def build_sdist(sdist_directory, config_settings=None):
+    raise NotImplementedError

--- a/tests/packages/test-metadata-invalid-name/pyproject.toml
+++ b/tests/packages/test-metadata-invalid-name/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = []
+build-backend = 'backend'
+backend-path = ['.']
+
+[project]
+name = 'test-metadata-project-name'
+version = '1.0.0'
+description = 'hello!'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -131,7 +131,7 @@ def test_build_isolated(mocker, package_test_flit):
     mocker.patch('build.__main__._error')
     install = mocker.patch('build.env.DefaultIsolatedEnv.install')
 
-    build.__main__.build_package(package_test_flit, '.', ['sdist'])
+    build.__main__.build_package(package_test_flit, '.', ['sdist'], skip_dependency_check=True)
 
     install.assert_any_call({'flit_core >=2,<3'})
 
@@ -230,12 +230,14 @@ def test_build_package_via_sdist_invalid_distribution(tmp_dir, package_test_setu
                 '* Installing packages in isolated environment... (setuptools >= 42.0.0, wheel >= 0.36.0)',
                 '* Getting build dependencies for sdist...',
                 '* Building sdist...',
+                '* Getting build dependencies for sdist...',
                 '* Building wheel from sdist',
                 '* Creating venv isolated environment...',
                 '* Installing packages in isolated environment... (setuptools >= 42.0.0, wheel >= 0.36.0)',
                 '* Getting build dependencies for wheel...',
                 '* Installing packages in isolated environment... (wheel)',
                 '* Building wheel...',
+                '* Getting build dependencies for wheel...',
                 'Successfully built test_setuptools-1.0.0.tar.gz and test_setuptools-1.0.0-py2.py3-none-any.whl',
             ],
         ),
@@ -258,6 +260,7 @@ def test_build_package_via_sdist_invalid_distribution(tmp_dir, package_test_setu
                 '* Getting build dependencies for wheel...',
                 '* Installing packages in isolated environment... (wheel)',
                 '* Building wheel...',
+                '* Getting build dependencies for wheel...',
                 'Successfully built test_setuptools-1.0.0-py2.py3-none-any.whl',
             ],
         ),


### PR DESCRIPTION
Implement a basic build requirement cycle detector per PEP-517:

- Project build requirements will define a directed graph of requirements (project A needs B to build, B needs C and D, etc.) This graph MUST NOT contain cycles. If (due to lack of co-ordination between projects, for example) a cycle is present, front ends MAY refuse to build the project.

- Front ends SHOULD check explicitly for requirement cycles, and terminate the build with an informative message if one is found.

See:
https://www.python.org/dev/peps/pep-0517/#build-requirements