### PR TITLE
🐛 fix(deps): add pre-commit to release dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ mypy = [
 release = [
   "gitpython >= 3.1.44",
   "packaging >= 25",
+  "pre-commit >= 3.0",
   "towncrier >= 24.8",
 ]
 dev = [


### PR DESCRIPTION
The pre-release workflow fails at run 23515770142 because the release script calls `pre-commit` to format and lint the generated release commit, but `pre-commit` is not installed in the release tox environment. 🔧 The script invokes `pre-commit run --all-files` on lines 70 and 72 of `tasks/release.py`, resulting in a `FileNotFoundError` when the command cannot be found.

Added `pre-commit >= 3.0` to the release dependency group in `pyproject.toml`. This matches the version constraint used in the docs dependency group and ensures the release script can run formatting hooks on the generated changelog and version updates.

Without this dependency, the release workflow cannot complete successfully. With it, the pre-commit hooks will properly format the release commit before it gets tagged and pushed.