### PR TITLE
Show debug information about backend

### DIFF
--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -189,6 +189,8 @@ def _build(
         installer,
         pyproject_hooks.quiet_subprocess_runner if _ctx.verbosity < 0 else None,
     ) as builder:
+        version = builder.get_backend_version()
+        _ctx.log('backend_version  ' + version, origin=('build',))
         return builder.build(distribution, outdir, config_settings)
 
 

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -189,8 +189,6 @@ def _build(
         installer,
         pyproject_hooks.quiet_subprocess_runner if _ctx.verbosity < 0 else None,
     ) as builder:
-        version = builder.get_backend_version()
-        _ctx.log('backend_version  ' + version, origin=('build',))
         return builder.build(distribution, outdir, config_settings)
 
 

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -90,9 +90,9 @@ def _make_logger() -> _ctx.Logger:
                 initial_indent = '> ' if origin[1] == 'cmd' else '< '
                 for line in message.splitlines():
                     _cprint('{dim}{}{reset}', fill(line, initial_indent=initial_indent), file=sys.stderr)
-            elif origin[0] == 'build':
+            elif origin[0] == 'debug':
                 if _ctx.verbosity >= 1:
-                    print('build:' + message)
+                    print(f'{origin[1]}:{message}')
 
     return log
 

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -91,7 +91,7 @@ def _make_logger() -> _ctx.Logger:
                     _cprint('{dim}{}{reset}', fill(line, initial_indent=initial_indent), file=sys.stderr)
             elif origin[0] == 'debug':
                 if _ctx.verbosity >= 1:
-                    print(f'{origin[1]}:{message}')
+                    print(f'{message}', file=sys.stderr)
 
     return log
 

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -90,6 +90,9 @@ def _make_logger() -> _ctx.Logger:
                 initial_indent = '> ' if origin[1] == 'cmd' else '< '
                 for line in message.splitlines():
                     _cprint('{dim}{}{reset}', fill(line, initial_indent=initial_indent), file=sys.stderr)
+            elif origin[0] == 'build':
+                if _ctx.verbosity >= 1:
+                    print('build:' + message)
 
     return log
 

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -81,10 +81,9 @@ def _make_logger() -> _ctx.Logger:
     def log(message: str, *, origin: tuple[str, ...] | None = None) -> None:
         if _ctx.verbosity >= -1:
             if origin is None:
-                (first, *rest) = message.splitlines()
-                _cprint('{bold}{}{reset}', fill(first, initial_indent='* '), file=sys.stderr)
-                for line in rest:
-                    print(fill(line, initial_indent='  '), file=sys.stderr)
+                print(message, file=sys.stderr)
+            elif origin[0] == 'step':
+                _cprint('{bold}{}{reset}', fill(message, initial_indent='* '), file=sys.stderr)
 
             elif origin[0] == 'subprocess':
                 initial_indent = '> ' if origin[1] == 'cmd' else '< '
@@ -295,7 +294,7 @@ def build_package_via_sdist(
         with tarfile.TarFile.open(sdist) as t:
             t.extractall(sdist_out)
             try:
-                _ctx.log(f'Building {_natural_language_list(distributions)} from sdist')
+                _ctx.log(f'Building {_natural_language_list(distributions)} from sdist', origin=('step',))
                 srcdir = os.path.join(sdist_out, sdist_name[: -len('.tar.gz')])
                 for distribution in distributions:
                     out = _build(isolation, srcdir, outdir, distribution, config_settings, skip_dependency_check, installer)

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -271,6 +271,14 @@ class ProjectBuilder:
                 return None
             raise
 
+    def get_backend_version(self) -> str | None:
+        # setuptools.build_meta:__legacy__  -->  setuptools
+        lib = self._backend.split('.')[0]
+        script = f'import {lib}; print({lib}.__version__)'
+        cmd = [self.python_executable, '-c', script]
+        version = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout
+        return version
+
     def build(
         self,
         distribution: Distribution,

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -164,7 +164,7 @@ class ProjectBuilder:
         self._build_system = _parse_build_system_table(_read_pyproject_toml(pyproject_toml_path))
 
         self._backend = self._build_system['build-backend']
-        _ctx.log('backend  ' + self._backend, origin=('debug', 'build'))
+        _ctx.log('build:backend  ' + self._backend, origin=('debug',))
 
         self._hook = pyproject_hooks.BuildBackendHookCaller(
             self._source_dir,
@@ -173,7 +173,6 @@ class ProjectBuilder:
             python_executable=self._python_executable,
             runner=self._runner,
         )
-        _ctx.log('python_executable  ' + str(self._python_executable), origin=('debug', 'build'))
 
         self._env = env.BaseEnv() if build_env is None else build_env
 

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -278,7 +278,7 @@ class ProjectBuilder:
         cmd = [self.python_executable, '-c', script]
         version = 'Unknown'
         try:
-            version = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout
+            version = subprocess.run(cmd, capture_output=True, check=True, encoding='utf-8').stdout
         except subprocess.CalledProcessError as exc:
             _ctx.log_subprocess_error(exc)
         return f'{lib} {version}'

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -225,7 +225,7 @@ class ProjectBuilder:
             (``sdist`` or ``wheel``)
         :param config_settings: Config settings for the build backend
         """
-        _ctx.log(f'Getting build dependencies for {distribution}...')
+        _ctx.log(f'Getting build dependencies for {distribution}...', origin=('step',))
         hook_name = f'get_requires_for_build_{distribution}'
         get_requires = getattr(self._hook, hook_name)
 
@@ -263,7 +263,7 @@ class ProjectBuilder:
         :param config_settings: Config settings for the build backend
         :returns: The full path to the prepared metadata directory
         """
-        _ctx.log(f'Getting metadata for {distribution}...')
+        _ctx.log(f'Getting metadata for {distribution}...', origin=('step',))
         try:
             return self._call_backend(
                 f'prepare_metadata_for_build_{distribution}',
@@ -306,7 +306,8 @@ class ProjectBuilder:
         :returns: The full path to the built distribution
         """
         versions = self.get_backend_version()
-        _ctx.log(f'Building {distribution}...\n{versions}')
+        _ctx.log(f'Building {distribution}...', origin=('step',))
+        _ctx.log(versions)
 
         kwargs = {} if metadata_directory is None else {'metadata_directory': metadata_directory}
         return self._call_backend(f'build_{distribution}', output_directory, config_settings, **kwargs)

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -271,13 +271,17 @@ class ProjectBuilder:
                 return None
             raise
 
-    def get_backend_version(self) -> str | None:
+    def get_backend_version(self) -> str:
         # setuptools.build_meta:__legacy__  -->  setuptools
         lib = self._backend.split('.')[0]
         script = f'import {lib}; print({lib}.__version__)'
         cmd = [self.python_executable, '-c', script]
-        version = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout
-        return version
+        version = 'Unknown'
+        try:
+            version = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout
+        except subprocess.CalledProcessError as exc:
+            _ctx.log_subprocess_error(exc)
+        return f'{lib} {version}'
 
     def build(
         self,

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -274,23 +274,24 @@ class ProjectBuilder:
 
     def get_backend_version(self) -> str:
         # setuptools.build_meta:__legacy__  -->  setuptools
-        lib = self._backend.split('.')[0]
-        script = textwrap.dedent(f'''
+        module = self._backend.split('.')[0]
+        script = textwrap.dedent(f"""
             import sys
             try:
                 from importlib import metadata
             except ModuleNotFoundError:
                 # Python < (3, 10, 2)
                 import importlib_metadata as metadata
-            print(metadata.version('{lib}'))
-        ''')
+            lib = metadata.packages_distributions()['{module}'][0]
+            print(lib + ' ' + metadata.version(lib))
+        """)
         cmd = [self.python_executable, '-c', script]
-        version = 'Unknown'
+        info = f'{module} Unknown'
         try:
-            version = subprocess.run(cmd, capture_output=True, check=True, encoding='utf-8').stdout.strip()
+            info = subprocess.run(cmd, capture_output=True, check=True, encoding='utf-8').stdout.strip()
         except subprocess.CalledProcessError as exc:
             _ctx.log_subprocess_error(exc)
-        return f'{lib} {version}'
+        return info
 
     def build(
         self,

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -7,6 +7,7 @@ import difflib
 import os
 import subprocess
 import sys
+import textwrap
 import warnings
 import zipfile
 
@@ -274,7 +275,15 @@ class ProjectBuilder:
     def get_backend_version(self) -> str:
         # setuptools.build_meta:__legacy__  -->  setuptools
         lib = self._backend.split('.')[0]
-        script = f'import {lib}; print({lib}.__version__)'
+        script = textwrap.dedent(f'''
+            import sys
+            try:
+                from importlib import metadata
+            except ModuleNotFoundError:
+                # Python < (3, 10, 2)
+                import importlib_metadata as metadata
+            print(metadata.version('{lib}'))
+        ''')
         cmd = [self.python_executable, '-c', script]
         version = 'Unknown'
         try:

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -135,7 +135,7 @@ class ProjectBuilder:
         source_dir: StrPath,
         python_executable: str = sys.executable,
         runner: SubprocessRunner = pyproject_hooks.default_subprocess_runner,
-        env: env.IsolatedEnv = None,
+        build_env: env.BaseEnv | None = None,
     ) -> None:
         """
         :param source_dir: The source directory
@@ -175,7 +175,7 @@ class ProjectBuilder:
         )
         _ctx.log('python_executable  ' + str(self._python_executable), origin=('debug', 'build'))
 
-        self._env = env
+        self._env = env.BaseEnv() if build_env is None else build_env
 
     @classmethod
     def from_isolated_env(
@@ -188,7 +188,7 @@ class ProjectBuilder:
             source_dir=source_dir,
             python_executable=env.python_executable,
             runner=_wrap_subprocess_runner(runner, env),
-            env=env,
+            build_env=env,
         )
 
     @property

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -24,7 +24,7 @@ from ._exceptions import (
     TypoWarning,
 )
 from ._types import ConfigSettings, Distribution, StrPath, SubprocessRunner
-from ._util import check_dependency, debug, parse_wheel_filename
+from ._util import check_dependency, parse_wheel_filename
 
 
 _TProjectBuilder = TypeVar('_TProjectBuilder', bound='ProjectBuilder')
@@ -162,7 +162,7 @@ class ProjectBuilder:
         self._build_system = _parse_build_system_table(_read_pyproject_toml(pyproject_toml_path))
 
         self._backend = self._build_system['build-backend']
-        debug("build:backend  " + self._backend)
+        _ctx.log('backend  ' + self._backend, origin=('build',))
 
         self._hook = pyproject_hooks.BuildBackendHookCaller(
             self._source_dir,
@@ -171,7 +171,7 @@ class ProjectBuilder:
             python_executable=self._python_executable,
             runner=self._runner,
         )
-        debug("build:python_executable  " + str(self._python_executable))
+        _ctx.log('python_executable  ' + str(self._python_executable), origin=('build',))
 
     @classmethod
     def from_isolated_env(

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -24,7 +24,7 @@ from ._exceptions import (
     TypoWarning,
 )
 from ._types import ConfigSettings, Distribution, StrPath, SubprocessRunner
-from ._util import check_dependency, parse_wheel_filename
+from ._util import check_dependency, debug, parse_wheel_filename
 
 
 _TProjectBuilder = TypeVar('_TProjectBuilder', bound='ProjectBuilder')
@@ -162,6 +162,7 @@ class ProjectBuilder:
         self._build_system = _parse_build_system_table(_read_pyproject_toml(pyproject_toml_path))
 
         self._backend = self._build_system['build-backend']
+        debug("build:backend  " + self._backend)
 
         self._hook = pyproject_hooks.BuildBackendHookCaller(
             self._source_dir,
@@ -170,6 +171,7 @@ class ProjectBuilder:
             python_executable=self._python_executable,
             runner=self._runner,
         )
+        debug("build:python_executable  " + str(self._python_executable))
 
     @classmethod
     def from_isolated_env(

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -278,7 +278,7 @@ class ProjectBuilder:
         cmd = [self.python_executable, '-c', script]
         version = 'Unknown'
         try:
-            version = subprocess.run(cmd, capture_output=True, check=True, encoding='utf-8').stdout
+            version = subprocess.run(cmd, capture_output=True, check=True, encoding='utf-8').stdout.strip()
         except subprocess.CalledProcessError as exc:
             _ctx.log_subprocess_error(exc)
         return f'{lib} {version}'
@@ -301,6 +301,9 @@ class ProjectBuilder:
         :returns: The full path to the built distribution
         """
         _ctx.log(f'Building {distribution}...')
+        version = self.get_backend_version()
+        _ctx.log('backend_version  ' + version, origin=('build',))
+
         kwargs = {} if metadata_directory is None else {'metadata_directory': metadata_directory}
         return self._call_backend(f'build_{distribution}', output_directory, config_settings, **kwargs)
 

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -300,9 +300,8 @@ class ProjectBuilder:
             previous ``prepare`` call on the same ``distribution`` kind
         :returns: The full path to the built distribution
         """
-        _ctx.log(f'Building {distribution}...')
         version = self.get_backend_version()
-        _ctx.log('backend_version  ' + version, origin=('build',))
+        _ctx.log(f'Building {distribution}...\n(using {version})')
 
         kwargs = {} if metadata_directory is None else {'metadata_directory': metadata_directory}
         return self._call_backend(f'build_{distribution}', output_directory, config_settings, **kwargs)

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -162,7 +162,7 @@ class ProjectBuilder:
         self._build_system = _parse_build_system_table(_read_pyproject_toml(pyproject_toml_path))
 
         self._backend = self._build_system['build-backend']
-        _ctx.log('backend  ' + self._backend, origin=('build',))
+        _ctx.log('backend  ' + self._backend, origin=('debug', 'build'))
 
         self._hook = pyproject_hooks.BuildBackendHookCaller(
             self._source_dir,
@@ -171,7 +171,7 @@ class ProjectBuilder:
             python_executable=self._python_executable,
             runner=self._runner,
         )
-        _ctx.log('python_executable  ' + str(self._python_executable), origin=('build',))
+        _ctx.log('python_executable  ' + str(self._python_executable), origin=('debug', 'build'))
 
     @classmethod
     def from_isolated_env(

--- a/src/build/_ctx.py
+++ b/src/build/_ctx.py
@@ -19,8 +19,8 @@ _default_logger = logging.getLogger(_package_name)
 
 
 def _log_default(message: str, *, origin: tuple[str, ...] | None = None) -> None:
-    if origin is None:
-        _default_logger.log(logging.INFO, message, stacklevel=2)
+    # the log function that works in tests, real log function is set in __main__
+    _default_logger.log(logging.INFO, message, stacklevel=2)
 
 
 LOGGER = contextvars.ContextVar('LOGGER', default=_log_default)

--- a/src/build/_util.py
+++ b/src/build/_util.py
@@ -12,6 +12,10 @@ _WHEEL_FILENAME_REGEX = re.compile(
 )
 
 
+def debug(msg: str) -> None:
+    print(msg)
+
+
 def check_dependency(
     req_string: str, ancestral_req_strings: tuple[str, ...] = (), parent_extras: Set[str] = frozenset()
 ) -> Iterator[tuple[str, ...]]:

--- a/src/build/_util.py
+++ b/src/build/_util.py
@@ -12,10 +12,6 @@ _WHEEL_FILENAME_REGEX = re.compile(
 )
 
 
-def debug(msg: str) -> None:
-    print(msg)
-
-
 def check_dependency(
     req_string: str, ancestral_req_strings: tuple[str, ...] = (), parent_extras: Set[str] = frozenset()
 ) -> Iterator[tuple[str, ...]]:

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -110,7 +110,7 @@ class DefaultIsolatedEnv(BaseEnv):
             else:
                 self._env_backend = _PipBackend()
 
-            _ctx.log(f'Creating isolated environment: {self._env_backend.display_name}...')
+            _ctx.log(f'Creating isolated environment: {self._env_backend.display_name}...', origin=('step',))
             self._env_backend.create(self._path)
 
         except Exception:  # cleanup folder if creation fails
@@ -157,7 +157,8 @@ class DefaultIsolatedEnv(BaseEnv):
         if not requirements:
             return
 
-        _ctx.log('Installing packages in isolated environment:\n' + '\n'.join(f'- {r}' for r in sorted(requirements)))
+        _ctx.log('Installing packages in isolated environment:', origin=('step',))
+        _ctx.log('\n'.join(f'  - {r}' for r in sorted(requirements)))
         self._env_backend.install_requirements(requirements)
 
 

--- a/tests/test_ctx_logger.py
+++ b/tests/test_ctx_logger.py
@@ -21,14 +21,6 @@ def test_default_ctx_logger(caplog: pytest.LogCaptureFixture):
     assert record.message == 'foo'
 
 
-def test_default_ctx_logger_only_logs_null_origin_messages(caplog: pytest.LogCaptureFixture):
-    build._ctx.log('foo', origin=None)
-    build._ctx.log('bar', origin=('bar',))
-
-    [record] = caplog.records
-    assert record.message == 'foo'
-
-
 def test_ctx_custom_logger(mocker: pytest_mock.MockerFixture):
     log_stub = mocker.stub('custom_logger')
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -108,7 +108,8 @@ def test_isolated_env_log(
 
     assert [(record.levelname, record.message) for record in caplog.records] == [
         ('INFO', 'Creating isolated environment: venv+pip...'),
-        ('INFO', 'Installing packages in isolated environment:\n- something'),
+        ('INFO', 'Installing packages in isolated environment:'),
+        ('INFO', '  - something'),
     ]
 
 

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -561,6 +561,7 @@ def test_log(mocker, caplog, package_test_flit):
     builder.build('wheel', '.')
 
     assert [(record.levelname, record.message) for record in caplog.records] == [
+        ('INFO', 'build:backend  flit_core.buildapi'),
         ('INFO', 'Getting build dependencies for sdist...'),
         ('INFO', 'Getting build dependencies for wheel...'),
         ('INFO', 'Getting metadata for wheel...'),

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -550,6 +550,7 @@ def test_metadata_invalid_wheel(tmp_dir, package_test_bad_wheel):
 def test_log(mocker, caplog, package_test_flit):
     mocker.patch('pyproject_hooks.BuildBackendHookCaller', autospec=True)
     mocker.patch('build.ProjectBuilder._call_backend', return_value='some_path')
+    mocker.patch('build.env.BaseEnv.get_package_version', return_value='3.12.0')
     caplog.set_level(logging.DEBUG)
 
     builder = build.ProjectBuilder(package_test_flit)
@@ -564,7 +565,9 @@ def test_log(mocker, caplog, package_test_flit):
         ('INFO', 'Getting build dependencies for wheel...'),
         ('INFO', 'Getting metadata for wheel...'),
         ('INFO', 'Building sdist...'),
+        ('INFO', '  flit_core==3.12.0'),
         ('INFO', 'Building wheel...'),
+        ('INFO', '  flit_core==3.12.0'),
     ]
 
 


### PR DESCRIPTION
When reporting underlying backend (setuptools) issues, the (setuptools) tracker requirement is to mention exact version of backend being used. This information is, however, absent from the `build` output.

This PR shows backed spec being used, without version:

    $ touch pyproject.toml
    $ python -m build
    * Creating isolated environment: venv+pip... build:backend  setuptools.build_meta:__legacy__ build:python_executable  /tmp/build-env-098a9c2b/bin/python
    * Installing packages in isolated environment:
      - setuptools >= 40.8.0 ...

Getting version requires running custom code in venv created by `build` after backend is installed and it is not clear how to do that yet. The code should extract first component from the spec, and append `__version__` to it. At least that's the way of doing it for `setuptools`.

Fixes https://github.com/pypa/build/issues/959