### PR TITLE
fix: correct changelog category ordering

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,12 @@
 - Allow setting build constraints - by :user:`gaborbernat` (:issue:`963`)
 - Automate releases with pre-release workflow and trusted publishing - by :user:`gaborbernat` (:issue:`991`)
 
+**********
+ Bugfixes
+**********
+
+- Fix pip hack workaround - by :user:`gaborbernat` (:issue:`980`)
+
 ***************
  Documentation
 ***************
@@ -35,12 +41,6 @@
 ***************
 
 - :issue:`991`
-
-**********
- Bugfixes
-**********
-
-- Fix pip hack workaround - by :user:`gaborbernat` (:issue:`980`)
 
 ####################
  1.4.0 (2026-01-08)

--- a/docs/changelog/1007.bugfix.rst
+++ b/docs/changelog/1007.bugfix.rst
@@ -1,0 +1,1 @@
+Fix towncrier template to generate changelog categories in definition order - by :user:`gaborbernat`

--- a/docs/changelog/1015.bugfix.rst
+++ b/docs/changelog/1015.bugfix.rst
@@ -1,0 +1,1 @@
+Resolve thread-safety races in the build API - by :user:`gaborbernat`

--- a/docs/changelog/1016.bugfix.rst
+++ b/docs/changelog/1016.bugfix.rst
@@ -1,0 +1,1 @@
+Validate ``backend-path`` entries exist on disk with a clear error - by :user:`gaborbernat`

--- a/docs/changelog/973.feature.rst
+++ b/docs/changelog/973.feature.rst
@@ -1,0 +1,1 @@
+Add ``kind`` parameter to log messages to separate semantic and representation - by :user:`abitrolly`

--- a/docs/changelog/template.jinja2
+++ b/docs/changelog/template.jinja2
@@ -8,7 +8,8 @@
 {% for section, _ in sections.items() %}
 {% set section_entries = sections[section] %}
 {% if section_entries %}
-{% for category, entries in section_entries.items() if entries %}
+{% for category in definitions.keys() if section_entries.get(category) %}
+{% set entries = section_entries[category] %}
 {{ underlines[0] * (definitions[category]['name']|length + 2) }}
  {{ definitions[category]['name'] }}
 {{ underlines[0] * (definitions[category]['name']|length + 2) }}


### PR DESCRIPTION
## Summary
- Move Bugfixes before Documentation in the 1.4.1 changelog section to match the towncrier type definition order
- Fix towncrier template to iterate categories using `definitions.keys()` order (from pyproject.toml) instead of
  `section_entries.items()` (filesystem-dependent `os.listdir()` order via `split_fragments`)

**Root cause**: towncrier's `split_fragments()` populates the category dict via `setdefault()` as it processes fragment
files from `os.listdir()`. On the CI runner that generated 1.4.1, `980.bugfix.rst` was listed after `991.misc.rst`,
placing Bugfixes after Miscellaneous.

Closes #1007