### PR TITLE
Fix _has_valid_outer_pip when pip is missing

### DIFF
--- a/docs/changelog/1003.fix.rst
+++ b/docs/changelog/1003.fix.rst
@@ -1,0 +1,2 @@
+Fix ``_has_valid_outer_pip`` returning ``True`` when pip is missing, causing build to try using a non-existent pip
+instead of falling back to virtualenv.

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -188,7 +188,7 @@ class _PipBackend(_EnvBackend):
                         return True
             return False
 
-        return True
+        return None  # pragma: no cover
 
     @functools.cached_property
     def _has_virtualenv(self) -> bool:


### PR DESCRIPTION
#980 inverted the control flow of `_has_valid_outer_pip` to use a walrus operator, but the final `return True` was not updated. When pip is missing, `_has_dependency` returns `None`, the `if dist :=` block is skipped, and the method returns `True` instead of `None`.

This causes `build` to try using a non-existent pip via `--python` instead of falling back to virtualenv.