### PR TITLE
chore: lazy imports

### DIFF
--- a/docs/changelog/1021.misc.rst
+++ b/docs/changelog/1021.misc.rst
@@ -1,0 +1,1 @@
+Use lazy imports on Python 3.15+.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,10 +205,14 @@ extend-select = [
   "TRY",    # tryceratops
   "EM",     # flake8-errmsg
   "TID251", # flake8-tidy-imports
+  "TC",   # flake8-type-checking
 ]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "typing.TYPE_CHECKING".msg = "Use TYPE_CHECKING=False instead"
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**.py" = ["TID251", "TC"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,18 +193,22 @@ quote-style = "single"
 
 [tool.ruff.lint]
 extend-select = [
-  "B",    # flake8-bugbear
-  "C4",   # flake8-comprehensions
-  "C9",   # mccabe
-  "I",    # isort
-  "PGH",  # pygrep-hooks
-  "RUF",  # ruff
-  "UP",   # pyupgrade
-  "W",    # pycodestyle
-  "YTT",  # flake8-2020
-  "TRY",  # tryceratops
-  "EM",   # flake8-errmsg
+  "B",      # flake8-bugbear
+  "C4",     # flake8-comprehensions
+  "C9",     # mccabe
+  "I",      # isort
+  "PGH",    # pygrep-hooks
+  "RUF",    # ruff
+  "UP",     # pyupgrade
+  "W",      # pycodestyle
+  "YTT",    # flake8-2020
+  "TRY",    # tryceratops
+  "EM",     # flake8-errmsg
+  "TID251", # flake8-tidy-imports
 ]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"typing.TYPE_CHECKING".msg = "Use TYPE_CHECKING=False instead"
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -4,6 +4,14 @@ build - A simple, correct Python build frontend
 
 from __future__ import annotations
 
+
+__lazy_modules__ = [
+    f'{__spec__.parent}._builder',
+    f'{__spec__.parent}._exceptions',
+    f'{__spec__.parent}._types',
+    f'{__spec__.parent}._util',
+]
+
 from ._builder import ProjectBuilder
 from ._exceptions import (
     BuildBackendException,

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -16,7 +16,6 @@ import textwrap
 import traceback
 import warnings
 
-from collections.abc import Iterator, Mapping, Sequence
 from functools import partial
 from typing import Any, NoReturn, TextIO
 
@@ -27,8 +26,15 @@ import build
 from . import ProjectBuilder, _ctx
 from . import env as _env
 from ._exceptions import BuildBackendException, BuildException, FailedProcessError
-from ._types import ConfigSettings, Distribution, StrPath, SubprocessRunner
 from .env import DefaultIsolatedEnv
+
+
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping, Sequence
+
+    from ._types import ConfigSettings, Distribution, StrPath, SubprocessRunner
 
 
 _COLORS = {

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -53,7 +53,7 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping, Sequence
 
-    from ._types import ConfigSettings, Distribution, StrPath, SubprocessRunner
+    from build._types import ConfigSettings, Distribution, StrPath, SubprocessRunner
 
 
 _COLORS = {

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -2,6 +2,25 @@
 
 from __future__ import annotations
 
+
+__lazy_modules__ = [
+    'argparse',
+    f'{__spec__.parent}._exceptions',
+    f'{__spec__.parent}.env',
+    'functools',
+    'json',
+    'os',
+    'platform',
+    'pyproject_hooks',
+    'shutil',
+    'subprocess',
+    'tempfile',
+    'textwrap',
+    'traceback',
+    'typing',
+    'warnings',
+]
+
 import argparse
 import contextlib
 import contextvars

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 __lazy_modules__ = [
     'argparse',
-    f'{__spec__.parent}._exceptions',
-    f'{__spec__.parent}.env',
+    'build._exceptions',
+    'build.env',
     'functools',
     'json',
     'os',
@@ -41,11 +41,11 @@ from typing import Any, NoReturn, TextIO
 import pyproject_hooks
 
 import build
+import build.env as _env
 
-from . import ProjectBuilder, _ctx
-from . import env as _env
-from ._exceptions import BuildBackendException, BuildException, FailedProcessError
-from .env import DefaultIsolatedEnv
+from build import ProjectBuilder, _ctx
+from build._exceptions import BuildBackendException, BuildException, FailedProcessError
+from build.env import DefaultIsolatedEnv
 
 
 TYPE_CHECKING = False

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -2,6 +2,21 @@
 
 from __future__ import annotations
 
+
+__lazy_modules__ = [
+    'contextlib',
+    'difflib',
+    f'{__spec__.parent}._compat',
+    f'{__spec__.parent}._exceptions',
+    f'{__spec__.parent}._util',
+    'os',
+    'pyproject_hooks',
+    'subprocess',
+    'sys',
+    'warnings',
+    'zipfile',
+]
+
 import contextlib
 import difflib
 import os

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -10,7 +10,6 @@ import sys
 import warnings
 import zipfile
 
-from collections.abc import Iterator, Mapping, Sequence
 from typing import Any, TypeVar
 
 import pyproject_hooks
@@ -23,8 +22,15 @@ from ._exceptions import (
     BuildSystemTableValidationError,
     TypoWarning,
 )
-from ._types import ConfigSettings, Distribution, StrPath, SubprocessRunner
 from ._util import check_dependency, parse_wheel_filename
+
+
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping, Sequence
+
+    from ._types import ConfigSettings, Distribution, StrPath, SubprocessRunner
 
 
 _TProjectBuilder = TypeVar('_TProjectBuilder', bound='ProjectBuilder')

--- a/src/build/_compat/importlib.py
+++ b/src/build/_compat/importlib.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import sys
-import typing
 
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
     import importlib_metadata as metadata
 else:
     if sys.version_info >= (3, 10, 2):

--- a/src/build/_compat/tarfile.py
+++ b/src/build/_compat/tarfile.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import sys
 import tarfile
-import typing
 
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
     TarFile = tarfile.TarFile
 
 else:

--- a/src/build/_compat/tomllib.py
+++ b/src/build/_compat/tomllib.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+
+__lazy_modules__ = ['tomli', 'tomllib']
+
 import sys
 
 

--- a/src/build/_ctx.py
+++ b/src/build/_ctx.py
@@ -74,7 +74,9 @@ def run_subprocess(cmd: Sequence[StrPath], cwd: str | None = None, env: Mapping[
             raise
 
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
     log: Logger
     verbosity: bool
 

--- a/src/build/_ctx.py
+++ b/src/build/_ctx.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+
+__lazy_modules__ = ['subprocess']
+
 import contextvars
 import logging
 import subprocess

--- a/src/build/_ctx.py
+++ b/src/build/_ctx.py
@@ -5,9 +5,13 @@ import logging
 import subprocess
 import typing
 
-from collections.abc import Mapping, Sequence
 
-from ._types import StrPath
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from ._types import StrPath
 
 
 class Logger(typing.Protocol):  # pragma: no cover
@@ -73,8 +77,6 @@ def run_subprocess(cmd: Sequence[StrPath], cwd: str | None = None, env: Mapping[
             log_subprocess_error(error)
             raise
 
-
-TYPE_CHECKING = False
 
 if TYPE_CHECKING:
     log: Logger

--- a/src/build/_exceptions.py
+++ b/src/build/_exceptions.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
-import subprocess
-import types
+
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    import subprocess
+    import types
 
 
 class BuildException(Exception):

--- a/src/build/_types.py
+++ b/src/build/_types.py
@@ -11,7 +11,9 @@ Distribution = typing.Literal['sdist', 'wheel', 'editable']
 
 StrPath = typing.Union[str, os.PathLike[str]]
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
     from pyproject_hooks import SubprocessRunner
 else:
     SubprocessRunner = typing.Callable[

--- a/src/build/_util.py
+++ b/src/build/_util.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import re
 
-from collections.abc import Iterator, Set
+
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Set
 
 
 _WHEEL_FILENAME_REGEX = re.compile(

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -22,7 +22,9 @@ from ._exceptions import FailedProcessError
 from ._util import check_dependency
 
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
     from ._compat.importlib import metadata as importlib_metadata
 
 

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -1,5 +1,24 @@
 from __future__ import annotations
 
+
+__lazy_modules__ = [
+    'abc',
+    'contextlib',
+    f'{__spec__.parent}._ctx',
+    f'{__spec__.parent}._exceptions',
+    f'{__spec__.parent}._util',
+    'importlib',
+    'importlib.util',
+    'os',
+    'platform',
+    'shutil',
+    'subprocess',
+    'sys',
+    'sysconfig',
+    'tempfile',
+    'warnings',
+]
+
 import abc
 import contextlib
 import functools

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -14,8 +14,6 @@ import tempfile
 import typing
 import warnings
 
-from collections.abc import Collection, Mapping
-
 from . import _ctx
 from ._ctx import run_subprocess
 from ._exceptions import FailedProcessError
@@ -25,6 +23,8 @@ from ._util import check_dependency
 TYPE_CHECKING = False
 
 if TYPE_CHECKING:
+    from collections.abc import Collection, Mapping
+
     from ._compat.importlib import metadata as importlib_metadata
 
 

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+
+__lazy_modules__ = [f'{__spec__.parent}._compat', f'{__spec__.parent}.env', 'pathlib', 'tempfile']
+
 import pathlib
 import tempfile
 

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -9,8 +9,12 @@ import pyproject_hooks
 
 from . import ProjectBuilder
 from ._compat import importlib
-from ._types import StrPath, SubprocessRunner
 from .env import DefaultIsolatedEnv
+
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from ._types import StrPath, SubprocessRunner
 
 
 def _project_wheel_metadata(builder: ProjectBuilder) -> importlib.metadata.PackageMetadata:


### PR DESCRIPTION
- **chore: use TYPE_CHECKING=False trick**
- **chore: enforce TYPE_CHECKING=False trick**
- **chore: add lazy imports**

## Description

<!-- Describe what changes you made and why -->

This adds lazy imports.

```console
$ hyperfine --warmup 10 \
    -n FullLazy ".venv/bin/python -X lazy_imports=all    -m build -h" \
    --reference ".venv/bin/python -X lazy_imports=normal -m build -h" \
    -n Eager    ".venv/bin/python -X lazy_imports=none   -m build -h"
...
  .venv/bin/python -X lazy_imports=normal -m build -h ran
    1.31 ± 0.12 times slower than FullLazy
    1.10 ± 0.11 times faster than Eager
```

I used `uvx flake8-lazy —-apply src/**/*.py` to get the lazy lists.

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

- [ ] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing ``Add custom backend support - by :user:`yourname` ``

## Checklist

- [ ] Tests pass locally (`tox`)
- [ ] Code follows project style (`tox -e fix`)
- [ ] Type checks pass (`tox -e type`)
- [ ] Documentation builds (`tox -e docs`)
