### PR TITLE
MNT: remove workaround for 3.14b1

### DIFF
--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -331,9 +331,6 @@ def main_parser() -> argparse.ArgumentParser:
     Construct the main parser.
     """
     formatter_class = argparse.RawDescriptionHelpFormatter
-    # Workaround for 3.14.0 beta 1, can remove once beta 2 is out
-    if sys.version_info >= (3, 14):
-        formatter_class = partial(formatter_class, color=True)
 
     make_parser = partial(
         argparse.ArgumentParser,


### PR DESCRIPTION
This is broken with cpython main which removed the color keyword argument to HelperFormatter in https://github.com/python/cpython/pull/142274

I have not dug into whatthis was working around to verify that it is safe to remove and trusted @henryiii 's comment.  If it is not, then this should be adjusted to have an upper bound of the Python version. 