### PR TITLE
main: ensure config_settings are passed to get_requires_for_build

### DIFF
--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -112,7 +112,7 @@ def _build_in_isolated_env(
         # first install the build dependencies
         env.install(builder.build_system_requires)
         # then get the extra required dependencies from the backend (which was installed in the call above :P)
-        env.install(builder.get_requires_for_build(distribution))
+        env.install(builder.get_requires_for_build(distribution, config_settings or {}))
         return builder.build(distribution, outdir, config_settings or {})
 
 
@@ -126,7 +126,7 @@ def _build_in_current_env(
     builder = _ProjectBuilder(srcdir)
 
     if not skip_dependency_check:
-        missing = builder.check_dependencies(distribution)
+        missing = builder.check_dependencies(distribution, config_settings or {})
         if missing:
             dependencies = ''.join('\n\t' + dep for deps in missing for dep in (deps[0], _format_dep_chain(deps[1:])) if dep)
             _cprint()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -135,7 +135,7 @@ def test_build_isolated(mocker, package_test_flit):
 
     install.assert_any_call({'flit_core >=2,<3'})
 
-    required_cmd.assert_called_with('sdist')
+    required_cmd.assert_called_with('sdist', {})
     install.assert_any_call(['dep1', 'dep2'])
 
     build_cmd.assert_called_with('sdist', '.', {})


### PR DESCRIPTION
Fixes builds for packages like psycopg2(for example if the `--pg-config` config setting needs to be set) that can hard error in some cases without `config_settings` being passed to their `get_requires_for_build` hooks.