### PR TITLE
🐛 fix(check_dependency): verify URL reqs via PEP 610

### DIFF
--- a/docs/changelog/860.bugfix.rst
+++ b/docs/changelog/860.bugfix.rst
@@ -1,0 +1,2 @@
+``check_dependency`` now reports URL requirements as unmet instead of silently accepting them when a package with the
+same name is installed - by :user:`gaborbernat`

--- a/src/build/_util.py
+++ b/src/build/_util.py
@@ -9,12 +9,30 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from collections.abc import Set as AbstractSet
 
+    from ._compat.importlib import metadata
+
 
 _WHEEL_FILENAME_REGEX = re.compile(
     r'(?P<distribution>.+)-(?P<version>.+)'
     r'(-(?P<build_tag>.+))?-(?P<python_tag>.+)'
     r'-(?P<abi_tag>.+)-(?P<platform_tag>.+)\.whl'
 )
+
+
+def _url_matches_direct_url(req_url: str, dist: metadata.Distribution) -> bool:
+    """Check if the installed distribution's origin (PEP 610) matches the requirement URL."""
+    import json
+
+    if not (raw := dist.read_text('direct_url.json')):
+        return False
+    direct_url: dict[str, object] = json.loads(raw)
+    url = direct_url.get('url', '')
+    if isinstance(vcs_info := direct_url.get('vcs_info'), dict):
+        origin = f'{vcs_info.get("vcs", "")}+{url}'
+        if requested_revision := vcs_info.get('requested_revision'):
+            origin += f'@{requested_revision}'
+        return bool(req_url == origin)
+    return bool(req_url == url)
 
 
 def check_dependency(
@@ -55,7 +73,10 @@ def check_dependency(
         # dependency is not installed in the environment.
         yield (*ancestral_req_strings, normalised_req_string)
     else:
-        if req.specifier and not req.specifier.contains(dist.version, prereleases=True):
+        if req.url and not _url_matches_direct_url(req.url, dist):
+            # the installed distribution's origin does not match the URL requirement (PEP 610).
+            yield (*ancestral_req_strings, normalised_req_string)
+        elif req.specifier and not req.specifier.contains(dist.version, prereleases=True):
             # the installed version is incompatible.
             yield (*ancestral_req_strings, normalised_req_string)
         elif dist.requires:

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -43,17 +43,11 @@ class MockDistribution(_importlib.metadata.Distribution):
             return self._metadata
         return ''
 
+    _registry: typing.ClassVar[dict[str, type[MockDistribution]]] = {}
+
     @classmethod
     def from_name(cls, name: str) -> MockDistribution:
-        registry: dict[str, type[MockDistribution]] = {
-            'extras_dep': ExtraMockDistribution,
-            'requireless_dep': RequirelessMockDistribution,
-            'recursive_dep': RecursiveMockDistribution,
-            'prerelease_dep': PrereleaseMockDistribution,
-            'circular_dep': CircularMockDistribution,
-            'nested_circular_dep': NestedCircularMockDistribution,
-        }
-        if (dist_cls := registry.get(name)) is not None:
+        if (dist_cls := cls._registry.get(name)) is not None:
             return dist_cls()
         raise _importlib.metadata.PackageNotFoundError
 
@@ -110,6 +104,18 @@ class NestedCircularMockDistribution(MockDistribution):
         Requires-Dist: circular_dep""")
 
 
+MockDistribution._registry.update(
+    {
+        'extras_dep': ExtraMockDistribution,
+        'requireless_dep': RequirelessMockDistribution,
+        'recursive_dep': RecursiveMockDistribution,
+        'prerelease_dep': PrereleaseMockDistribution,
+        'circular_dep': CircularMockDistribution,
+        'nested_circular_dep': NestedCircularMockDistribution,
+    }
+)
+
+
 @pytest.mark.parametrize(
     ('requirement_string', 'expected'),
     [
@@ -146,6 +152,95 @@ class NestedCircularMockDistribution(MockDistribution):
 def test_check_dependency(monkeypatch: pytest.MonkeyPatch, requirement_string: str, expected: tuple[str, ...] | None) -> None:
     monkeypatch.setattr(_importlib.metadata, 'Distribution', MockDistribution)
     assert next(build.check_dependency(requirement_string), None) == expected
+
+
+class _DirectUrlMixin(MockDistribution):
+    _direct_url_json: str = ''
+
+    def read_text(self, filename: str) -> str:
+        if filename == 'direct_url.json':
+            return self._direct_url_json
+        return super().read_text(filename)
+
+
+class DirectUrlMockDistribution(_DirectUrlMixin):
+    _metadata = textwrap.dedent("""\
+        Metadata-Version: 2.2
+        Name: direct_url_dep
+        Version: 1.0.0""")
+    _direct_url_json = '{"url": "https://example.com/direct_url_dep-1.0.0.tar.gz", "archive_info": {}}'
+
+
+class VcsDirectUrlMockDistribution(_DirectUrlMixin):
+    _metadata = textwrap.dedent("""\
+        Metadata-Version: 2.2
+        Name: vcs_dep
+        Version: 1.0.0""")
+    _direct_url_json = (
+        '{"url": "https://github.com/example/vcs_dep.git",'
+        ' "vcs_info": {"vcs": "git", "requested_revision": "v1.0.0",'
+        ' "commit_id": "abc123"}}'
+    )
+
+
+class VcsNoRevisionMockDistribution(_DirectUrlMixin):
+    _metadata = textwrap.dedent("""\
+        Metadata-Version: 2.2
+        Name: vcs_dep
+        Version: 1.0.0""")
+    _direct_url_json = '{"url": "https://github.com/example/vcs_dep.git", "vcs_info": {"vcs": "git", "commit_id": "abc123"}}'
+
+
+MockDistribution._registry.update(
+    {
+        'direct_url_dep': DirectUrlMockDistribution,
+        'vcs_dep': VcsDirectUrlMockDistribution,
+    }
+)
+
+
+@pytest.mark.parametrize(
+    'requirement_string',
+    [
+        'extras_dep @ https://example.com/extras_dep-1.0.0.tar.gz',
+        'missing_dep @ https://example.com/missing_dep-1.0.0.tar.gz',
+    ],
+)
+def test_check_dependency_url_no_direct_url_is_unmet(monkeypatch: pytest.MonkeyPatch, requirement_string: str) -> None:
+    monkeypatch.setattr(_importlib.metadata, 'Distribution', MockDistribution)
+    assert next(build.check_dependency(requirement_string), None) is not None
+
+
+def test_check_dependency_url_matching_direct_url_is_met(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_importlib.metadata, 'Distribution', MockDistribution)
+    assert next(build.check_dependency('direct_url_dep @ https://example.com/direct_url_dep-1.0.0.tar.gz'), None) is None
+
+
+def test_check_dependency_url_mismatched_direct_url_is_unmet(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_importlib.metadata, 'Distribution', MockDistribution)
+    assert next(build.check_dependency('direct_url_dep @ https://example.com/other-1.0.0.tar.gz'), None) is not None
+
+
+def test_check_dependency_vcs_url_matching_direct_url_is_met(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_importlib.metadata, 'Distribution', MockDistribution)
+    assert next(build.check_dependency('vcs_dep @ git+https://github.com/example/vcs_dep.git@v1.0.0'), None) is None
+
+
+def test_check_dependency_vcs_url_mismatched_direct_url_is_unmet(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_importlib.metadata, 'Distribution', MockDistribution)
+    assert next(build.check_dependency('vcs_dep @ git+https://github.com/example/vcs_dep.git@v2.0.0'), None) is not None
+
+
+def test_check_dependency_vcs_url_no_revision_is_met(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_importlib.metadata, 'Distribution', MockDistribution)
+    monkeypatch.setitem(MockDistribution._registry, 'vcs_dep', VcsNoRevisionMockDistribution)
+    assert next(build.check_dependency('vcs_dep @ git+https://github.com/example/vcs_dep.git'), None) is None
+
+
+def test_check_dependency_vcs_url_no_revision_mismatch_is_unmet(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_importlib.metadata, 'Distribution', MockDistribution)
+    monkeypatch.setitem(MockDistribution._registry, 'vcs_dep', VcsNoRevisionMockDistribution)
+    assert next(build.check_dependency('vcs_dep @ git+https://github.com/other/repo.git'), None) is not None
 
 
 def test_bad_project(package_test_no_project: str) -> None:


### PR DESCRIPTION
`check_dependency` silently accepted URL requirements like `pkg @ https://...` whenever a package with the same name was already installed, regardless of its origin. 🐛 For example, `packaging==24.2` from PyPI would satisfy `packaging @ git+https://github.com/pypa/packaging.git@24.1`.

The fix uses PEP 610 `direct_url.json` metadata to compare the installed distribution's origin against the required URL. For VCS requirements, the URL is reconstructed from the `vcs_info` fields (`vcs`, `url`, `requested_revision`). A URL requirement is only reported as unmet when the origin doesn't match — if the installed package was installed from the same URL, it's accepted as before.

Fixes #860