### PR TITLE
chore: fix PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 
 - [ ] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
   - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
-  - Example: `123.feature.rst` containing `Add custom backend support - by :user:`yourname\`\`
+  - Example: `123.feature.rst` containing ``Add custom backend support - by :user:`yourname` ``
 
 ## Checklist
 


### PR DESCRIPTION

## Description

<!-- Describe what changes you made and why -->

Made the template a little better. Still has an extra space I don't know how to get rid of, but better than before.

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

- [ ] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing ``Add custom backend support - by :user:`yourname` ``

## Checklist

- [ ] Tests pass locally (`tox`)
- [ ] Code follows project style (`tox -e fix`)
- [ ] Type checks pass (`tox -e type`)
- [ ] Documentation builds (`tox -e docs`)
