### PR TITLE
fix: support invalid folders in cwd

### DIFF
--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -6,15 +6,20 @@ build - A simple, correct PEP 517 build frontend
 
 from __future__ import annotations
 
+import os
+import sys
 
-__version__ = '1.0.3'
+
+# Remove '' and current working directory from the first entry
+# of sys.path, if present to avoid using current directory
+if sys.path[0] in ('', os.getcwd()):
+    sys.path.pop(0)
+
 
 import contextlib
 import difflib
 import logging
-import os
 import subprocess
-import sys
 import warnings
 import zipfile
 
@@ -33,6 +38,9 @@ from ._exceptions import (
     TypoWarning,
 )
 from ._util import check_dependency, parse_wheel_filename
+
+
+__version__ = '1.0.3'
 
 
 RunnerType = Callable[[Sequence[str], Optional[str], Optional[Mapping[str, str]]], None]


### PR DESCRIPTION
Noticed in https://github.com/astral-sh/uv/issues/1972. Fix pulled from Pip, but putting it in `__main__.py` doesn't seem to be working - runpy seems to load `__init__.py` before `__main__.py`. This affects `python -m venv` too, so not sure we can do much about it.

Placing this at the top of `__init__.py` does fix the problem, though. I think `pipx run build` would still be broken since that breaks before getting to build.

`pyproject-build` and `PYTHONSAFEPATH=1 python -m build` (3.11+) both work fine as is.

To reproduce, clone `mihalikv/improved-umbrella` and switch to the `nested_lib` dir and try to build.


