### PR TITLE
ci: bump version used to run tox

### DIFF
--- a/.github/workflows/reusable-pytest.yml
+++ b/.github/workflows/reusable-pytest.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Setup python for tox
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.12"
 
       - name: Install tox
         run: python -m pip install tox


### PR DESCRIPTION
Pulling this out of #738.