### PR TITLE
tests: mark more network tests

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -67,6 +67,7 @@ def get_project(name, tmp_path):
     return dest / f'{name}-{version}'
 
 
+@pytest.mark.network
 @pytest.mark.parametrize(
     'call',
     [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -439,6 +439,7 @@ ERROR Failed to create venv. Maybe try installing virtualenv.
     )
 
 
+@pytest.mark.network
 @pytest.mark.parametrize('verbosity', [0, 1])
 def test_verbose_output(
     capsys: pytest.CaptureFixture,


### PR DESCRIPTION
The tests test_build and test_verbose_output both fail when run without a network connection, so mark them appropriately.