### PR TITLE
🐛 fix(builder): validate backend-path entries exist on disk

### DIFF
--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -115,6 +115,14 @@ def _parse_build_system_table(pyproject_toml: Mapping[str, Any]) -> Mapping[str,
     return build_system_table
 
 
+def _validate_backend_path(source_dir: str, backend_paths: Sequence[str]) -> None:
+    for path in backend_paths:
+        resolved = os.path.join(source_dir, path)
+        if not os.path.isdir(resolved):
+            msg = f'`backend-path` entry {path!r} does not exist or is not a directory'
+            raise BuildSystemTableValidationError(msg)
+
+
 def _wrap_subprocess_runner(runner: SubprocessRunner, env: env.IsolatedEnv) -> SubprocessRunner:
     def _invoke_wrapped_runner(
         cmd: Sequence[str], cwd: str | None = None, extra_environ: Mapping[str, str] | None = None
@@ -162,6 +170,9 @@ class ProjectBuilder:
         self._build_system = _parse_build_system_table(_read_pyproject_toml(pyproject_toml_path))
 
         self._backend = self._build_system['build-backend']
+
+        if backend_paths := self._build_system.get('backend-path'):
+            _validate_backend_path(self._source_dir, backend_paths)
 
         self._hook = pyproject_hooks.BuildBackendHookCaller(
             self._source_dir,

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -9,6 +9,7 @@ import pathlib
 import sys
 import textwrap
 
+from collections.abc import Callable
 from typing import NoReturn
 
 import pyproject_hooks
@@ -632,7 +633,7 @@ def test_parse_invalid_build_system_table_type(pyproject_toml, error_message):
         pytest.param(lambda tmp_path: (tmp_path / 'bad').write_text('', encoding='utf-8'), id='file-not-dir'),
     ],
 )
-def test_backend_path_invalid_directory(tmp_path: pathlib.Path, setup: object) -> None:
+def test_backend_path_invalid_directory(tmp_path: pathlib.Path, setup: Callable[[pathlib.Path], None]) -> None:
     (tmp_path / 'pyproject.toml').write_text(
         textwrap.dedent("""\
             [build-system]
@@ -642,6 +643,6 @@ def test_backend_path_invalid_directory(tmp_path: pathlib.Path, setup: object) -
         """),
         encoding='utf-8',
     )
-    setup(tmp_path)  # type: ignore[operator]
+    setup(tmp_path)
     with pytest.raises(build.BuildSystemTableValidationError, match='does not exist or is not a directory'):
         build.ProjectBuilder(tmp_path)

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -623,3 +623,25 @@ def test_parse_valid_build_system_table_type(pyproject_toml, parse_output):
 def test_parse_invalid_build_system_table_type(pyproject_toml, error_message):
     with pytest.raises(build.BuildSystemTableValidationError, match=error_message):
         build._builder._parse_build_system_table(pyproject_toml)
+
+
+@pytest.mark.parametrize(
+    'setup',
+    [
+        pytest.param(lambda _tmp_path: None, id='nonexistent'),
+        pytest.param(lambda tmp_path: (tmp_path / 'bad').write_text('', encoding='utf-8'), id='file-not-dir'),
+    ],
+)
+def test_backend_path_invalid_directory(tmp_path: pathlib.Path, setup: object) -> None:
+    (tmp_path / 'pyproject.toml').write_text(
+        textwrap.dedent("""\
+            [build-system]
+            requires = []
+            build-backend = "backend"
+            backend-path = ["bad"]
+        """),
+        encoding='utf-8',
+    )
+    setup(tmp_path)  # type: ignore[operator]
+    with pytest.raises(build.BuildSystemTableValidationError, match='does not exist or is not a directory'):
+        build.ProjectBuilder(tmp_path)


### PR DESCRIPTION
When `backend-path` in `pyproject.toml` points to a nonexistent directory (typo, missing checkout, wrong relative path), the error only surfaces deep inside a subprocess as an opaque `BackendUnavailable` exception from `pyproject_hooks`. This makes it hard to diagnose what went wrong.

This adds early validation in `ProjectBuilder.__init__` that checks each `backend-path` entry resolves to an existing directory relative to the source directory. When it doesn't, a `BuildSystemTableValidationError` is raised immediately with a clear message identifying the bad path. This is consistent with the existing type validation already performed on `[build-system]` table fields.

Closes #145