### PR TITLE
🐛 fix(env): prevent pip credential hang with private indexes

### DIFF
--- a/docs/changelog/409.bugfix.rst
+++ b/docs/changelog/409.bugfix.rst
@@ -1,0 +1,1 @@
+Pass ``--no-input`` to pip to prevent hidden credential prompts that cause hangs, and automatically set ``PIP_KEYRING_PROVIDER=subprocess`` when the ``keyring`` CLI is on ``PATH`` -- by :user:`gaborbernat`

--- a/docs/changelog/409.bugfix.rst
+++ b/docs/changelog/409.bugfix.rst
@@ -1,2 +1,3 @@
 Pass ``--no-input`` to pip to prevent hidden credential prompts that cause hangs, and automatically set
-``PIP_KEYRING_PROVIDER=subprocess`` when the ``keyring`` CLI is on ``PATH`` -- by :user:`gaborbernat`
+``PIP_KEYRING_PROVIDER=subprocess`` (or ``UV_KEYRING_PROVIDER=subprocess`` for the uv installer) when the ``keyring``
+CLI is on ``PATH`` -- by :user:`gaborbernat`

--- a/docs/changelog/409.bugfix.rst
+++ b/docs/changelog/409.bugfix.rst
@@ -1,1 +1,2 @@
-Pass ``--no-input`` to pip to prevent hidden credential prompts that cause hangs, and automatically set ``PIP_KEYRING_PROVIDER=subprocess`` when the ``keyring`` CLI is on ``PATH`` -- by :user:`gaborbernat`
+Pass ``--no-input`` to pip to prevent hidden credential prompts that cause hangs, and automatically set
+``PIP_KEYRING_PROVIDER=subprocess`` when the ``keyring`` CLI is on ``PATH`` -- by :user:`gaborbernat`

--- a/docs/how-to/corporate-environments.rst
+++ b/docs/how-to/corporate-environments.rst
@@ -304,7 +304,7 @@ See :doc:`troubleshooting` for more details on warnings.
 ***************
 
 Build fails with authentication errors
-=======================================
+======================================
 
 Build passes ``--no-input`` to pip to prevent hidden credential prompts. If your private index requires authentication,
 pip will fail instead of hanging. Configure one of the authentication methods above (embedded credentials, keyring, or

--- a/docs/how-to/corporate-environments.rst
+++ b/docs/how-to/corporate-environments.rst
@@ -69,9 +69,9 @@ Using keyring
 =============
 
 Build passes ``--no-input`` to pip, preventing hidden credential prompts that cause the process to appear stuck. When
-the ``keyring`` CLI is available on ``PATH``, build automatically sets ``PIP_KEYRING_PROVIDER=subprocess`` so pip
-delegates credential lookups to the system keyring without needing keyring installed inside the isolated build
-environment.
+the ``keyring`` CLI is available on ``PATH``, build automatically sets ``PIP_KEYRING_PROVIDER=subprocess`` (or
+``UV_KEYRING_PROVIDER=subprocess`` when using the uv installer) so the installer delegates credential lookups to the
+system keyring without needing keyring installed inside the isolated build environment.
 
 Install keyring system-wide so it is available on ``PATH``:
 
@@ -104,7 +104,8 @@ installed in a non-standard location:
 
 .. code-block:: console
 
-    $ export PIP_KEYRING_PROVIDER=subprocess
+    $ export PIP_KEYRING_PROVIDER=subprocess  # for pip installer
+    $ export UV_KEYRING_PROVIDER=subprocess   # for uv installer
     $ python -m build
 
 To disable keyring entirely:
@@ -112,6 +113,7 @@ To disable keyring entirely:
 .. code-block:: console
 
     $ export PIP_KEYRING_PROVIDER=disabled
+    $ export UV_KEYRING_PROVIDER=disabled
     $ python -m build
 
 Using .netrc

--- a/docs/how-to/corporate-environments.rst
+++ b/docs/how-to/corporate-environments.rst
@@ -68,23 +68,51 @@ You can embed credentials directly in the index URL:
 Using keyring
 =============
 
-Install the keyring package to store credentials securely:
+Build passes ``--no-input`` to pip, preventing hidden credential prompts that cause the process to appear stuck. When
+the ``keyring`` CLI is available on ``PATH``, build automatically sets ``PIP_KEYRING_PROVIDER=subprocess`` so pip
+delegates credential lookups to the system keyring without needing keyring installed inside the isolated build
+environment.
+
+Install keyring system-wide so it is available on ``PATH``:
 
 .. code-block:: console
 
-    $ pip install keyring
+    $ pipx install keyring
 
-Build will automatically use keyring when available. Configure it with:
+Or install build with the keyring extra:
+
+.. code-block:: console
+
+    $ pip install build[keyring]
+
+Then store your credentials:
 
 .. code-block:: console
 
     $ keyring set https://pypi.company.com username
 
-Build will prompt for the password when needed, or you can use:
+For specialized backends (e.g., Google Artifact Registry, Azure Artifacts), install the corresponding keyring plugin
+alongside keyring:
 
 .. code-block:: console
 
-    $ export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring  # Disable keyring if needed
+    $ pipx install keyring
+    $ pipx inject keyring keyrings.google-artifactregistry-auth
+
+You can also set the keyring provider explicitly via environment variable, which is useful in CI or when keyring is
+installed in a non-standard location:
+
+.. code-block:: console
+
+    $ export PIP_KEYRING_PROVIDER=subprocess
+    $ python -m build
+
+To disable keyring entirely:
+
+.. code-block:: console
+
+    $ export PIP_KEYRING_PROVIDER=disabled
+    $ python -m build
 
 Using .netrc
 ============
@@ -275,13 +303,12 @@ See :doc:`troubleshooting` for more details on warnings.
  Common issues
 ***************
 
-Build hangs waiting for input
-=============================
+Build fails with authentication errors
+=======================================
 
-If build appears to hang, it may be waiting for authentication. This happens when pip prompts for credentials but the
-prompt is hidden.
-
-Solution: Use one of the authentication methods above (embedded credentials, keyring, or .netrc).
+Build passes ``--no-input`` to pip to prevent hidden credential prompts. If your private index requires authentication,
+pip will fail instead of hanging. Configure one of the authentication methods above (embedded credentials, keyring, or
+``.netrc``) to provide credentials non-interactively.
 
 401/403 errors
 ==============

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ dependencies = [
 uv = [
   "uv >= 0.1.18",
 ]
+keyring = [
+  "keyring",
+]
 virtualenv = [
   "virtualenv >= 20.11; python_version < '3.10'",
   "virtualenv >= 20.17; python_version >= '3.10' and python_version < '3.14'",

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -406,6 +406,8 @@ class _UvBackend(_EnvBackend):
 
             env = {k: v for k, v in os.environ.items() if k != 'PYTHONPATH'}
             env['VIRTUAL_ENV'] = self._env_path
+            if 'UV_KEYRING_PROVIDER' not in os.environ and _has_keyring_cli():
+                env['UV_KEYRING_PROVIDER'] = 'subprocess'
             run_subprocess(cmd, env=env)
 
     @property

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -191,6 +191,17 @@ class _EnvBackend(typing.Protocol):  # pragma: no cover
     def display_name(self) -> str: ...
 
 
+@functools.cache
+def _has_keyring_cli() -> bool:
+    return shutil.which('keyring') is not None
+
+
+def _pip_env() -> dict[str, str] | None:
+    if 'PIP_KEYRING_PROVIDER' not in os.environ and _has_keyring_cli():
+        return {**os.environ, 'PIP_KEYRING_PROVIDER': 'subprocess'}
+    return None
+
+
 class _PipBackend(_EnvBackend):
     def __init__(self) -> None:
         self._create_with_virtualenv = not self._has_valid_outer_pip and self._has_virtualenv
@@ -296,7 +307,10 @@ class _PipBackend(_EnvBackend):
                     minimum_pip_version_str,
                     path=[purelib],
                 ):
-                    run_subprocess([self.python_executable, '-Im', 'pip', 'install', f'pip>={minimum_pip_version_str}'])
+                    run_subprocess(
+                        [self.python_executable, '-Im', 'pip', 'install', '--no-input', f'pip>={minimum_pip_version_str}'],
+                        env=_pip_env(),
+                    )
 
                 # Uninstall setuptools from the build env to prevent depending on it implicitly.
                 # Pythons 3.12 and up do not install setuptools, check if it exists first.
@@ -304,7 +318,10 @@ class _PipBackend(_EnvBackend):
                     'setuptools',
                     path=[purelib],
                 ):
-                    run_subprocess([self.python_executable, '-Im', 'pip', 'uninstall', '-y', 'setuptools'])
+                    run_subprocess(
+                        [self.python_executable, '-Im', 'pip', 'uninstall', '--no-input', '-y', 'setuptools'],
+                        env=_pip_env(),
+                    )
 
     def install_dependencies(self, requirements: Collection[str], constraints: Collection[str]) -> None:
         with contextlib.ExitStack() as exit_stack:
@@ -316,7 +333,7 @@ class _PipBackend(_EnvBackend):
             if (verbosity := _ctx.verbosity) > 1:
                 cmd += [f'-{"v" * (verbosity - 1)}']
 
-            cmd += ['install', '--use-pep517', '--no-warn-script-location', '--no-compile']
+            cmd += ['install', '--use-pep517', '--no-warn-script-location', '--no-compile', '--no-input']
 
             # pip does not honour environment markers in command line arguments
             # but it does from requirement files.
@@ -337,7 +354,7 @@ class _PipBackend(_EnvBackend):
 
                 cmd += ['-c', os.path.abspath(constraint_file.name)]
 
-            run_subprocess(cmd)
+            run_subprocess(cmd, env=_pip_env())
 
     @property
     def display_name(self) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,7 +94,15 @@ def local_pip(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture(autouse=True)
 def avoid_constraints(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv('PIP_CONSTRAINT', raising=False)
+    monkeypatch.delenv('PIP_KEYRING_PROVIDER', raising=False)
     monkeypatch.delenv('UV_CONSTRAINT', raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _clear_keyring_cache() -> Generator[None, None, None]:
+    build.env._has_keyring_cli.cache_clear()
+    yield
+    build.env._has_keyring_cli.cache_clear()
 
 
 @pytest.fixture(autouse=True, params=[False])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,7 @@ def avoid_constraints(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv('PIP_CONSTRAINT', raising=False)
     monkeypatch.delenv('PIP_KEYRING_PROVIDER', raising=False)
     monkeypatch.delenv('UV_CONSTRAINT', raising=False)
+    monkeypatch.delenv('UV_KEYRING_PROVIDER', raising=False)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -541,3 +541,35 @@ def test_install_dependencies_passes_keyring_env(
 
     (install_call,) = run_subprocess.call_args_list
     assert install_call.kwargs['env']['PIP_KEYRING_PROVIDER'] == 'subprocess'
+
+
+@pytest.mark.skipif(IS_PYPY, reason='uv cannot find PyPy executable')
+@pytest.mark.skipif(MISSING_UV, reason='uv executable not found')
+def test_uv_install_dependencies_passes_keyring_env(  # pragma: no cover -- uv tests are skipped on PyPy
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    mocker.patch('shutil.which', return_value='/usr/bin/keyring')
+
+    with build.env.DefaultIsolatedEnv(installer='uv') as env:
+        run_subprocess = mocker.patch('build.env.run_subprocess')
+        env.install(['some-package'])
+
+    (install_call,) = run_subprocess.call_args_list
+    assert install_call.kwargs['env']['UV_KEYRING_PROVIDER'] == 'subprocess'
+
+
+@pytest.mark.skipif(IS_PYPY, reason='uv cannot find PyPy executable')
+@pytest.mark.skipif(MISSING_UV, reason='uv executable not found')
+def test_uv_install_respects_existing_keyring_env(  # pragma: no cover -- uv tests are skipped on PyPy
+    mocker: pytest_mock.MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mocker.patch('shutil.which', return_value='/usr/bin/keyring')
+    monkeypatch.setenv('UV_KEYRING_PROVIDER', 'disabled')
+
+    with build.env.DefaultIsolatedEnv(installer='uv') as env:
+        run_subprocess = mocker.patch('build.env.run_subprocess')
+        env.install(['some-package'])
+
+    (install_call,) = run_subprocess.call_args_list
+    assert install_call.kwargs['env']['UV_KEYRING_PROVIDER'] == 'disabled'

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -164,12 +164,19 @@ def test_pip_needs_upgrade_mac_os_11(
     with build.env.DefaultIsolatedEnv() as env:
         if Version(pip_version) < Version(min_pip_version):
             assert run_subprocess.call_args_list == [
-                mocker.call([env.python_executable, '-Im', 'pip', 'install', f'pip>={min_pip_version}']),
-                mocker.call([env.python_executable, '-Im', 'pip', 'uninstall', '-y', 'setuptools']),
+                mocker.call(
+                    [env.python_executable, '-Im', 'pip', 'install', '--no-input', f'pip>={min_pip_version}'],
+                    env=mocker.ANY,
+                ),
+                mocker.call(
+                    [env.python_executable, '-Im', 'pip', 'uninstall', '--no-input', '-y', 'setuptools'],
+                    env=mocker.ANY,
+                ),
             ]
         else:
             run_subprocess.assert_called_once_with(
-                [env.python_executable, '-Im', 'pip', 'uninstall', '-y', 'setuptools'],
+                [env.python_executable, '-Im', 'pip', 'uninstall', '--no-input', '-y', 'setuptools'],
+                env=mocker.ANY,
             )
 
 
@@ -231,10 +238,12 @@ def test_default_impl_install_cmd_well_formed(
                 '--use-pep517',
                 '--no-warn-script-location',
                 '--no-compile',
+                '--no-input',
                 '-r',
                 mocker.ANY,
                 *(['-c', mocker.ANY] if constraints else []),
-            ]
+            ],
+            env=mocker.ANY,
         )
 
 
@@ -485,3 +494,50 @@ def test_venv_creation_no_setuptools(
         assert env.python_executable
 
     assert all('setuptools' not in str(c) for c in run_subprocess.call_args_list)
+
+
+def test_has_keyring_cli_found(mocker: pytest_mock.MockerFixture) -> None:
+    mocker.patch('shutil.which', return_value='/usr/bin/keyring')
+    assert build.env._has_keyring_cli() is True
+
+
+def test_has_keyring_cli_missing(mocker: pytest_mock.MockerFixture) -> None:
+    mocker.patch('shutil.which', return_value=None)
+    assert build.env._has_keyring_cli() is False
+
+
+def test_pip_env_with_keyring(mocker: pytest_mock.MockerFixture) -> None:
+    mocker.patch('shutil.which', return_value='/usr/bin/keyring')
+
+    result = build.env._pip_env()
+
+    assert result is not None
+    assert result['PIP_KEYRING_PROVIDER'] == 'subprocess'
+
+
+def test_pip_env_without_keyring(mocker: pytest_mock.MockerFixture) -> None:
+    mocker.patch('shutil.which', return_value=None)
+    assert build.env._pip_env() is None
+
+
+def test_pip_env_respects_existing_env_var(
+    mocker: pytest_mock.MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mocker.patch('shutil.which', return_value='/usr/bin/keyring')
+    monkeypatch.setenv('PIP_KEYRING_PROVIDER', 'import')
+    assert build.env._pip_env() is None
+
+
+@pytest.mark.usefixtures('local_pip')
+def test_install_dependencies_passes_keyring_env(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    mocker.patch('shutil.which', return_value='/usr/bin/keyring')
+
+    with build.env.DefaultIsolatedEnv() as env:
+        run_subprocess = mocker.patch('build.env.run_subprocess')
+        env.install(['some-package'])
+
+    (install_call,) = run_subprocess.call_args_list
+    assert install_call.kwargs['env']['PIP_KEYRING_PROVIDER'] == 'subprocess'


### PR DESCRIPTION
Running `python -m build` against a private PyPI index that requires authentication causes the process to appear frozen. 🔒 pip prompts for credentials interactively, but since build captures subprocess output, the prompt is invisible and there is no way for the user to respond.

All pip subprocess calls now include `--no-input`, converting the silent hang into a clear authentication error. When the `keyring` CLI is available on `PATH`, build sets `PIP_KEYRING_PROVIDER=subprocess` (or `UV_KEYRING_PROVIDER=subprocess` for the uv installer) in the subprocess environment so the installer delegates credential lookups to the system keyring binary rather than trying to import `keyring` (which is unavailable inside the isolated build venv). This respects any user-set provider env var and is silently ignored by older pip versions that predate the flag. A `build[keyring]` optional extra is provided for convenience.

The corporate environments documentation is rewritten to reflect actual behavior: how keyring auto-detection works for both pip and uv installers, how to install keyring system-wide via `pipx`, and how to configure the keyring provider explicitly for CI or non-standard setups.

Fixes #409