### PR TITLE
Fix Ruff `test-bad-syntax` exclusion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,10 +146,10 @@ skip-string-normalization = true
 
 [tool.ruff]
 src = ["src"]
+exclude = ["tests/packages/test-bad-syntax"]
 line-length = 127
 
 [tool.ruff.lint]
-exclude = ["tests/packages/test-bad-syntax"]
 extend-select = [
   "B",    # flake8-bugbear
   "C4",   # flake8-comprehensions


### PR DESCRIPTION
This PR fixes `ruff check .` which started failing with after moving the `exclude` to `[ruff.lint]`

```
ruff failed
  Cause: TOML parse error at line 2, column 19
  |
2 | requires = ['bad' 'syntax']
  |                   ^
invalid array
expected `]`
```

`ruff.exclude` and `ruff.lint.exclude` have slightly different semantics: 

* `ruff.exclude`: Excludes files from your project, so that ruff skips them for all commands. This also prevents ruff from loading configuration files in excluded directories. 
* `ruff.lint.exclude`: Excludes files from linting only. However, ruff loads the files (and related configurations).

You want `ruff.lint.exclude` to avoid the intentionally malformed configuration. 

Question: Could we improve our documentation to make this distinction more clear?

## Test Plan

`ruff check .` no longer fails because of the malformed configuration.