### PR TITLE
ci: publish artifact attestation and PyPI packages

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,4 +14,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: hynek/build-and-inspect-python-package@v2
+
+  publish:
+    needs: [dist]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    environment:
+      name: pypi
+      url: https://pypi.org/p/build
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+
+      - name: Generate artifact attestation for sdist and wheel
+        uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
+        with:
+          subject-path: "dist/build-*"
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,7 +27,6 @@ jobs:
     permissions:
       id-token: write
       attestations: write
-      contents: read
 
     steps:
       - uses: actions/download-artifact@v4

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,10 +9,17 @@ Installation
    $ pip install build
 
 You can also check out the latest `git tag`_, download a tarball_ from GitHub, or
-manually fetch the artifacts from the `project page`_ on PyPI. The git tags are
-recommended for redistribution and are PGP-signed with one of the following keys:
+manually fetch the artifacts from the `project page`_ on PyPI. `Attestations
+<https://github.com/pypa/build/attestations>`_ are available after 1.2.1 and
+can be verified with the ``gh`` CLI tool:
 
-- |3DCE51D60930EBA47858BA4146F633CBB0EB4BF2|_ *(Filipe Laíns)*
+.. code-block:: sh
+
+   $ python -m pip --no-cache-dir download --no-deps build
+   $ gh attestation verify build*.whl --repo pypa/build
+
+Build plans to support `PEP 740 <https://peps.python.org/pep-0740>`_ if
+accepted.
 
 .. tip::
    If you prefer, or are already using virtualenv_ in your workflow, you can
@@ -27,6 +34,9 @@ recommended for redistribution and are PGP-signed with one of the following keys
    that rely on virtualenv_, such as tox_, or when your operating system's
    Python package does not include venv_ in the standard installation (such as
    some versions of Ubuntu).
+
+   There is also a ``uv`` extra, which can be used for ``--installer=uv`` if
+   you don't have another install of ``uv`` available.
 
 Bootstrapping
 =============

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -2,26 +2,20 @@
 Release Process
 ***************
 
-As this project is critical to the Python ecosystem's supply chain security, all
-releases are PGP signed with one of the keys listed in the :doc:`installation page <installation>`.
-Before releasing please make sure your PGP key is listed there, and preferably
-signed by one of the other key holders. If your key is not signed by one of the
-other key holders, please make sure the PR that added your key to the
-:doc:`installation page <installation>` was approved by at least one other maintainer.
+You may release the project by following these steps:
 
-After that is done, you may release the project by following these steps:
-
-#. Bump the versions in ``pyproject.toml`` and ``src/build/__init__.py``
+#. Bump the version ``src/build/__init__.py``
 #. Update ``CHANGELOG.rst`` with the new version and current date
 #. Make a release commit with the changes made above
     - The commit message should follow the ``release X.Y.Z`` format
-#. Make a signed tag (``git tag -s X.Y.Z``)
+#. Make a signed tag (``git tag --sign X.Y.Z``)
     - The tag title should follow the ``build X.Y.Z`` format
     - The tag body should be a plaintext version of the changelog for the current
       release
 #. Push the commit and tag to the repository (``git push`` and ``git push --tags``)
-#. Build the Python artifacts (``python -m build``)
-#. Sign and push the artifacts to PyPI (``twine upload -s dist/*``)
+#. Download the built release from GitHub Actions
+#. Generate a token for uploading to PyPI
+#. Push the artifacts to PyPI (``twine upload -s dist/*``)
 
 If you have any questions, please look at previous releases and/or ping the
 other maintainers.

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -13,9 +13,8 @@ You may release the project by following these steps:
     - The tag body should be a plaintext version of the changelog for the current
       release
 #. Push the commit and tag to the repository (``git push`` and ``git push --tags``)
-#. Download the built release from GitHub Actions
-#. Generate a token for uploading to PyPI
-#. Push the artifacts to PyPI (``twine upload -s dist/*``)
+#. Make a release on GitHub or with the ``gh`` CLI tool. Copy the release notes
+   into the release.
 
 If you have any questions, please look at previous releases and/or ping the
 other maintainers.


### PR DESCRIPTION
This adds Trusted Publisher based PyPI publishing and GitHub Artifact Attestations for the binaries, which can be queried from GitHub after publishing at https://github.com/pypa/build/attestations. Not supported on PyPI yet, [PEP 740](https://peps.python.org/pep-0740/) will add support.

Replaces https://github.com/pypa/build/pull/759. Needs setup on PyPI (which I can do if we think this is a good idea).

WDYT?


- https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/
- https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
- PEP 740