### PR TITLE
Stop injecting `wheel` as a build dep fallback

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog
 +++++++++
 
+
+next release
+============
+
+- Stopped injecting ``wheel`` as a build dependency automatically, in the
+  case of missing ``pyproject.toml`` -- by :user:`webknjaz`.
+  (:pr:`716`)
+
+
 1.0.3 (2023-09-06)
 ==================
 

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -49,7 +49,7 @@ _TProjectBuilder = TypeVar('_TProjectBuilder', bound='ProjectBuilder')
 
 _DEFAULT_BACKEND = {
     'build-backend': 'setuptools.build_meta:__legacy__',
-    'requires': ['setuptools >= 40.8.0', 'wheel'],
+    'requires': ['setuptools >= 40.8.0'],
 }
 
 

--- a/tests/packages/test-invalid-requirements/pyproject.toml
+++ b/tests/packages/test-invalid-requirements/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ['setuptools >= 42.0.0', 'wheel >= 0.36.0', 'this is invalid']
+requires = ['setuptools >= 42.0.0', 'this is invalid']
 build-backend = 'setuptools.build_meta'

--- a/tests/packages/test-no-prepare/pyproject.toml
+++ b/tests/packages/test-no-prepare/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
 build-backend = 'backend_no_prepare'
 backend-path = ['.']
-requires = ['setuptools >= 42.0.0', 'wheel >= 0.36.0']
+requires = ['setuptools >= 42.0.0']

--- a/tests/packages/test-setuptools/pyproject.toml
+++ b/tests/packages/test-setuptools/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ['setuptools >= 42.0.0', 'wheel >= 0.36.0']
+requires = ['setuptools >= 42.0.0']
 build-backend = 'setuptools.build_meta'

--- a/tests/packages/test-typo/pyproject.toml
+++ b/tests/packages/test-typo/pyproject.toml
@@ -1,3 +1,3 @@
 [build_sytem]
-requires = ['setuptools >= 40.8.0', 'wheel']
+requires = ['setuptools >= 40.8.0']
 build-backend = 'setuptools.build_meta'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -230,12 +230,12 @@ def test_build_package_via_sdist_invalid_distribution(tmp_dir, package_test_setu
             [],
             [
                 '* Creating venv isolated environment...',
-                '* Installing packages in isolated environment... (setuptools >= 42.0.0, wheel >= 0.36.0)',
+                '* Installing packages in isolated environment... (setuptools >= 42.0.0)',
                 '* Getting build dependencies for sdist...',
                 '* Building sdist...',
                 '* Building wheel from sdist',
                 '* Creating venv isolated environment...',
-                '* Installing packages in isolated environment... (setuptools >= 42.0.0, wheel >= 0.36.0)',
+                '* Installing packages in isolated environment... (setuptools >= 42.0.0)',
                 '* Getting build dependencies for wheel...',
                 '* Installing packages in isolated environment... (wheel)',
                 '* Building wheel...',
@@ -260,7 +260,7 @@ def test_build_package_via_sdist_invalid_distribution(tmp_dir, package_test_setu
             ['--wheel'],
             [
                 '* Creating venv isolated environment...',
-                '* Installing packages in isolated environment... (setuptools >= 42.0.0, wheel >= 0.36.0)',
+                '* Installing packages in isolated environment... (setuptools >= 42.0.0)',
                 '* Getting build dependencies for wheel...',
                 '* Installing packages in isolated environment... (wheel)',
                 '* Building wheel...',
@@ -324,7 +324,7 @@ def main_reload_styles():
             'ERROR ',
             [
                 '* Creating venv isolated environment...',
-                '* Installing packages in isolated environment... (setuptools >= 42.0.0, this is invalid, wheel >= 0.36.0)',
+                '* Installing packages in isolated environment... (setuptools >= 42.0.0, this is invalid)',
                 '',
                 'Traceback (most recent call last):',
             ],
@@ -334,8 +334,7 @@ def main_reload_styles():
             '\33[91mERROR\33[0m ',
             [
                 '\33[1m* Creating venv isolated environment...\33[0m',
-                '\33[1m* Installing packages in isolated environment... '
-                '(setuptools >= 42.0.0, this is invalid, wheel >= 0.36.0)\33[0m',
+                '\33[1m* Installing packages in isolated environment... (setuptools >= 42.0.0, this is invalid)\33[0m',
                 '',
                 '\33[2mTraceback (most recent call last):',
             ],

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -21,7 +21,7 @@ build_open_owner = 'builtins'
 
 DEFAULT_BACKEND = {
     'build-backend': 'setuptools.build_meta:__legacy__',
-    'requires': ['setuptools >= 40.8.0', 'wheel'],
+    'requires': ['setuptools >= 40.8.0'],
 }
 
 


### PR DESCRIPTION
PEP 517 doesn't mandate depending on `wheel` when a `__legacy__` setuptools fallback is used. Historically, it used to be assumed as necessary, but later it turned out to be wrong. The reason is that `setuptools`' `get_requires_for_build_wheel()` hook already injects this dependency when building wheels is requested [[1]]. It also used to have this hint in the docs, but it was corrected earlier [[2]].

This patch removes `wheel` from said `requires` list fallback.

[1]: https://github.com/pypa/setuptools/blob/v40.8.0/setuptools/build_meta.py#L130
[2]: https://github.com/pypa/setuptools/pull/3056