### PR TITLE
ci: remove bot comments from generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci


### PR DESCRIPTION
The autogenerated summary is handy for preparing the release notes, but it includes a lot of bot PRs. This filters them.
