### PR TITLE
PEP 639 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ authors = [
   { name = "Henry Schreiner", email = "henryschreineriii@gmail.com" },
 ]
 classifiers = [
-  "License :: OSI Approved :: MIT License",  # for compatibility with tooling such as pip-licenses
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
~~Keep the redundant Trove classifier for now, until tools such as pip-licenses support PEP 639.~~

Also, implicit is better than explicit: flit can discover the `LICENSE` file by default, as documented under [New style metadata](https://flit.pypa.io/en/stable/pyproject_toml.html#new-style-metadata):
> license-files
> 
>   A list of glob patterns for license files to include. Defaults to `['COPYING*', 'LICEN[CS]E*']`.
