### PR TITLE
chore: use dependency-groups

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,15 +1,12 @@
 version: 2
 
-sphinx:
-  configuration: docs/conf.py
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.10"
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements: [docs]
+    python: "3.12"
+  commands:
+    - asdf plugin add uv
+    - asdf install uv latest
+    - asdf global uv latest
+    - uv run --no-dev --group docs sphinx-build -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,5 @@
 version: 2
 
-
 build:
   os: ubuntu-22.04
   tools:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,36 +42,6 @@ dependencies = [
   'tomli >= 1.1.0; python_version < "3.11"',
 ]
 
-[project.optional-dependencies]
-docs = [
-  "furo >= 2023.08.17",
-  "sphinx ~= 7.0",
-  "sphinx-argparse-cli >= 1.5",
-  "sphinx-autodoc-typehints >= 1.10",
-  "sphinx-issues >= 3.0.0",
-]
-test = [
-  "build[uv, virtualenv]",
-  "filelock >= 3",
-  "pytest >= 6.2.4",
-  "pytest-cov >= 2.12",
-  "pytest-mock >= 2",
-  "pytest-rerunfailures >= 9.1",
-  "pytest-xdist >= 1.34",
-  "wheel >= 0.36.0",
-  'setuptools >= 42.0.0; python_version < "3.10"',
-  'setuptools >= 56.0.0; python_version == "3.10"',
-  'setuptools >= 56.0.0; python_version == "3.11"',
-  'setuptools >= 67.8.0; python_version >= "3.12"',
-  "setuptools_scm >= 6",
-]
-typing = [
-  "build[uv]",
-  "importlib-metadata >= 5.1",
-  "mypy ~= 1.15.0",
-  "tomli",
-  "typing-extensions >= 3.7.4.3",
-]
 uv = [
   "uv >= 0.1.18",
 ]
@@ -86,6 +56,42 @@ pyproject-build = "build.__main__:entrypoint"
 
 [project.entry-points."pipx.run"]
 build = "build.__main__:entrypoint"
+
+[dependency-groups]
+docs = [
+  "furo >= 2023.08.17",
+  "sphinx ~= 7.0",
+  "sphinx-argparse-cli >= 1.5",
+  "sphinx-autodoc-typehints >= 1.10",
+  "sphinx-issues >= 3.0.0",
+]
+test = [
+  "filelock >= 3",
+  "pytest >= 6.2.4",
+  "pytest-cov >= 2.12",
+  "pytest-mock >= 2",
+  "pytest-rerunfailures >= 9.1",
+  "pytest-xdist >= 1.34",
+  "virtualenv >= 20.0.35",
+  "wheel >= 0.36.0",
+  'setuptools >= 42.0.0; python_version < "3.10"',
+  'setuptools >= 56.0.0; python_version == "3.10"',
+  'setuptools >= 56.0.0; python_version == "3.11"',
+  'setuptools >= 67.8.0; python_version >= "3.12"',
+  "setuptools_scm >= 6",
+]
+typing = [
+  "importlib-metadata >= 5.1",
+  "mypy ~= 1.15.0",
+  "tomli",
+  "typing-extensions >= 3.7.4.3",
+  "uv >= 0.1.18",
+  "virtualenv >= 20.0.35",
+]
+dev = [
+  { include-group = "test" },
+  { include-group = "typing" },
+]
 
 [tool.flit.sdist]
 include = ["tests/", ".gitignore", "CHANGELOG.rst", "docs/", ".dockerignore", "tox.ini"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   'tomli >= 1.1.0; python_version < "3.11"',
 ]
 
+[project.optional-dependencies]
 uv = [
   "uv >= 0.1.18",
 ]
@@ -58,6 +59,10 @@ pyproject-build = "build.__main__:entrypoint"
 build = "build.__main__:entrypoint"
 
 [dependency-groups]
+extra = [
+  "uv >= 0.1.18",
+  "virtualenv >= 20.0.35",
+]
 docs = [
   "furo >= 2023.08.17",
   "sphinx ~= 7.0",
@@ -72,21 +77,20 @@ test = [
   "pytest-mock >= 2",
   "pytest-rerunfailures >= 9.1",
   "pytest-xdist >= 1.34",
-  "virtualenv >= 20.0.35",
   "wheel >= 0.36.0",
   'setuptools >= 42.0.0; python_version < "3.10"',
   'setuptools >= 56.0.0; python_version == "3.10"',
   'setuptools >= 56.0.0; python_version == "3.11"',
   'setuptools >= 67.8.0; python_version >= "3.12"',
   "setuptools_scm >= 6",
+  { include-group = "extra" },
 ]
 typing = [
   "importlib-metadata >= 5.1",
   "mypy ~= 1.15.0",
   "tomli",
   "typing-extensions >= 3.7.4.3",
-  "uv >= 0.1.18",
-  "virtualenv >= 20.0.35",
+  { include-group = "extra" },
 ]
 dev = [
   { include-group = "test" },

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 requires =
-    tox>=4.2
+    tox>=4.22
     virtualenv>=20.0.34
 env_list =
     fix
@@ -15,8 +15,6 @@ description =
     run test suite with {basepython}
 deps =
     pip
-extras =
-    test
 pass_env =
     LC_ALL
     PIP_*
@@ -32,6 +30,8 @@ commands =
     pytest -ra --cov --cov-config pyproject.toml \
       --cov-report=html:{envdir}/htmlcov --cov-context=test \
       --cov-report=xml:{toxworkdir}/coverage.{envname}.xml {posargs:-n auto}
+dependency_groups =
+    test
 
 [testenv:fix]
 description = run static analysis and style checks
@@ -48,21 +48,21 @@ commands =
 
 [testenv:type]
 description = run type check on code base
-extras =
-    typing
 set_env =
     PYTHONWARNDEFAULTENCODING =
 commands =
     mypy
+dependency_groups =
+    typing
 
 [testenv:docs]
 description = build documentations
 base_python = python3.12
-extras =
-    docs
 commands =
     sphinx-build -n docs {envtmpdir} {posargs:-W}
     python -c 'print("Documentation available under file://{envtmpdir}/index.html")'
+dependency_groups =
+    docs
 
 [testenv:path]
 description = verify build can run from source (bootstrap)
@@ -83,12 +83,12 @@ description = generate a DEV environment
 package = editable
 deps =
     virtualenv>=20.0.34
-extras =
-    doc
-    test
 commands =
     python -m pip list --format=columns
     python -c 'import sys; print(sys.executable)'
+dependency_groups =
+    docs
+    test
 
 [testenv:coverage]
 description = combine coverage from test environments


### PR DESCRIPTION
Use dependency-groups, drop the `[test]`/`[docs]`/`[typing]` extras.
