### PR TITLE
tests: fix  under pyproject-hooks 1.2

### DIFF
--- a/tests/packages/test-no-prepare/backend_no_prepare.py
+++ b/tests/packages/test-no-prepare/backend_no_prepare.py
@@ -1,4 +1,25 @@
 # SPDX-License-Identifier: MIT
 
-from setuptools.build_meta import build_sdist as build_sdist
-from setuptools.build_meta import build_wheel as build_wheel
+
+def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+    import os.path
+    import zipfile
+
+    from build._compat import tomllib
+
+    with open('pyproject.toml', 'rb') as f:
+        metadata = tomllib.load(f)
+
+    wheel_basename = f"{metadata['project']['name'].replace('-', '_')}-{metadata['project']['version']}"
+    with zipfile.ZipFile(os.path.join(wheel_directory, f'{wheel_basename}-py3-none-any.whl'), 'w') as wheel:
+        wheel.writestr(
+            f'{wheel_basename}.dist-info/METADATA',
+            f"""\
+Metadata-Version: 2.2
+Name: {metadata['project']['name']}
+Version: {metadata['project']['version']}
+Summary: {metadata['project']['description']}
+""",
+        )
+
+    return wheel.filename

--- a/tests/packages/test-no-prepare/pyproject.toml
+++ b/tests/packages/test-no-prepare/pyproject.toml
@@ -1,4 +1,9 @@
 [build-system]
 build-backend = 'backend_no_prepare'
 backend-path = ['.']
-requires = ['setuptools >= 42.0.0']
+requires = []
+
+[project]
+name = "test-no-prepare"
+version = "1.0.0"
+description = "Test extracting metadata from a backend w/out `prepare_metadata_for_build_wheel` hook"

--- a/tests/packages/test-no-prepare/setup.cfg
+++ b/tests/packages/test-no-prepare/setup.cfg
@@ -1,3 +1,0 @@
-[metadata]
-name = test_no_prepare
-version = 1.0.0

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -504,8 +504,7 @@ def test_metadata_path_no_prepare(tmp_dir, package_test_no_prepare):
         pathlib.Path(builder.metadata_path(tmp_dir)),
     ).metadata
 
-    # Setuptools < v69.0.3 (https://github.com/pypa/setuptools/pull/4159) normalized this to dashes
-    assert metadata['name'].replace('-', '_') == 'test_no_prepare'
+    assert metadata['name'] == 'test-no-prepare'
     assert metadata['Version'] == '1.0.0'
 
 


### PR DESCRIPTION
By replacing setuptools with a bare-bones wheel builder.

Close #823.