### PR TITLE
fix: disable use of `pip install --python` for debundled pip

### DIFF
--- a/src/build/env.py
+++ b/src/build/env.py
@@ -158,6 +158,12 @@ class _PipBackend(_EnvBackend):
         This checks for a valid global pip. Returns None if pip is missing, False
         if pip is too old, and True if it can be used.
         """
+        # `pip install --python` is nonfunctional on Gentoo debundled pip
+        try:
+            import pip._vendor
+        except ImportError:
+            return False
+
         # Version to have added the `--python` option.
         return _has_dependency('pip', '22.3')
 

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -166,7 +166,7 @@ class _PipBackend(_EnvBackend):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
             if importlib.util.find_spec('pip._vendor') is None:
-                return False
+                return False  # pragma: no cover
 
         # Version to have added the `--python` option.
         return _has_dependency('pip', '22.3')

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -159,9 +159,7 @@ class _PipBackend(_EnvBackend):
         if pip is too old, and True if it can be used.
         """
         # `pip install --python` is nonfunctional on Gentoo debundled pip
-        try:
-            import pip._vendor
-        except ImportError:
+        if importlib.util.find_spec("pip._vendor") is None:
             return False
 
         # Version to have added the `--python` option.

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -159,7 +159,7 @@ class _PipBackend(_EnvBackend):
         if pip is too old, and True if it can be used.
         """
         # `pip install --python` is nonfunctional on Gentoo debundled pip
-        if importlib.util.find_spec("pip._vendor") is None:
+        if importlib.util.find_spec('pip._vendor') is None:
             return False
 
         # Version to have added the `--python` option.

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -11,6 +11,7 @@ import sys
 import sysconfig
 import tempfile
 import typing
+import warnings
 
 from collections.abc import Collection, Mapping
 
@@ -158,9 +159,14 @@ class _PipBackend(_EnvBackend):
         This checks for a valid global pip. Returns None if pip is missing, False
         if pip is too old, and True if it can be used.
         """
-        # `pip install --python` is nonfunctional on Gentoo debundled pip
-        if importlib.util.find_spec('pip._vendor') is None:
-            return False
+        # `pip install --python` is nonfunctional on Gentoo debundled pip.
+        # Detect that by checking if pip._vendor` module exists.  However,
+        # searching for pip could yield warnings from _distutils_hack,
+        # so silence them.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            if importlib.util.find_spec('pip._vendor') is None:
+                return False
 
         # Version to have added the `--python` option.
         return _has_dependency('pip', '22.3')


### PR DESCRIPTION
In the debundled pip version distributed on Gentoo systems, `pip install --python` is nonfunctional since it expects all of pip's dependencies to be present in the (empty) virtual environment.  Detect this case by the removal of `pip._vendor` package, and use the "no valid outer pip" codepath.

Bug: https://bugs.gentoo.org/934922