### PR TITLE
ci: reduce frequency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "0 8 * * *"
+    - cron: "0 8 * * 1"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Our CI has been broken for over four months, and it wasn't obvious even though we were running scheduled jobs _daily_. This changes it to weekly. Might be worth pointing out that anyone making a PR with failing CI should check the last scheduled run before worrying about it.
