### PR TITLE
Revert "tests: fix  under pyproject-hooks 1.2"

### DIFF
--- a/tests/packages/test-no-prepare/backend_no_prepare.py
+++ b/tests/packages/test-no-prepare/backend_no_prepare.py
@@ -1,25 +1,4 @@
 # SPDX-License-Identifier: MIT
 
-
-def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
-    import os.path
-    import zipfile
-
-    from build._compat import tomllib
-
-    with open('pyproject.toml', 'rb') as f:
-        metadata = tomllib.load(f)
-
-    wheel_basename = f"{metadata['project']['name'].replace('-', '_')}-{metadata['project']['version']}"
-    with zipfile.ZipFile(os.path.join(wheel_directory, f'{wheel_basename}-py3-none-any.whl'), 'w') as wheel:
-        wheel.writestr(
-            f'{wheel_basename}.dist-info/METADATA',
-            f"""\
-Metadata-Version: 2.2
-Name: {metadata['project']['name']}
-Version: {metadata['project']['version']}
-Summary: {metadata['project']['description']}
-""",
-        )
-
-    return wheel.filename
+from setuptools.build_meta import build_sdist as build_sdist
+from setuptools.build_meta import build_wheel as build_wheel

--- a/tests/packages/test-no-prepare/pyproject.toml
+++ b/tests/packages/test-no-prepare/pyproject.toml
@@ -1,9 +1,4 @@
 [build-system]
 build-backend = 'backend_no_prepare'
 backend-path = ['.']
-requires = []
-
-[project]
-name = "test-no-prepare"
-version = "1.0.0"
-description = "Test extracting metadata from a backend w/out `prepare_metadata_for_build_wheel` hook"
+requires = ['setuptools >= 42.0.0']

--- a/tests/packages/test-no-prepare/setup.cfg
+++ b/tests/packages/test-no-prepare/setup.cfg
@@ -1,0 +1,3 @@
+[metadata]
+name = test_no_prepare
+version = 1.0.0

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -504,7 +504,8 @@ def test_metadata_path_no_prepare(tmp_dir, package_test_no_prepare):
         pathlib.Path(builder.metadata_path(tmp_dir)),
     ).metadata
 
-    assert metadata['name'] == 'test-no-prepare'
+    # Setuptools < v69.0.3 (https://github.com/pypa/setuptools/pull/4159) normalized this to dashes
+    assert metadata['name'].replace('-', '_') == 'test_no_prepare'
     assert metadata['Version'] == '1.0.0'
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,8 @@ skip_missing_interpreters = true
 [testenv]
 description =
     run test suite with {basepython}
+deps =
+    setuptools@ https://github.com/abravalheri/setuptools/archive/refs/heads/issue-pyproject-hooks-206-take2.zip
 extras =
     test
 pass_env =


### PR DESCRIPTION
Reverts pypa/build#824

Testing fix in https://github.com/pypa/setuptools/pull/4680. See https://github.com/pypa/pyproject-hooks/issues/206.