### PR TITLE
chore: add an easy way to bump the version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,3 +175,14 @@ lines-after-imports = 2
 ignore = [
   "W005",  # We _are_ build
 ]
+
+[tool.bumpversion]
+current_version = "1.0.0"
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search = 'version = "{current_version}"'
+
+[[tool.bumpversion.files]]
+filename = "src/build/__init__.py"
+search = "__version__ = '{current_version}'"

--- a/tox.ini
+++ b/tox.ini
@@ -111,7 +111,7 @@ depends =
 description = bump versions, pass major/minor/patch
 skip_install = true
 deps =
-    bump-my-version
+    bump-my-version >=0.10
 set_env =
 commands =
     bump-my-version bump {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -106,3 +106,12 @@ commands =
 depends =
     path
     {py312, py311, py310, py39, py38, py37, pypy39, pypy38, pypy37}{, -min}
+
+[testenv:bump]
+description = bump versions, pass major/minor/patch
+skip_install = true
+deps =
+    bump-my-version
+set_env =
+commands =
+    bump-my-version bump {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -111,7 +111,7 @@ depends =
 description = bump versions, pass major/minor/patch
 skip_install = true
 deps =
-    bump-my-version >=0.10
+    bump-my-version>=0.10
 set_env =
 commands =
     bump-my-version bump {posargs}


### PR DESCRIPTION
This seems to be the replacement for the unmaintained bump2version, which is a fork of the unmaintained bumpversion...

