### PR TITLE
chore: split up typing and mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,15 +86,18 @@ test = [
 ]
 typing = [
   "importlib-metadata >= 5.1",
-  "mypy ~= 1.18.2",
   "tomli",
   "typing-extensions >= 3.7.4.3",
   { include-group = "extra" },
 ]
+mypy = [
+  "mypy ~= 1.18.2",
+  { include-group = "typing" },
+]
 dev = [
   "flit-core",
   { include-group = "test" },
-  { include-group = "typing" },
+  { include-group = "mypy" },
 ]
 
 [tool.flit.sdist]

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ env_list =
     type
     docs
     path
-    {py314, py313, py312, py311, py310, py39, pypy314, pypy311, pypy310, pypy39}{, -min}
+    {py314, py313, py312, py311, py310, py39, pypy311, pypy310, pypy39}{, -min}
 skip_missing_interpreters = true
 
 [testenv]
@@ -54,7 +54,7 @@ set_env =
 commands =
     mypy
 dependency_groups =
-    typing
+    mypy
 
 [testenv:docs]
 description = build documentations


### PR DESCRIPTION
Splitting up typing and mypy, so that we can reuse this for other type checkers (playing around with ty a bit, pasted job below, 6 errors currently).


