### PR TITLE
feat: quote installed dependencies

### DIFF
--- a/src/build/env.py
+++ b/src/build/env.py
@@ -123,7 +123,7 @@ class DefaultIsolatedEnv(IsolatedEnv):
         if not requirements:
             return
 
-        self.log(f'Installing packages in isolated environment... ({", ".join(sorted(requirements))})')
+        self.log(f'Installing packages in isolated environment... ({", ".join(_quote_text(req) for req in sorted(requirements))})')
 
         # pip does not honour environment markers in command line arguments
         # but it does for requirements from a file
@@ -159,6 +159,15 @@ class DefaultIsolatedEnv(IsolatedEnv):
         else:
             _logger.log(logging.INFO, message)
 
+
+def _quote_text(text: str) -> str:
+    """Quote text for log message
+    
+    This method is a workaround for getting quotes in the nested f-string prior to Python 3.12
+    
+    :param text: Text to quote
+    """
+    return f'"{text}"' 
 
 def _create_isolated_env_virtualenv(path: str) -> tuple[str, str]:
     """

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -162,12 +162,12 @@ class DefaultIsolatedEnv(IsolatedEnv):
 
 def _quote_text(text: str) -> str:
     """Quote text for log message
-    
+
     This method is a workaround for getting quotes in the nested f-string prior to Python 3.12
-    
+
     :param text: Text to quote
     """
-    return f'"{text}"' 
+    return f'"{text}"'
 
 def _create_isolated_env_virtualenv(path: str) -> tuple[str, str]:
     """

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -123,7 +123,9 @@ class DefaultIsolatedEnv(IsolatedEnv):
         if not requirements:
             return
 
-        self.log(f'Installing packages in isolated environment... ({", ".join(_quote_text(req) for req in sorted(requirements))})')
+        self.log(
+            f'Installing packages in isolated environment... ({", ".join(_quote_text(req) for req in sorted(requirements))})'
+        )
 
         # pip does not honour environment markers in command line arguments
         # but it does for requirements from a file
@@ -168,6 +170,7 @@ def _quote_text(text: str) -> str:
     :param text: Text to quote
     """
     return f'"{text}"'
+
 
 def _create_isolated_env_virtualenv(path: str) -> tuple[str, str]:
     """

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -112,7 +112,7 @@ def test_isolated_env_log(mocker, caplog, package_test_flit):
     assert [(record.levelname, record.message) for record in caplog.records] == [
         ('INFO', 'something'),
         ('INFO', 'Creating venv isolated environment...'),
-        ('INFO', 'Installing packages in isolated environment... (something)'),
+        ('INFO', 'Installing packages in isolated environment... ("something")'),
     ]
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,6 +14,7 @@ import pytest
 import build
 import build.__main__
 
+
 build_open_owner = 'builtins'
 
 cwd = os.getcwd()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,7 +14,6 @@ import pytest
 import build
 import build.__main__
 
-
 build_open_owner = 'builtins'
 
 cwd = os.getcwd()
@@ -230,14 +229,14 @@ def test_build_package_via_sdist_invalid_distribution(tmp_dir, package_test_setu
             [],
             [
                 '* Creating venv isolated environment...',
-                '* Installing packages in isolated environment... (setuptools >= 42.0.0, wheel >= 0.36.0)',
+                '* Installing packages in isolated environment... ("setuptools >= 42.0.0", "wheel >= 0.36.0")',
                 '* Getting build dependencies for sdist...',
                 '* Building sdist...',
                 '* Building wheel from sdist',
                 '* Creating venv isolated environment...',
-                '* Installing packages in isolated environment... (setuptools >= 42.0.0, wheel >= 0.36.0)',
+                '* Installing packages in isolated environment... ("setuptools >= 42.0.0", "wheel >= 0.36.0")',
                 '* Getting build dependencies for wheel...',
-                '* Installing packages in isolated environment... (wheel)',
+                '* Installing packages in isolated environment... ("wheel")',
                 '* Building wheel...',
                 'Successfully built test_setuptools-1.0.0.tar.gz and test_setuptools-1.0.0-py2.py3-none-any.whl',
             ],
@@ -260,9 +259,9 @@ def test_build_package_via_sdist_invalid_distribution(tmp_dir, package_test_setu
             ['--wheel'],
             [
                 '* Creating venv isolated environment...',
-                '* Installing packages in isolated environment... (setuptools >= 42.0.0, wheel >= 0.36.0)',
+                '* Installing packages in isolated environment... ("setuptools >= 42.0.0", "wheel >= 0.36.0")',
                 '* Getting build dependencies for wheel...',
-                '* Installing packages in isolated environment... (wheel)',
+                '* Installing packages in isolated environment... ("wheel")',
                 '* Building wheel...',
                 'Successfully built test_setuptools-1.0.0-py2.py3-none-any.whl',
             ],
@@ -324,7 +323,7 @@ def main_reload_styles():
             'ERROR ',
             [
                 '* Creating venv isolated environment...',
-                '* Installing packages in isolated environment... (setuptools >= 42.0.0, this is invalid, wheel >= 0.36.0)',
+                '* Installing packages in isolated environment... ("setuptools >= 42.0.0", "this is invalid", "wheel >= 0.36.0")',
                 '',
                 'Traceback (most recent call last):',
             ],
@@ -335,7 +334,7 @@ def main_reload_styles():
             [
                 '\33[1m* Creating venv isolated environment...\33[0m',
                 '\33[1m* Installing packages in isolated environment... '
-                '(setuptools >= 42.0.0, this is invalid, wheel >= 0.36.0)\33[0m',
+                '("setuptools >= 42.0.0", "this is invalid", "wheel >= 0.36.0")\33[0m',
                 '',
                 '\33[2mTraceback (most recent call last):',
             ],


### PR DESCRIPTION
Implements quoted dependencies as requested in #617. This reduces the confusion around commas used to separate the dependencies and commas used in version specifiers.

**Changes**
* Quote the installed dependencies
* Update tests to reflect the new output

**Old output**
```
* Installing packages in isolated environment... (setuptools >= 42.0.0, wheel >= 0.36.0)
```
**New output**
```
* Installing packages in isolated environment... ("setuptools >= 42.0.0", "wheel >= 0.36.0")
```