### PR TITLE
🐛 fix(env): strip PYTHONPATH from isolated builds

### DIFF
--- a/docs/changelog/405.bugfix.rst
+++ b/docs/changelog/405.bugfix.rst
@@ -1,0 +1,2 @@
+Strip ``PYTHONPATH`` from the environment during isolated builds to prevent host packages from leaking into the build -
+by :user:`gaborbernat`

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -154,7 +154,11 @@ class DefaultIsolatedEnv(IsolatedEnv):
         return {
             'PATH': os.pathsep.join([self._env_backend.scripts_dir, path])
             if path is not None
-            else self._env_backend.scripts_dir
+            else self._env_backend.scripts_dir,
+            # Set PYTHONPATH to empty to override any host value. An empty
+            # PYTHONPATH is treated as unset by CPython's path initialization
+            # (the ``if pythonpath_env:`` check makes it a no-op).
+            'PYTHONPATH': '',
         }
 
     def install(self, requirements: Collection[str], constraints: Collection[str] = []) -> None:
@@ -383,7 +387,9 @@ class _UvBackend(_EnvBackend):
 
                 cmd += ['-c', os.path.abspath(constraint_file.name)]
 
-            run_subprocess(cmd, env={**os.environ, 'VIRTUAL_ENV': self._env_path})
+            env = {k: v for k, v in os.environ.items() if k != 'PYTHONPATH'}
+            env['VIRTUAL_ENV'] = self._env_path
+            run_subprocess(cmd, env=env)
 
     @property
     def display_name(self) -> str:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -28,6 +28,25 @@ MISSING_UV = importlib.util.find_spec('uv') is None and not shutil.which('uv')
 MISSING_VIRTUALENV = importlib.util.find_spec('virtualenv') is None
 
 
+def test_make_extra_environ_overrides_pythonpath() -> None:
+    with build.env.DefaultIsolatedEnv() as env:
+        extra = env.make_extra_environ()
+        assert extra['PYTHONPATH'] == ''
+        assert env._env_backend.scripts_dir in extra['PATH']
+
+
+def test_uv_install_strips_pythonpath(
+    mocker: pytest_mock.MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv('PYTHONPATH', '/some/leaky/path')
+    run_subprocess = mocker.patch('build.env.run_subprocess')
+    with build.env.DefaultIsolatedEnv(installer='uv') as env:
+        env.install(['some-package'])
+    (install_call,) = run_subprocess.call_args_list
+    assert 'PYTHONPATH' not in install_call.kwargs['env']
+
+
 @pytest.mark.isolated
 def test_isolation() -> None:
     subprocess.check_call([sys.executable, '-c', 'import build.env'])


### PR DESCRIPTION
Closes #405

When `PYTHONPATH` is set in the host environment, it leaks into isolated build subprocesses. The build backend and package installers then discover packages from the host instead of the isolated venv, breaking the isolation contract. 🔒 This causes hard-to-diagnose build failures when the host has incompatible package versions — for example, an old pip that lacks `--use-pep517`.

The fix clears `PYTHONPATH` in `make_extra_environ()` so all backend hook calls via pyproject_hooks strip it from their subprocess environment. The uv backend's install path, which explicitly passes `os.environ`, also gets the same treatment. Internal pip calls already use `-Im` (isolated mode) which ignores `PYTHONPATH`, so they were unaffected.

Setting `PYTHONPATH` to an empty string (rather than removing it) ensures the key is present in the environment dict and overrides whatever value the host had, even when the runner merges it with `os.environ.copy()`. Non-isolated builds (`--no-isolation`) are unaffected since they don't go through `DefaultIsolatedEnv`.