### PR TITLE
fix: Fix `ModuleNotFoundError` when `pip` is not installed

### DIFF
--- a/src/build/env.py
+++ b/src/build/env.py
@@ -161,7 +161,7 @@ class _PipBackend(_EnvBackend):
         """
 
         # Version to have added the `--python` option.
-        if not _has_dependency('pip', '22.3'):
+        if not _has_dependency('pip', '22.3'):  # pragma: no cover
             return False
 
         # `pip install --python` is nonfunctional on Gentoo debundled pip.

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -159,6 +159,11 @@ class _PipBackend(_EnvBackend):
         This checks for a valid global pip. Returns None if pip is missing, False
         if pip is too old, and True if it can be used.
         """
+
+        # Version to have added the `--python` option.
+        if not _has_dependency('pip', '22.3'):
+            return False
+
         # `pip install --python` is nonfunctional on Gentoo debundled pip.
         # Detect that by checking if pip._vendor` module exists.  However,
         # searching for pip could yield warnings from _distutils_hack,
@@ -168,8 +173,7 @@ class _PipBackend(_EnvBackend):
             if importlib.util.find_spec('pip._vendor') is None:
                 return False  # pragma: no cover
 
-        # Version to have added the `--python` option.
-        return _has_dependency('pip', '22.3')
+        return True
 
     @functools.cached_property
     def _has_virtualenv(self) -> bool:


### PR DESCRIPTION
Fix the exception raised if `pip` is not installed at all:

```
[...]
  File "/usr/lib/python3.14/site-packages/build/env.py", line 168, in _has_valid_outer_pip
    if importlib.util.find_spec('pip._vendor') is None:
       ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "<frozen importlib.util>", line 90, in find_spec
ModuleNotFoundError: No module named 'pip'
```

This is a regression from #861 where I did not predict that `find_spec()` will actually raise when the parent package is not available. To fix it, just reorder the conditions to make sure that `pip` is installed first.