### PR TITLE
tests: add network marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ norecursedirs = "tests/integration/*"
 markers = [
   "isolated",
   "pypy3323bug",
+  "network",
 ]
 filterwarnings = [
   "error",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -188,6 +188,7 @@ def test_build_raises_build_backend_exception(mocker, package_test_flit):
         build.__main__.build_package(package_test_flit, '.', ['sdist'])
 
 
+@pytest.mark.network
 @pytest.mark.pypy3323bug
 def test_build_package(tmp_dir, package_test_setuptools):
     build.__main__.build_package(package_test_setuptools, tmp_dir, ['sdist', 'wheel'])
@@ -198,6 +199,7 @@ def test_build_package(tmp_dir, package_test_setuptools):
     ]
 
 
+@pytest.mark.network
 @pytest.mark.pypy3323bug
 def test_build_package_via_sdist(tmp_dir, package_test_setuptools):
     build.__main__.build_package_via_sdist(package_test_setuptools, tmp_dir, ['wheel'])
@@ -223,7 +225,7 @@ def test_build_package_via_sdist_invalid_distribution(tmp_dir, package_test_setu
 @pytest.mark.parametrize(
     ('args', 'output'),
     [
-        (
+        pytest.param(
             [],
             [
                 '* Creating venv isolated environment...',
@@ -238,8 +240,10 @@ def test_build_package_via_sdist_invalid_distribution(tmp_dir, package_test_setu
                 '* Building wheel...',
                 'Successfully built test_setuptools-1.0.0.tar.gz and test_setuptools-1.0.0-py2.py3-none-any.whl',
             ],
+            id='via-sdist-isolation',
+            marks=[pytest.mark.network, pytest.mark.isolated],
         ),
-        (
+        pytest.param(
             ['--no-isolation'],
             [
                 '* Getting build dependencies for sdist...',
@@ -249,8 +253,9 @@ def test_build_package_via_sdist_invalid_distribution(tmp_dir, package_test_setu
                 '* Building wheel...',
                 'Successfully built test_setuptools-1.0.0.tar.gz and test_setuptools-1.0.0-py2.py3-none-any.whl',
             ],
+            id='via-sdist-no-isolation',
         ),
-        (
+        pytest.param(
             ['--wheel'],
             [
                 '* Creating venv isolated environment...',
@@ -260,24 +265,28 @@ def test_build_package_via_sdist_invalid_distribution(tmp_dir, package_test_setu
                 '* Building wheel...',
                 'Successfully built test_setuptools-1.0.0-py2.py3-none-any.whl',
             ],
+            id='wheel-direct-isolation',
+            marks=[pytest.mark.network, pytest.mark.isolated],
         ),
-        (
+        pytest.param(
             ['--wheel', '--no-isolation'],
             [
                 '* Getting build dependencies for wheel...',
                 '* Building wheel...',
                 'Successfully built test_setuptools-1.0.0-py2.py3-none-any.whl',
             ],
+            id='wheel-direct-no-isolation',
         ),
-        (
+        pytest.param(
             ['--sdist', '--no-isolation'],
             [
                 '* Getting build dependencies for sdist...',
                 '* Building sdist...',
                 'Successfully built test_setuptools-1.0.0.tar.gz',
             ],
+            id='sdist-direct-no-isolation',
         ),
-        (
+        pytest.param(
             ['--sdist', '--wheel', '--no-isolation'],
             [
                 '* Getting build dependencies for sdist...',
@@ -286,15 +295,8 @@ def test_build_package_via_sdist_invalid_distribution(tmp_dir, package_test_setu
                 '* Building wheel...',
                 'Successfully built test_setuptools-1.0.0.tar.gz and test_setuptools-1.0.0-py2.py3-none-any.whl',
             ],
+            id='sdist-and-wheel-direct-no-isolation',
         ),
-    ],
-    ids=[
-        'via-sdist-isolation',
-        'via-sdist-no-isolation',
-        'wheel-direct-isolation',
-        'wheel-direct-no-isolation',
-        'sdist-direct-no-isolation',
-        'sdist-and-wheel-direct-no-isolation',
     ],
 )
 @pytest.mark.flaky(reruns=5)

--- a/tests/test_self_packaging.py
+++ b/tests/test_self_packaging.py
@@ -43,6 +43,7 @@ wheel_files = {
 }
 
 
+@pytest.mark.network
 def test_build_sdist(monkeypatch, tmpdir):
     monkeypatch.chdir(MAIN_DIR)
 
@@ -66,6 +67,7 @@ def test_build_sdist(monkeypatch, tmpdir):
     assert simpler == sdist_files
 
 
+@pytest.mark.network
 @pytest.mark.parametrize('args', ((), ('--wheel',)), ids=('from_sdist', 'direct'))
 def test_build_wheel(monkeypatch, tmpdir, args):
     monkeypatch.chdir(MAIN_DIR)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,7 +8,7 @@ import build.util
 
 
 @pytest.mark.pypy3323bug
-@pytest.mark.parametrize('isolated', [False, True])
+@pytest.mark.parametrize('isolated', [False, pytest.param(True, marks=[pytest.mark.network, pytest.mark.isolated])])
 def test_wheel_metadata(package_test_setuptools, isolated):
     metadata = build.util.project_wheel_metadata(package_test_setuptools, isolated)
 
@@ -16,6 +16,7 @@ def test_wheel_metadata(package_test_setuptools, isolated):
     assert metadata['version'] == '1.0.0'
 
 
+@pytest.mark.network
 @pytest.mark.pypy3323bug
 def test_wheel_metadata_isolation(package_test_flit):
     if importlib.util.find_spec('flit_core'):
@@ -33,6 +34,7 @@ def test_wheel_metadata_isolation(package_test_flit):
         build.util.project_wheel_metadata(package_test_flit, isolated=False)
 
 
+@pytest.mark.network
 @pytest.mark.pypy3323bug
 def test_with_get_requires(package_test_metadata):
     metadata = build.util.project_wheel_metadata(package_test_metadata)


### PR DESCRIPTION
Fixes #648. Adds a network marker for tests using the network.

Tested by disabling wifi and running `pytest -m "not network"`.