### PR TITLE
🐛 fix(release): generate consistent CHANGELOG heading levels

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -45,6 +45,8 @@ jobs:
           git config user.email "$(echo "$user_info" | jq -r '.id')+$(echo "$user_info" | jq -r '.login')@users.noreply.github.com"
       - name: Generate release commit and tag
         run: uv tool run --with tox-uv tox r -e release -- --version "${{ inputs.bump }}" --no-push
+      - name: Verify docs build against the release commit
+        run: uv tool run --with tox-uv tox r -e docs
       - name: Push release commit and tag
         run: |
           git remote set-url origin "https://x-access-token:${GH_RELEASE_TOKEN}@github.com/${{ github.repository }}.git"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,19 +1,19 @@
-********************
+####################
  1.4.3 (2026-04-10)
-********************
+####################
 
-==========
+**********
  Features
-==========
+**********
 
 - Add ``kind`` parameter to log messages to separate semantic and representation - by :user:`abitrolly` (:issue:`973`)
 
-==========
+**********
  Bugfixes
-==========
+**********
 
-- Strip ``PYTHONPATH`` from the environment during isolated builds to prevent host packages from leaking into the build -
-  by :user:`gaborbernat` (:issue:`405`)
+- Strip ``PYTHONPATH`` from the environment during isolated builds to prevent host packages from leaking into the build
+  - by :user:`gaborbernat` (:issue:`405`)
 - Pass ``--no-input`` to pip to prevent hidden credential prompts that cause hangs, and automatically set
   ``PIP_KEYRING_PROVIDER=subprocess`` (or ``UV_KEYRING_PROVIDER=subprocess`` for the uv installer) when the ``keyring``
   CLI is on ``PATH`` -- by :user:`gaborbernat` (:issue:`409`)
@@ -25,9 +25,9 @@
 - Resolve thread-safety races in the build API - by :user:`gaborbernat` (:issue:`1015`)
 - Validate ``backend-path`` entries exist on disk with a clear error - by :user:`gaborbernat` (:issue:`1016`)
 
-===============
+***************
  Miscellaneous
-===============
+***************
 
 - :issue:`1020`, :issue:`1021`
 

--- a/docs/changelog/1031.bugfix.rst
+++ b/docs/changelog/1031.bugfix.rst
@@ -1,0 +1,1 @@
+Fix release pipeline generating ``CHANGELOG.rst`` entries with inconsistent heading levels, which broke ``sphinx -W`` and pinned Read the Docs ``stable`` at 1.4.0 - by :user:`gaborbernat`.

--- a/docs/changelog/1031.bugfix.rst
+++ b/docs/changelog/1031.bugfix.rst
@@ -1,1 +1,2 @@
-Fix release pipeline generating ``CHANGELOG.rst`` entries with inconsistent heading levels, which broke ``sphinx -W`` and pinned Read the Docs ``stable`` at 1.4.0 - by :user:`gaborbernat`.
+Fix release pipeline generating ``CHANGELOG.rst`` entries with inconsistent heading levels, which broke ``sphinx -W``
+and pinned Read the Docs ``stable`` at 1.4.0 - by :user:`gaborbernat`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,8 +244,7 @@ directory = "docs/changelog"
 title_format = false
 issue_format = ":issue:`{issue}`"
 template = "docs/changelog/template.jinja2"
-underlines = ["*", "=", "-"]
-top_underline = "#"
+underlines = ["#", "*", "=", "-"]
 
 [[tool.towncrier.section]]
 path = ""


### PR DESCRIPTION
Read the Docs' `stable` version has been pinned at 1.4.0 since January because every tagged release after it (1.4.1, 1.4.2, 1.4.3) shipped a `CHANGELOG.rst` entry whose heading characters did not match prior entries, and `sphinx -W` rejected the file with `Inconsistent title style: skip from level 1 to 3`. The previous two releases were patched up by hand after the fact; 1.4.3 has not been, which is what issue #1031 reports. 🐛

The root cause traces back to #1002, which added `top_underline = "#"` to `[tool.towncrier]` intending to drive the version overline character. `top_underline` has never been a towncrier config key, though. Its settings loader only reads `underlines`, and internally towncrier passes `underlines[0]` into the template as the `top_underline` variable. The addition was silently ignored from the day it landed, and every subsequent release kept emitting `*` for the version heading and `=` for the section headings, neither of which match the `#`/`*` hierarchy the rest of the changelog uses. When the release script then ran `pre-commit`, docstrfmt rejected the hybrid file and left the new entry half-rewritten.

The fix prepends `#` to `underlines` so towncrier feeds `#` as the top underline and `*` as the section underline, which matches both the historical changelog and docstrfmt's expectations. The 1.4.3 entry is rewritten to the correct hierarchy so the current docs build succeeds without another follow-up patch commit. As a backstop, the `pre-release` workflow now runs `tox r -e docs` against the generated release commit before pushing, so any future regression fails the workflow instead of shipping a tag whose docs cannot build.

Verified end-to-end by running `tox r -e release -- --version 1.4.3 --no-push` against the pre-1.4.3 commit in a worktree: with the config fix, the release script completes, `docstrfmt` stays idempotent, and `sphinx -W -n` builds cleanly. Once 1.4.4 tags with this fix, RTD's `stable` will catch up.

Closes #1031.