### PR TITLE
ci: release note filtering now requires `[bot]`

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,5 +1,5 @@
 changelog:
   exclude:
     authors:
-      - dependabot
-      - pre-commit-ci
+      - dependabot[bot]
+      - pre-commit-ci[bot]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "pyproject_hooks",
   # not actually a runtime dependency, only supplied as there is not "recommended dependency" support
   'colorama; os_name == "nt"',
-  'importlib-metadata >= 4.6; python_full_version < "3.10.2"',  # Not required for 3.8+, but fixes a stdlib bug
+  'importlib-metadata >= 4.6; python_full_version < "3.10.2"',  # Not required but fixes a stdlib bug
   'tomli >= 1.1.0; python_version < "3.11"',
 ]
 


### PR DESCRIPTION
Now required to filter bot commits when generating the release notes.
