### PR TITLE
fix: mypy update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,12 +58,6 @@ test = [
   'setuptools >= 42.0.0; python_version < "3.10"',
   'setuptools >= 56.0.0; python_version >= "3.10"',
 ]
-typing = [
-  "importlib-metadata >= 5.1",
-  "mypy == 0.991",
-  "tomli",
-  "typing-extensions >= 3.7.4.3",
-]
 virtualenv = [
   "virtualenv >= 20.0.35",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,12 @@ test = [
   'setuptools >= 42.0.0; python_version < "3.10"',
   'setuptools >= 56.0.0; python_version >= "3.10"',
 ]
+typing = [
+  "importlib-metadata >= 5.1",
+  "mypy == 1.2.0",
+  "tomli",
+  "typing-extensions >= 3.7.4.3",
+]
 virtualenv = [
   "virtualenv >= 20.0.35",
 ]

--- a/src/build/_util.py
+++ b/src/build/_util.py
@@ -49,7 +49,7 @@ def check_dependency(
             return
 
     try:
-        dist = importlib_metadata.distribution(req.name)  # type: ignore[no-untyped-call]
+        dist = importlib_metadata.distribution(req.name)
     except importlib_metadata.PackageNotFoundError:
         # dependency is not installed in the environment.
         yield (*ancestral_req_strings, normalised_req_string)

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -223,7 +223,7 @@ def _create_isolated_env_venv(path: str) -> tuple[str, str]:
     executable, script_dir, purelib = _find_executable_and_scripts(path)
 
     # Get the version of pip in the environment
-    pip_distribution = next(iter(metadata.distributions(name='pip', path=[purelib])))  # type: ignore[no-untyped-call]
+    pip_distribution = next(iter(metadata.distributions(name='pip', path=[purelib])))
     current_pip_version = packaging.version.Version(pip_distribution.version)
 
     if platform.system() == 'Darwin' and int(platform.mac_ver()[0].split('.')[0]) >= 11:

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,15 @@ commands_pre =
 
 [testenv:type]
 description = run type check on code base
-extras = typing
+skip_install = true
+setenv =
+    PYTHONWARNDEFAULTENCODING =
+deps =
+    importlib-metadata>=5.1
+    mypy==1.2.0
+    tomli
+    typing-extensions>=3.7.4.3
+    packaging
 commands =
     mypy
 

--- a/tox.ini
+++ b/tox.ini
@@ -54,15 +54,9 @@ commands_pre =
 
 [testenv:type]
 description = run type check on code base
-skip_install = true
+extras = typing
 setenv =
     PYTHONWARNDEFAULTENCODING =
-deps =
-    importlib-metadata>=5.1
-    mypy==1.2.0
-    tomli
-    typing-extensions>=3.7.4.3
-    packaging
 commands =
     mypy
 


### PR DESCRIPTION
This fixes the issue with two type ignores no longer being needed, updates mypy, moves the configuration out of extras (it was outdated and not helpful to force pin mypy in extras, and not required to use mypy to type anyway, and removes the requirement that build be installed to type check (which is not needed).
