### PR TITLE
tests: avoid pyproject-hooks 1.2 on tests for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ test = [
   'setuptools >= 56.0.0; python_version == "3.10"',
   'setuptools >= 56.0.0; python_version == "3.11"',
   'setuptools >= 67.8.0; python_version >= "3.12"',
+  'pyproject_hooks!=1.2.0; python_version < "3.10"',
 ]
 typing = [
   "build[uv]",


### PR DESCRIPTION
This is a very specific issue, and I think eliminating 1.2.0 from the full requirements will have more fallout than the bug does. We can add a note for users. Needed for #820 to pass. See https://github.com/pypa/pyproject-hooks/issues/206.
