### PR TITLE
docs: move source links

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -95,14 +95,14 @@ Where to start
 
    development/contributing
    development/release
+   Source Code <https://github.com/pypa/build/>
+   Issue Tracker <https://github.com/pypa/build/issues>
 
 .. toctree::
-   :caption: Project
+   :caption: Changelog
    :hidden:
 
    changelog
-   Source Code <https://github.com/pypa/build/>
-   Issue Tracker <https://github.com/pypa/build/issues>
 
 .. _pip: https://github.com/pypa/pip
 .. _PyPI: https://pypi.org/


### PR DESCRIPTION
## Description

Move the source links so they are on the screen. Rename `Project` since it's just an expanded list of versions.

Do we really want an expanded list of versions here, actually? It would keep growing...

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

- [ ] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing ``Add custom backend support - by :user:`yourname` ``

## Checklist

- [ ] Tests pass locally (`tox`)
- [ ] Code follows project style (`tox -e fix`)
- [ ] Type checks pass (`tox -e type`)
- [ ] Documentation builds (`tox -e docs`)
