### PR TITLE
🐛 fix(ci): resolve pre-release auth failure and change detection

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -44,4 +44,11 @@ jobs:
           git config user.name "$(echo "$user_info" | jq -r '.name // .login')"
           git config user.email "$(echo "$user_info" | jq -r '.id')+$(echo "$user_info" | jq -r '.login')@users.noreply.github.com"
       - name: Generate release commit and tag
-        run: uv tool run --with tox-uv tox r -e release -- --version "${{ inputs.bump }}"
+        run: uv tool run --with tox-uv tox r -e release -- --version "${{ inputs.bump }}" --no-push
+      - name: Push release commit and tag
+        run: |
+          git remote set-url origin "https://x-access-token:${GH_RELEASE_TOKEN}@github.com/${{ github.repository }}.git"
+          git push origin HEAD:main
+          git push origin "$(git describe --tags --abbrev=0)"
+        env:
+          GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}

--- a/.github/workflows/reusable-change-detection.yml
+++ b/.github/workflows/reusable-change-detection.yml
@@ -51,7 +51,7 @@ jobs:
             CHANGELOG.rst
             README.md
             .github/workflows/test.yml
-            .github/workflows/reusable-check.yml
+            .github/workflows/reusable-docs.yml
       - name: Set a flag for building the docs
         if: >-
           github.event_name != 'pull_request'


### PR DESCRIPTION
The pre-release workflow failed at run 23514492252 because `release.py` attempted to push commits and tags with no git credentials configured. 🔐 The checkout action uses `persist-credentials: false`, so the release script's built-in push functionality cannot authenticate with the remote repository.

The fix splits the release process into two steps: generate the commit and tag locally using `--no-push`, then push using a token-authenticated remote URL in a separate step. This preserves the security benefit of `persist-credentials: false` while enabling the workflow to push releases successfully.

Also fixed a bug in the change detection workflow that referenced `reusable-check.yml` (which doesn't exist) instead of `reusable-docs.yml`. This prevented documentation rebuilds from triggering on pull requests when the docs workflow file was modified.