### PR TITLE
ci: macos-latest now points at macos-14

### DIFF
--- a/.github/workflows/reusable-pytest.yml
+++ b/.github/workflows/reusable-pytest.yml
@@ -11,9 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu
-          - macos
-          - windows
+          - ubuntu-latest
+          - macos-13
+          - windows-latest
         py:
           - "pypy-3.8"
           - "pypy-3.9"
@@ -26,12 +26,19 @@ jobs:
         tox-target:
           - "tox"
           - "min"
+        include:
+          - os: macos-14
+            py: "3.10"
+            tox-target: "tox"
+          - os: macos-14
+            py: "3.12"
+            tox-target: "tox"
 
     continue-on-error: >- # jobs not required in branch protection
       ${{
         (
           startsWith(matrix.py, 'pypy-')
-          && matrix.os == 'windows'
+          && matrix.os == 'windows-latest'
         )
         && true
         || false
@@ -67,7 +74,7 @@ jobs:
       - name: Setup python for tox
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.10
 
       - name: Install tox
         run: python -m pip install tox


### PR DESCRIPTION
ARM is fine, no Python 3.8-3.9 is not.