### PR TITLE
ci: build and test SDist/wheels

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,17 @@
+name: CD
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+  release:
+    types:
+      - published
+
+jobs:
+  dist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hynek/build-and-inspect-python-package@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,3 +171,8 @@ max-complexity = 10
 lines-between-types = 1
 lines-after-imports = 2
 known-first-party = ["build"]
+
+[tool.check-wheel-contents]
+ignore = [
+  "W005",  # We _are_ build
+]


### PR DESCRIPTION
The artifacts can be downloaded and released from the CI build.
