### PR TITLE
chore: drop type ignore for spec parent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ test = [
 typing = [
   "build[uv]",
   "importlib-metadata >= 5.1",
-  "mypy ~= 1.9.0",
+  "mypy ~= 1.15.0",
   "tomli",
   "typing-extensions >= 3.7.4.3",
 ]

--- a/src/build/_ctx.py
+++ b/src/build/_ctx.py
@@ -15,7 +15,7 @@ class _Logger(typing.Protocol):  # pragma: no cover
     def __call__(self, message: str, *, origin: tuple[str, ...] | None = None) -> None: ...
 
 
-_package_name = __spec__.parent  # type: ignore[name-defined]
+_package_name = __spec__.parent
 _default_logger = logging.getLogger(_package_name)
 
 


### PR DESCRIPTION
I think this is no longer needed.
