### PR TITLE
chore: bump to 1.0.1.post1 since 1.0.1 seems to be taken

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "build"
-version = "1.0.1"
+version = "1.0.1.post1"
 description = "A simple, correct Python build frontend"
 readme = "README.md"
 requires-python = ">= 3.7"

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -7,7 +7,7 @@ build - A simple, correct PEP 517 build frontend
 from __future__ import annotations
 
 
-__version__ = '1.0.1'
+__version__ = '1.0.1.post1'
 
 import contextlib
 import difflib


### PR DESCRIPTION
It seems there was a previous build 1.0.1 release. Without knowing what files the old project had, we are kind of stuck in this try, try again game.

Another good reason to move to CalVer, IMO. :)
