### PR TITLE
fix: virtualenv no-wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,8 @@ uv = [
   "uv >= 0.1.18",
 ]
 virtualenv = [
-  "virtualenv >= 20.0.35",
+  "virtualenv >= 20.11; python_version < '3.10'",
+  "virtualenv >= 20.17; python_version >= '3.10'",
 ]
 
 [project.scripts]
@@ -134,11 +135,6 @@ filterwarnings = [
   "error",
   "ignore:path is deprecated.:DeprecationWarning",
   "ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning",
-  "ignore:use poll_interval instead of poll_intervall:DeprecationWarning",  # old virtualenv
-  "ignore:'pipes' is deprecated and slated for removal in Python 3.13:DeprecationWarning",  # old virtualenv
-  "ignore:is still running:ResourceWarning",  # old virtualenv
-  "ignore:The distutils package is deprecated:DeprecationWarning",  # old virtualenv
-  "ignore:The distutils.sysconfig module is deprecated:DeprecationWarning",  # old virtualenv
   "default:Python 3.14 will, by default, filter extracted tar archives:DeprecationWarning",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,11 @@ filterwarnings = [
   "error",
   "ignore:path is deprecated.:DeprecationWarning",
   "ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning",
+  "ignore:use poll_interval instead of poll_intervall:DeprecationWarning",  # old virtualenv
+  "ignore:'pipes' is deprecated and slated for removal in Python 3.13:DeprecationWarning",  # old virtualenv
+  "ignore:is still running:ResourceWarning",  # old virtualenv
+  "ignore:The distutils package is deprecated:DeprecationWarning",  # old virtualenv
+  "ignore:The distutils.sysconfig module is deprecated:DeprecationWarning",  # old virtualenv
   "default:Python 3.14 will, by default, filter extracted tar archives:DeprecationWarning",
 ]
 

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -202,18 +202,24 @@ class _PipBackend(_EnvBackend):
 
     def create(self, path: str) -> None:
         if self._create_with_virtualenv:
+            import packaging.version
             import virtualenv
 
-            result = virtualenv.cli_run(
-                [
-                    path,
-                    '--activators',
-                    '',
-                    '--no-setuptools',
-                    '--no-wheel',
-                ],
-                setup_logging=False,
-            )
+            from ._compat import importlib
+
+            virtualenv_ver = packaging.version.Version(importlib.metadata.version('virtualenv'))
+
+            opts = [
+                path,
+                '--activators',
+                '',
+                '--no-setuptools',
+            ]
+
+            if virtualenv_ver < packaging.version.Version('20.31.0'):
+                opts.append('--no-wheel')
+
+            result = virtualenv.cli_run(opts, setup_logging=False)
 
             # The creator attributes are `pathlib.Path`s.
             self.python_executable = str(result.creator.exe)

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -214,6 +214,7 @@ class _PipBackend(_EnvBackend):
                 '--activators',
                 '',
                 '--no-setuptools',
+                '--no-periodic-update',
             ]
 
             if virtualenv_ver < packaging.version.Version('20.31.0'):

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -16,7 +16,9 @@ from .env import DefaultIsolatedEnv
 def _project_wheel_metadata(builder: ProjectBuilder) -> importlib.metadata.PackageMetadata:
     with tempfile.TemporaryDirectory() as tmpdir:
         path = pathlib.Path(builder.metadata_path(tmpdir))
-        return importlib.metadata.PathDistribution(path).metadata
+        metadata = importlib.metadata.PathDistribution(path).metadata
+        assert metadata is not None
+        return metadata
 
 
 def project_wheel_metadata(

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -8,6 +8,6 @@ setuptools==56.0.0; python_version == "3.11"
 setuptools==67.8.0; python_version >= "3.12"
 setuptools_scm==6.3.1; python_version < "3.12"
 tomli==1.1.0
-virtualenv==20.0.35; python_version < "3.13"
-virtualenv==20.15; python_version >= "3.13"
+virtualenv==20.11; python_version < "3.10"
+virtualenv==20.17; python_version >= "3.10"
 wheel==0.36.0

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -8,5 +8,6 @@ setuptools==56.0.0; python_version == "3.11"
 setuptools==67.8.0; python_version >= "3.12"
 setuptools_scm==6.3.1; python_version < "3.12"
 tomli==1.1.0
-# virtualenv==20.0.35
+virtualenv==20.0.35; python_version < "3.13"
+virtualenv==20.15; python_version >= "3.13"
 wheel==0.36.0


### PR DESCRIPTION
Adapting to the new `--no-wheel` deprecation. See https://github.com/pypa/virtualenv/pull/2868.
