### PR TITLE
chore: isort Ruff code was missing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ select = [
   "C9",   # mccabe
   "E",    # pycodestyle
   "F",    # pyflakes
-  "I",    # isrot
+  "I",    # isort
   "PGH",  # pygrep-hooks
   "RUF",  # ruff
   "UP",   # pyupgrade

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ select = [
   "C9",   # mccabe
   "E",    # pycodestyle
   "F",    # pyflakes
+  "I",    # isrot
   "PGH",  # pygrep-hooks
   "RUF",  # ruff
   "UP",   # pyupgrade

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import pytest
 
 import build.env
 
+
 if sys.version_info < (3, 8):
     import importlib_metadata as metadata
 else:


### PR DESCRIPTION
This was missing, caught by scikit-hep's [repo-review tool](https://scikit-hep.org/developer/reporeview?repo=pypa%2Fbuild&branch=main).
