### PR TITLE
🔧 fix(towncrier): match docstrfmt RST formatting expectations

### DIFF
--- a/docs/changelog/template.jinja2
+++ b/docs/changelog/template.jinja2
@@ -9,8 +9,9 @@
 {% set section_entries = sections[section] %}
 {% if section_entries %}
 {% for category, entries in section_entries.items() if entries %}
-{{ definitions[category]['name'] }}
-{{ underlines[0] * definitions[category]['name']|length }}
+{{ underlines[0] * (definitions[category]['name']|length + 2) }}
+ {{ definitions[category]['name'] }}
+{{ underlines[0] * (definitions[category]['name']|length + 2) }}
 
 {% if definitions[category]['showcontent'] %}
 {% for text, values in entries.items() %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,6 +230,7 @@ title_format = false
 issue_format = ":issue:`{issue}`"
 template = "docs/changelog/template.jinja2"
 underlines = ["*", "=", "-"]
+top_underline = "#"
 
 [[tool.towncrier.section]]
 path = ""


### PR DESCRIPTION
The release workflow at run 23517320705 failed with the environment inconsistency check because `towncrier` generates CHANGELOG.rst with asterisks for version headers and equals signs for section headers, but `docstrfmt` expects hash symbols for version headers and asterisks with overlines for section headers. 🎨 When the release script runs, towncrier creates the changelog, then pre-commit runs docstrfmt which reformats it, causing the consistency check to fail.

Configure towncrier to use hash symbols for version titles via `top_underline = "#"` and update the template to add overlines above section headers. This ensures the generated changelog matches docstrfmt expectations without requiring reformatting, allowing the release script to pass the environment consistency check.

The next pre-release workflow run will generate a properly formatted changelog that passes all pre-commit checks.