### PR TITLE
Build in pip-less environments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ urls.changelog = "https://pypa-build.readthedocs.io/en/stable/changelog.html"
 dependencies = [
   "packaging >= 19.0",
   "pyproject_hooks",
+  "pip>=22.3",
   # not actually a runtime dependency, only supplied as there is not "recommended dependency" support
   'colorama; os_name == "nt"',
   'importlib-metadata >= 4.6; python_version < "3.10"',  # Not required for 3.8+, but fixes a stdlib bug


### PR DESCRIPTION
Hi! Here is a little idea to improve performance and simplify a couple of things.

Since 22.3, pip has as `--python` option which lets it manage a different environment than the one it is installed in.

So if `build` depends on `pip` it can control the minimum pip version that is installed with it.
It can then create build environments without pip for better performance, and use the pip version from its own environment to manage them.

What do you think?