### PR TITLE
perf: avoid compiling unused bytecode

### DIFF
--- a/src/build/env.py
+++ b/src/build/env.py
@@ -261,6 +261,7 @@ class _PipBackend(_EnvBackend):
                 'install',
                 '--use-pep517',
                 '--no-warn-script-location',
+                '--no-compile',
                 '-r',
                 os.path.abspath(req_file.name),
             ]

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -197,6 +197,7 @@ def test_default_impl_install_cmd_well_formed(
                 'install',
                 '--use-pep517',
                 '--no-warn-script-location',
+                '--no-compile',
                 '-r',
                 mocker.ANY,
             ]


### PR DESCRIPTION
Compiling bytecode is supposed to make usage more consistent for interaction. But it compiles everything, which isn't required for a single use non-interactive temporary environment. We can potentially save a bit of time this way.

This will need to be skipped for the uv backend in #751, since uv defaults to not compiling bytecode, and instead requires a flag to do so (most recent version). But flags aren't identical anyway.
