### PR TITLE
🐛 fix(api): resolve thread-safety races in build API

### DIFF
--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -332,7 +332,7 @@ class ProjectBuilder:
                 msg = f"Build path '{outdir}' exists and is not a directory"
                 raise BuildException(msg)
         else:
-            os.makedirs(outdir)
+            os.makedirs(outdir, exist_ok=True)
 
         with self._handle_backend(hook_name):
             basename: str = callback(outdir, config_settings, **kwargs)

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -111,8 +111,7 @@ class DefaultIsolatedEnv(IsolatedEnv):
         return self
 
     def __exit__(self, *args: object) -> None:
-        if os.path.exists(self._path):  # in case the user already deleted skip remove
-            shutil.rmtree(self._path)
+        shutil.rmtree(self._path, ignore_errors=True)
 
     @property
     def path(self) -> str:
@@ -282,8 +281,8 @@ class _PipBackend(_EnvBackend):
             else:
                 cmd = [self.python_executable, '-Im', 'pip']
 
-            if _ctx.verbosity > 1:
-                cmd += [f'-{"v" * (_ctx.verbosity - 1)}']
+            if (verbosity := _ctx.verbosity) > 1:
+                cmd += [f'-{"v" * (verbosity - 1)}']
 
             cmd += ['install', '--use-pep517', '--no-warn-script-location', '--no-compile']
 
@@ -339,8 +338,8 @@ class _UvBackend(_EnvBackend):
         with contextlib.ExitStack() as exit_stack:
             cmd = [self._uv_bin, 'pip']
 
-            if _ctx.verbosity > 1:
-                cmd += [f'-{"v" * min(2, _ctx.verbosity - 1)}']
+            if (verbosity := _ctx.verbosity) > 1:
+                cmd += [f'-{"v" * min(2, verbosity - 1)}']
 
             cmd += ['install', *requirements]
             cmd += ['--python', self.python_executable]


### PR DESCRIPTION
An adversarial audit of thread-safety (per #377) found three remaining races after the `os.chdir()` removal in #536. While the core `ProjectBuilder` API works correctly with separate instances per thread, these edge cases can bite callers using shared output directories or concurrent environment teardown.

🔧 `_call_backend` uses `os.path.exists()` followed by `os.makedirs()` without `exist_ok=True`. Two threads building into the same output directory race on directory creation, and one crashes with `FileExistsError`. `DefaultIsolatedEnv.__exit__` has a similar TOCTOU between `os.path.exists()` and `shutil.rmtree()`. The verbosity flag construction in both `_PipBackend` and `_UvBackend` reads `_ctx.verbosity` twice without caching, allowing an inconsistent value if the context changes between reads.

A separate `subprocess_runner()` context manager race lives upstream in `pyproject_hooks` — filed as https://github.com/pypa/pyproject-hooks/issues/226.

Closes #377