### PR TITLE
ci: explicit attestations no longer required

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,5 +40,3 @@ jobs:
           subject-path: "dist/build-*"
 
       - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          attestations: true


### PR DESCRIPTION
This is now the default. (And they are now accepted on PyPI! Looks like post1 has the attestation https://pypi.org/project/build/#build-1.2.2.post1.tar.gz).