### PR TITLE
tox: advance pypy runtime versions (removes 3.8; enables 3.11)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ env_list =
     type
     docs
     path
-    {py314, py313, py312, py311, py310, py39, pypy314, pypy310, pypy39, pypy38}{, -min}
+    {py314, py313, py312, py311, py310, py39, pypy314, pypy310, pypy39}{, -min}
 skip_missing_interpreters = true
 
 [testenv]
@@ -73,7 +73,7 @@ set_env =
 commands_pre =
     python -E -m pip uninstall -y build colorama
 
-[testenv:{py314, py313, py312, py311, py310, py39, pypy38, pypy39, pypy310, pypy311}-min]
+[testenv:{py314, py313, py312, py311, py310, py39, pypy39, pypy310, pypy311}-min]
 description = check minimum versions required of all dependencies
 set_env =
     PIP_CONSTRAINT = {toxinidir}/tests/constraints.txt
@@ -109,7 +109,7 @@ commands =
     python -m diff_cover.diff_cover_tool --compare-branch {env:DIFF_AGAINST:origin/main} {toxworkdir}/coverage.xml
 depends =
     path
-    {py314, py313, py312, py311, py310, py39, pypy311, pypy310, pypy39, pypy38}{, -min}
+    {py314, py313, py312, py311, py310, py39, pypy311, pypy310, pypy39}{, -min}
 
 [testenv:bump]
 description = bump versions, pass major/minor/patch

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ env_list =
     type
     docs
     path
-    {py314, py313, py312, py311, py310, py39, pypy314, pypy310, pypy39}{, -min}
+    {py314, py313, py312, py311, py310, py39, pypy314, pypy311, pypy310, pypy39}{, -min}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Follow-up to #891.

Also follows on from discussion at: https://github.com/pypa/build/pull/891#issuecomment-3155575059