### PR TITLE
fix: include all files in SDist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit-core >= 3.4"]
+requires = ["flit-core >= 3.8"]
 build-backend = "flit_core.buildapi"
 
 [project]
@@ -79,7 +79,7 @@ build = "build.__main__:entrypoint"
 
 [tool.flit.sdist]
 include = ["tests/", ".gitignore", "CHANGELOG.rst", "docs/", ".dockerignore", "tox.ini"]
-exclude = ["tests/__pycache__", "docs/_build"]
+exclude = ["**/__pycache__", "docs/_build"]
 
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,11 @@ pyproject-build = "build.__main__:entrypoint"
 [project.entry-points."pipx.run"]
 build = "build.__main__:entrypoint"
 
+[tool.flit.sdist]
+include = ["tests/", ".gitignore", "CHANGELOG.rst", "docs/", ".dockerignore", "tox.ini"]
+exclude = ["tests/__pycache__", "docs/_build"]
+
+
 [tool.coverage.run]
 source = [
   "build",


### PR DESCRIPTION
Building with build isn't the same as building with flit, due to flit-core not behaving the same when using standardized tools. :(

This adds all the files in the git repo, just like building with flit would. I've used check-sdist to do so, but haven't added it as a pre-commit check (yet).

Closes #656.
