### PR TITLE
docs: first argument for _has_dependency is a name

### DIFF
--- a/src/build/env.py
+++ b/src/build/env.py
@@ -41,7 +41,7 @@ class IsolatedEnv(typing.Protocol):
 
 def _has_dependency(name: str, minimum_version_str: str | None = None, /, **distargs: object) -> bool | None:
     """
-    Given a package name, see if it is present and return True if the version is
+    Given a distribution name, see if it is present and return True if the version is
     sufficient for build, False if it is not, None if the package is missing.
     """
     from packaging.version import Version


### PR DESCRIPTION
Fixed function description. It would be nice to get some usage example, how version string looks like. 

EDIT: The code has this example.
```sh
_has_dependency('pip', '22.3')
```
Which checks if `pip >= 22.3`  is installed.