### PR TITLE
docs: bump furo/sphinx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,8 @@ dependencies = [
 
 [project.optional-dependencies]
 docs = [
-  "furo >= 2021.08.31",
-  "sphinx ~= 6.0",
+  "furo >= 2023.08.17",
+  "sphinx ~= 7.0",
   "sphinx-argparse-cli >= 1.5",
   "sphinx-autodoc-typehints >= 1.10",
   "sphinx-issues >= 3.0.0",


### PR DESCRIPTION
@pradyunsg's furo is broken with Sphinx 6. I don't like requiring a week-old version of something (furo), but that's the only releases compatible with Sphinx 7. I think I like requiring a very recent Furo better than capping Furo, but I'm open to suggestions, just trying to restore our CI, which has been broken for days.