### PR TITLE
fix: switch to ruff-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.2
+    rev: v0.1.3
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,20 +16,15 @@ repos:
       - id: debug-statements
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: double-quote-string-fixer
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.15
     hooks:
       - id: validate-pyproject
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.10.1
-    hooks:
-      - id: black
   - repo: https://github.com/asottile/blacken-docs
     rev: 1.16.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==23.7.0]
+        additional_dependencies: [black==23.*]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v3.0.3"
     hooks:
@@ -39,6 +34,7 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]
+      - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
     rev: "v2.2.6"
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,9 @@ skip-string-normalization = true
 src = ["src"]
 line-length = 127
 
+[tool.ruff.format]
+quote-style = "single"
+
 [tool.ruff.lint]
 exclude = ["tests/packages/test-bad-syntax"]
 extend-select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,10 +140,6 @@ module = [
 ]
 ignore_missing_imports = true
 
-[tool.black]
-line-length = 127
-skip-string-normalization = true
-
 [tool.ruff]
 src = ["src"]
 line-length = 127

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -263,7 +263,7 @@ def main_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=textwrap.indent(
             textwrap.dedent(
-                '''
+                """
                 A simple, correct Python build frontend.
 
                 By default, a source distribution (sdist) is built from {srcdir}
@@ -275,7 +275,7 @@ def main_parser() -> argparse.ArgumentParser:
                 If you do this, the default behavior will be disabled, and all
                 artifacts will be built from {srcdir} (even if you combine
                 -w/--wheel with -s/--sdist, the wheel will be built from {srcdir}).
-                '''
+                """
             ).strip(),
             '    ',
         ),

--- a/src/build/_exceptions.py
+++ b/src/build/_exceptions.py
@@ -20,8 +20,11 @@ class BuildBackendException(Exception):
         self,
         exception: Exception,
         description: str | None = None,
-        exc_info: tuple[type[BaseException], BaseException, types.TracebackType]
-        | tuple[None, None, None] = (None, None, None),
+        exc_info: tuple[type[BaseException], BaseException, types.TracebackType] | tuple[None, None, None] = (
+            None,
+            None,
+            None,
+        ),
     ) -> None:
         super().__init__()
         self.exception = exception

--- a/tests/packages/test-metadata/backend.py
+++ b/tests/packages/test-metadata/backend.py
@@ -24,12 +24,12 @@ def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
     distinfo.mkdir(parents=True, exist_ok=True)
     distinfo.joinpath('METADATA').write_text(
         textwrap.dedent(
-            f'''
+            f"""
             Metadata-Version: 2.2
             Name: {metadata['project']['name']}
             Version: {metadata['project']['version']}
             Summary: {metadata['project']['description']}
-            '''
+            """
         ).strip()
     )
     return distinfo.name

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -431,7 +431,7 @@ def test_venv_fail(monkeypatch, package_test_flit, tmp_dir, capsys):
 
     assert (
         stdout
-        == '''\
+        == """\
 * Creating venv isolated environment...
 ERROR Failed to create venv. Maybe try installing virtualenv.
   Command 'test args' failed with return code 1
@@ -439,6 +439,6 @@ ERROR Failed to create venv. Maybe try installing virtualenv.
     stdoutput
   stderr:
     stderror
-'''
+"""
     )
     assert stderr == ''

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -383,7 +383,7 @@ def test_build_with_dep_on_console_script(tmp_path, demo_pkg_inline, capfd, mock
     # to validate backend invocations contain the correct path we use an inline backend that will fail, but first
     # provides the PATH information (and validates shutil.which is able to discover the executable - as PEP states)
     toml = textwrap.dedent(
-        '''
+        """
         [build-system]
         requires = ["demo_pkg_inline"]
         build-backend = "build"
@@ -392,17 +392,17 @@ def test_build_with_dep_on_console_script(tmp_path, demo_pkg_inline, capfd, mock
         [project]
         description = "Factory ⸻ A code generator 🏭"
         authors = [{name = "Łukasz Langa"}]
-        '''
+        """
     )
     code = textwrap.dedent(
-        '''
+        """
         import os
         import shutil
         import sys
         print("BB " + os.environ["PATH"])
         exe_at = shutil.which("demo-pkg-inline")
         print("BB " + exe_at)
-        '''
+        """
     )
     (tmp_path / 'pyproject.toml').write_text(toml, encoding='UTF-8')
     (tmp_path / 'build.py').write_text(code, encoding='utf-8')


### PR DESCRIPTION
This is 30x faster than black, drops a dependency, and supports single quotes as a setting.

See https://astral.sh/blog/the-ruff-formatter & https://github.com/scientific-python/cookie/pull/299.
