### PR TITLE
chore: use exclude_also for coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,8 +89,7 @@ source = [
 ]
 
 [tool.coverage.report]
-exclude_lines = [
-  '\#\s*pragma: no cover',
+exclude_also = [
   '^\s*raise NotImplementedError\b',
   "if typing.TYPE_CHECKING:",
 ]


### PR DESCRIPTION
This is now recommended (since February), based on the PythonBytes mention today.
