### PR TITLE
tests: faster on 3.12+ and reduce warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,10 @@ source = [
   "build",
   "tests",
 ]
+disable_warnings = [
+  "module-not-measured",  # Triggers in multithreaded context on build
+  "no-sysmon",
+]
 
 [tool.coverage.report]
 exclude_also = [

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ pass_env =
     PYTEST_*
     TERM
 set_env =
+    COVERAGE_CORE = sysmon
     COVERAGE_FILE = {toxworkdir}/.coverage.{envname}
     PYPY3323BUG = 1
     PYTHONWARNDEFAULTENCODING = 1


### PR DESCRIPTION
This is about 40% faster on Python 3.12+ when collecting coverage[^1] (which we are always doing). It also gets rid of a multithreading warning about build already being imported but not measured.

[^1]: When running locally without the isolation testing, which dominates the CI time, in CI it only is a few seconds faster but still something.