### PR TITLE
feat: use external pip if available

### DIFF
--- a/src/build/env.py
+++ b/src/build/env.py
@@ -70,7 +70,7 @@ def _minimum_pip_version() -> str:
     return '19.1.0'
 
 
-def _has_valid_pip(**distargs: str) -> bool:
+def _has_valid_pip(**distargs: object) -> bool:
     """
     Given a path, see if Pip is present and return True if the version is
     sufficient for build, False if it is not.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,11 @@ def is_integration(item):
     return os.path.basename(item.location[0]) == 'test_integration.py'
 
 
+@pytest.fixture()
+def local_pip(monkeypatch):
+    monkeypatch.setattr(build.env, '_valid_global_pip', lambda: None)
+
+
 @pytest.fixture(scope='session', autouse=True)
 def ensure_syconfig_vars_created():
     # the config vars are globally cached and may use get_path, make sure they are created

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -26,6 +26,7 @@ def test_isolation():
 
 
 @pytest.mark.isolated
+@pytest.mark.usefixtures('local_pip')
 def test_isolated_environment_install(mocker):
     with build.env.DefaultIsolatedEnv() as env:
         mocker.patch('build.env._subprocess')
@@ -117,6 +118,7 @@ def test_isolated_env_log(mocker, caplog, package_test_flit):
 
 
 @pytest.mark.isolated
+@pytest.mark.usefixtures('local_pip')
 def test_default_pip_is_never_too_old():
     with build.env.DefaultIsolatedEnv() as env:
         version = subprocess.check_output(
@@ -130,6 +132,7 @@ def test_default_pip_is_never_too_old():
 @pytest.mark.isolated
 @pytest.mark.parametrize('pip_version', ['20.2.0', '20.3.0', '21.0.0', '21.0.1'])
 @pytest.mark.parametrize('arch', ['x86_64', 'arm64'])
+@pytest.mark.usefixtures('local_pip')
 def test_pip_needs_upgrade_mac_os_11(mocker, pip_version, arch):
     SimpleNamespace = collections.namedtuple('SimpleNamespace', 'version')
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -140,8 +140,7 @@ def test_pip_needs_upgrade_mac_os_11(mocker, pip_version, arch):
     mocker.patch('platform.system', return_value='Darwin')
     mocker.patch('platform.machine', return_value=arch)
     mocker.patch('platform.mac_ver', return_value=('11.0', ('', '', ''), ''))
-    metadata_name = 'importlib_metadata' if sys.version_info < (3, 8) else 'importlib.metadata'
-    mocker.patch(metadata_name + '.distributions', return_value=(SimpleNamespace(version=pip_version),))
+    mocker.patch('build._importlib.metadata.distributions', return_value=(SimpleNamespace(version=pip_version),))
 
     min_version = Version('20.3' if arch == 'x86_64' else '21.0.1')
     with build.env.DefaultIsolatedEnv():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -342,6 +342,7 @@ def main_reload_styles():
     ],
     ids=['no-color', 'color'],
 )
+@pytest.mark.usefixtures('local_pip')
 def test_output_env_subprocess_error(
     mocker,
     monkeypatch,


### PR DESCRIPTION
Trying #733 out. Pip is used if it is in the same environment as build and new enough. Saves a bit of time setting up the venvs. Haven't worked on tests yet.

From quick testing building both an sdist and wheel for itself with virtualenv installed this goes from about 4.7 seconds to 3.2 seconds. With `venv` only, it goes from 10.5 seconds to 4.4 seconds.

FYI, with `uv` (hacked in) it took 2.36 secs.

(This is a very simple build, of course, with only a small handful of deps)

uv's experimental native build support took 571ms, but that's only building the wheel (above is SDist and wheel).