### PR TITLE
feat: drop 3.9, require 3.10+

### DIFF
--- a/.github/workflows/reusable-pytest.yml
+++ b/.github/workflows/reusable-pytest.yml
@@ -15,7 +15,6 @@ jobs:
           - macos
           - windows
         py:
-          - "pypy3.9-v7.3.14"
           - "pypy3.10-v7.3.19"
           - "pypy3.11-v7.3.19"
           - "3.15"
@@ -24,7 +23,6 @@ jobs:
           - "3.12"
           - "3.11"
           - "3.10"
-          - "3.9"
         tox-target:
           - "tox"
           - "min"

--- a/.github/workflows/reusable-type.yml
+++ b/.github/workflows/reusable-type.yml
@@ -13,10 +13,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Python 3.9
+      - name: Setup Python 3.10
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Install tox
         run: python -m pip install tox

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@ import build
 
 
 if hasattr(__builtins__, 'EncodingWarning'):
-    warnings.filterwarnings('ignore', category=EncodingWarning, module='sphinx_copybutton')  # noqa: F821
+    warnings.filterwarnings('ignore', category=EncodingWarning, module='sphinx_copybutton')
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/how-to/choosing-tools.rst
+++ b/docs/how-to/choosing-tools.rst
@@ -83,7 +83,7 @@ See `cibuildwheel documentation <https://cibuildwheel.readthedocs.io/>`_ for com
 
 Use `tox <https://tox.wiki/>`_ when you need to:
 
-- Test your package across multiple Python versions (e.g., 3.9, 3.10, 3.11)
+- Test your package across multiple Python versions (e.g., 3.10, 3.11, 3.12, 3.13, 3.14)
 - Run tests in `isolated environments <https://packaging.python.org/en/latest/glossary/#term-Virtual-Environment>`_
 - Automate testing workflows
 - Run linters (code checkers), formatters, type checkers
@@ -137,7 +137,7 @@ Example ``noxfile.py``:
     import nox
 
 
-    @nox.session(python=["3.8", "3.9", "3.10", "3.11", "3.12"])
+    @nox.session(python=["3.10", "3.11", "3.12", "3.13", "3.14"])
     def tests(session):
         session.install("pytest", "pytest-cov")
         session.run("pytest", "tests")
@@ -232,7 +232,7 @@ CI/CD workflow
         runs-on: ubuntu-latest
         strategy:
           matrix:
-            python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+            python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         steps:
           - uses: actions/checkout@v4
           - uses: actions/setup-python@v5

--- a/docs/how-to/ci-cd.rst
+++ b/docs/how-to/ci-cd.rst
@@ -296,9 +296,9 @@ Matrix builds
       extends: .build_template
       image: python:3.8
 
-    build:py39:
+    build:py310:
       extends: .build_template
-      image: python:3.9
+      image: python:3.10
 
     build:py312:
       extends: .build_template

--- a/docs/how-to/ci-cd.rst
+++ b/docs/how-to/ci-cd.rst
@@ -140,7 +140,7 @@ Test building with multiple Python versions:
         runs-on: ubuntu-latest
         strategy:
           matrix:
-            python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+            python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
         steps:
           - uses: actions/checkout@v4
@@ -292,17 +292,13 @@ Matrix builds
         paths:
           - dist/
 
-    build:py38:
-      extends: .build_template
-      image: python:3.8
-
     build:py310:
       extends: .build_template
       image: python:3.10
 
-    build:py312:
+    build:py314:
       extends: .build_template
-      image: python:3.12
+      image: python:3.14
 
 **********
  CircleCI
@@ -346,11 +342,11 @@ Basic build
 
     language: python
     python:
-      - "3.8"
-      - "3.9"
       - "3.10"
       - "3.11"
       - "3.12"
+      - "3.13"
+      - "3.14"
 
     install:
       - pip install build
@@ -375,10 +371,10 @@ Basic build
 
     strategy:
       matrix:
-        Python38:
-          python.version: '3.8'
-        Python312:
-          python.version: '3.12'
+        Python310:
+          python.version: '3.10'
+        Python314:
+          python.version: '3.14'
 
     steps:
     - task: UsePythonVersion@0

--- a/docs/how-to/install.rst
+++ b/docs/how-to/install.rst
@@ -87,13 +87,11 @@ should be used in this case.
 
 ``build`` is verified to be compatible with the following Python versions:
 
-- 3.9
 - 3.10
 - 3.11
 - 3.12
 - 3.13
 - 3.14
-- PyPy 3.9
 - PyPy 3.10
 - PyPy 3.11
 

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -14,7 +14,7 @@ This tutorial will guide you through installing build and creating your first Py
  Prerequisites
 ***************
 
-You need Python 3.9 or later installed on your system. Check your Python version:
+You need Python 3.10 or later installed on your system. Check your Python version:
 
 .. code-block:: console
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,6 +220,11 @@ ignore = [
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "typing.TYPE_CHECKING".msg = "Use TYPE_CHECKING=False instead"
 "os.path.commonprefix".msg = "Use os.path.commonpath or manually implement string manip"
+"typing.Callable".msg = "Use collections.abc.Callable instead."
+"typing.Iterator".msg = "Use collections.abc.Iterator instead."
+"typing.Mapping".msg = "Use collections.abc.Mapping instead."
+"typing.Sequence".msg = "Use collections.abc.Sequence instead."
+"typing.Set".msg = "Use collections.abc.Set instead."
 
 [tool.ruff.lint.per-file-ignores]
 "tasks/**.py" = ["T20", "INP", "S607"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "flit_core.buildapi"
 name = "build"
 description = "A simple, correct Python build frontend"
 readme = "README.md"
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 license = "MIT"
 authors = [
   { name = "Filipe Laíns", email = "lains@riseup.net" },
@@ -17,7 +17,7 @@ authors = [
 classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
+
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -176,7 +176,7 @@ filterwarnings = [
 [tool.mypy]
 files = ["src", "tests"]
 exclude = ["tests/packages"]
-python_version = "3.9"
+python_version = "3.10"
 strict = true
 enable_error_code = ["ignore-without-code", "truthy-bool", "redundant-expr"]
 warn_unreachable = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,11 +220,6 @@ ignore = [
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "typing.TYPE_CHECKING".msg = "Use TYPE_CHECKING=False instead"
 "os.path.commonprefix".msg = "Use os.path.commonpath or manually implement string manip"
-"typing.Callable".msg = "Use collections.abc.Callable instead."
-"typing.Iterator".msg = "Use collections.abc.Iterator instead."
-"typing.Mapping".msg = "Use collections.abc.Mapping instead."
-"typing.Sequence".msg = "Use collections.abc.Sequence instead."
-"typing.Set".msg = "Use collections.abc.Set instead."
 
 [tool.ruff.lint.per-file-ignores]
 "tasks/**.py" = ["T20", "INP", "S607"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ keyring = [
   "keyring",
 ]
 virtualenv = [
-  "virtualenv >= 20.11; python_version < '3.10'",
   "virtualenv >= 20.17; python_version >= '3.10' and python_version < '3.14'",
   "virtualenv >= 20.31; python_version >= '3.14'",
 ]
@@ -87,7 +86,6 @@ test = [
   "pytest-rerunfailures >= 9.1",
   "pytest-xdist >= 1.34",
   "wheel >= 0.36.0",
-  'setuptools >= 42.0.0; python_version < "3.10"',
   'setuptools >= 56.0.0; python_version == "3.10"',
   'setuptools >= 56.0.0; python_version == "3.11"',
   'setuptools >= 67.8.0; python_version >= "3.12"',

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -114,7 +114,7 @@ def _make_logger() -> _ctx.Logger:
                 case ('subprocess', 'cmd'):
                     for line in message.splitlines():
                         _cprint('{dim}{}{reset}', fill(line, initial_indent='> '), file=sys.stderr)
-                case ('subprocess', _):
+                case ('subprocess', 'stdout'):
                     for line in message.splitlines():
                         _cprint('{dim}{}{reset}', fill(line, initial_indent='< '), file=sys.stderr)
                 case _:

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -106,8 +106,6 @@ def _make_logger() -> _ctx.Logger:
     def log(message: str, *, kind: tuple[str, ...] | None = None) -> None:
         if _ctx.verbosity >= -1:
             match kind:
-                case None:
-                    print(fill(message, initial_indent='  '), file=sys.stderr)  # noqa: T201 # pragma: no cover
                 case ('step', *_):
                     (first, *rest) = message.splitlines()
                     _cprint('{bold}{}{reset}', fill(first, initial_indent='* '), file=sys.stderr)

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -105,18 +105,22 @@ def _make_logger() -> _ctx.Logger:
 
     def log(message: str, *, kind: tuple[str, ...] | None = None) -> None:
         if _ctx.verbosity >= -1:
-            if kind is None:
-                print(fill(message, initial_indent='  '), file=sys.stderr)  # noqa: T201 # pragma: no cover
-            elif kind[0] == 'step':
-                (first, *rest) = message.splitlines()
-                _cprint('{bold}{}{reset}', fill(first, initial_indent='* '), file=sys.stderr)
-                for line in rest:
-                    print(fill(line, initial_indent='  '), file=sys.stderr)  # noqa: T201
-
-            elif kind[0] == 'subprocess':
-                initial_indent = '> ' if kind[1] == 'cmd' else '< '
-                for line in message.splitlines():
-                    _cprint('{dim}{}{reset}', fill(line, initial_indent=initial_indent), file=sys.stderr)
+            match kind:
+                case None:
+                    print(fill(message, initial_indent='  '), file=sys.stderr)  # noqa: T201 # pragma: no cover
+                case ('step', *_):
+                    (first, *rest) = message.splitlines()
+                    _cprint('{bold}{}{reset}', fill(first, initial_indent='* '), file=sys.stderr)
+                    for line in rest:
+                        print(fill(line, initial_indent='  '), file=sys.stderr)  # noqa: T201
+                case ('subprocess', 'cmd'):
+                    for line in message.splitlines():
+                        _cprint('{dim}{}{reset}', fill(line, initial_indent='> '), file=sys.stderr)
+                case ('subprocess', _):
+                    for line in message.splitlines():
+                        _cprint('{dim}{}{reset}', fill(line, initial_indent='< '), file=sys.stderr)
+                case _:
+                    print(fill(message, initial_indent='  '), file=sys.stderr)  # noqa: T201
 
     return log
 

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -114,7 +114,7 @@ def _make_logger() -> _ctx.Logger:
                 case ('subprocess', 'cmd'):
                     for line in message.splitlines():
                         _cprint('{dim}{}{reset}', fill(line, initial_indent='> '), file=sys.stderr)
-                case ('subprocess', 'stdout'):
+                case ('subprocess', 'stdout' | 'stderr'):
                     for line in message.splitlines():
                         _cprint('{dim}{}{reset}', fill(line, initial_indent='< '), file=sys.stderr)
                 case _:

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -114,21 +114,24 @@ def _parse_build_system_table(pyproject_toml: Mapping[str, Any]) -> Mapping[str,
         msg = '`requires` must be an array of strings'
         raise BuildSystemTableValidationError(msg)
 
-    if 'build-backend' not in build_system_table:
-        _find_typo(build_system_table, 'build-backend')
-        # If ``build-backend`` is missing, inject the legacy setuptools backend
-        # but leave ``requires`` intact to emulate pip
-        build_system_table['build-backend'] = _DEFAULT_BACKEND['build-backend']
-    elif not isinstance(build_system_table['build-backend'], str):
-        msg = '`build-backend` must be a string'
-        raise BuildSystemTableValidationError(msg)
+    match build_system_table:
+        case {'build-backend': str()}:
+            pass
+        case {'build-backend': _}:
+            msg = '`build-backend` must be a string'
+            raise BuildSystemTableValidationError(msg)
+        case _:
+            _find_typo(build_system_table, 'build-backend')
+            # If ``build-backend`` is missing, inject the legacy setuptools backend
+            # but leave ``requires`` intact to emulate pip
+            build_system_table['build-backend'] = _DEFAULT_BACKEND['build-backend']
 
-    if 'backend-path' in build_system_table and (
-        not isinstance(build_system_table['backend-path'], list)
-        or not all(isinstance(i, str) for i in build_system_table['backend-path'])
-    ):
-        msg = '`backend-path` must be an array of strings'
-        raise BuildSystemTableValidationError(msg)
+    match build_system_table:
+        case {'backend-path': list() as lst} if all(isinstance(i, str) for i in lst):
+            pass
+        case {'backend-path': _}:
+            msg = '`backend-path` must be an array of strings'
+            raise BuildSystemTableValidationError(msg)
 
     unknown_props = build_system_table.keys() - {'requires', 'build-backend', 'backend-path'}
     if unknown_props:

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -127,7 +127,7 @@ def _parse_build_system_table(pyproject_toml: Mapping[str, Any]) -> Mapping[str,
             build_system_table['build-backend'] = _DEFAULT_BACKEND['build-backend']
 
     match build_system_table:
-        case {'backend-path': list() as lst} if all(isinstance(i, str) for i in lst):
+        case {'backend-path': list() as backend_path} if all(isinstance(i, str) for i in backend_path):
             pass
         case {'backend-path': _}:
             msg = '`backend-path` must be an array of strings'

--- a/src/build/_types.py
+++ b/src/build/_types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import collections.abc
 import os
 import typing
 
@@ -16,4 +17,6 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     from pyproject_hooks import SubprocessRunner
 else:
-    SubprocessRunner = collections.abc.Callable[[collections.abc.Sequence[str], str | None, collections.abc.Mapping[str, str] | None], None]
+    SubprocessRunner = collections.abc.Callable[
+        [collections.abc.Sequence[str], str | None, collections.abc.Mapping[str, str] | None], None
+    ]

--- a/src/build/_types.py
+++ b/src/build/_types.py
@@ -6,16 +6,14 @@ import typing
 
 __all__ = ['ConfigSettings', 'Distribution', 'StrPath', 'SubprocessRunner']
 
-ConfigSettings = typing.Mapping[str, typing.Union[str, typing.Sequence[str]]]
+ConfigSettings = typing.Mapping[str, str | typing.Sequence[str]]
 Distribution = typing.Literal['sdist', 'wheel', 'editable']
 
-StrPath = typing.Union[str, os.PathLike[str]]
+StrPath = str | os.PathLike[str]
 
 TYPE_CHECKING = False
 
 if TYPE_CHECKING:
     from pyproject_hooks import SubprocessRunner
 else:
-    SubprocessRunner = typing.Callable[
-        [typing.Sequence[str], typing.Optional[str], typing.Optional[typing.Mapping[str, str]]], None
-    ]
+    SubprocessRunner = typing.Callable[[typing.Sequence[str], str | None, typing.Mapping[str, str] | None], None]

--- a/src/build/_types.py
+++ b/src/build/_types.py
@@ -6,7 +6,7 @@ import typing
 
 __all__ = ['ConfigSettings', 'Distribution', 'StrPath', 'SubprocessRunner']
 
-ConfigSettings = typing.Mapping[str, str | typing.Sequence[str]]
+ConfigSettings = collections.abc.Mapping[str, str | collections.abc.Sequence[str]]
 Distribution = typing.Literal['sdist', 'wheel', 'editable']
 
 StrPath = str | os.PathLike[str]
@@ -16,4 +16,4 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     from pyproject_hooks import SubprocessRunner
 else:
-    SubprocessRunner = typing.Callable[[typing.Sequence[str], str | None, typing.Mapping[str, str] | None], None]
+    SubprocessRunner = collections.abc.Callable[[collections.abc.Sequence[str], str | None, collections.abc.Mapping[str, str] | None], None]

--- a/src/build/_util.py
+++ b/src/build/_util.py
@@ -16,6 +16,7 @@ _WHEEL_FILENAME_REGEX = re.compile(
     r'-(?P<abi_tag>.+)-(?P<platform_tag>.+)\.whl'
 )
 
+
 def check_dependency(
     req_string: str, ancestral_req_strings: tuple[str, ...] = (), parent_extras: AbstractSet[str] = frozenset()
 ) -> Iterator[tuple[str, ...]]:

--- a/src/build/_util.py
+++ b/src/build/_util.py
@@ -16,7 +16,6 @@ _WHEEL_FILENAME_REGEX = re.compile(
     r'-(?P<abi_tag>.+)-(?P<platform_tag>.+)\.whl'
 )
 
-
 def check_dependency(
     req_string: str, ancestral_req_strings: tuple[str, ...] = (), parent_extras: AbstractSet[str] = frozenset()
 ) -> Iterator[tuple[str, ...]]:

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -39,12 +39,13 @@ def resolve_version(version_str: str, repo: Repo) -> Version:
     latest_tag = repo.git.describe('--tags', '--abbrev=0')
     latest_tag = latest_tag.lstrip('v')
     parts = [int(x) for x in latest_tag.split('.')]
-    if version_str == 'major':
-        parts = [parts[0] + 1, 0, 0]
-    elif version_str == 'minor':
-        parts = [parts[0], parts[1] + 1, 0]
-    elif version_str in {'patch', 'auto'}:
-        parts[2] += 1
+    match version_str:
+        case 'major':
+            parts = [parts[0] + 1, 0, 0]
+        case 'minor':
+            parts = [parts[0], parts[1] + 1, 0]
+        case 'patch' | 'auto':
+            parts[2] += 1
     return Version('.'.join(str(p) for p in parts))
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,10 +14,10 @@ import sysconfig
 import tempfile
 import typing
 
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from functools import partial, update_wrapper
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 import pytest
 

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -3,13 +3,11 @@ packaging==24.0
 pip==22.3; python_version < "3.12"
 pip==23.2; python_version >= "3.12"
 pyproject_hooks==1.0
-setuptools==42.0.0; python_version < "3.10"
 setuptools==56.0.0; python_version == "3.10"
 setuptools==56.0.0; python_version == "3.11"
 setuptools==67.8.0; python_version >= "3.12"
 setuptools_scm==6.3.1; python_version < "3.12"
 tomli==1.1.0
-virtualenv==20.11; python_version < "3.10"
-virtualenv==20.17; python_version >= "3.10" and python_version < "3.14"
+virtualenv==20.17; python_version < "3.14"
 virtualenv==20.31; python_version >= "3.14"
 wheel==0.36.0

--- a/tests/packages/test-metadata/pyproject.toml
+++ b/tests/packages/test-metadata/pyproject.toml
@@ -11,4 +11,4 @@ description = 'hello!'
 [tool.black]
 line-length = 127
 skip-string-normalization = true
-target-version = ['py39', 'py38', 'py37', 'py36']
+target-version = ['py310', 'py38', 'py37', 'py36']

--- a/tests/packages/test-metadata/pyproject.toml
+++ b/tests/packages/test-metadata/pyproject.toml
@@ -11,4 +11,3 @@ description = 'hello!'
 [tool.black]
 line-length = 127
 skip-string-normalization = true
-target-version = ['py310', 'py38', 'py37', 'py36']

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ env_list =
     type
     docs
     path
-    {py315, py314, py313, py312, py311, py310, py39, pypy311, pypy310, pypy39}{, -min}
+    {py315, py314, py313, py312, py311, py310, pypy311, pypy310}{, -min}
 skip_missing_interpreters = true
 
 [testenv]
@@ -76,7 +76,7 @@ set_env =
 commands_pre =
     python -E -m pip uninstall -y build colorama
 
-[testenv:{py314, py313, py312, py311, py310, py39, pypy39, pypy310, pypy311}-min]
+[testenv:{py314, py313, py312, py311, py310, pypy310, pypy311}-min]
 description = check minimum versions required of all dependencies
 set_env =
     PIP_CONSTRAINT = {toxinidir}/tests/constraints.txt
@@ -112,7 +112,7 @@ commands =
     python -m diff_cover.diff_cover_tool --compare-branch {env:DIFF_AGAINST:origin/main} {toxworkdir}/coverage.xml
 depends =
     path
-    {py314, py313, py312, py311, py310, py39, pypy311, pypy310, pypy39}{, -min}
+    {py314, py313, py312, py311, py310, pypy311, pypy310}{, -min}
 
 [testenv:bump]
 description = bump versions, pass major/minor/patch


### PR DESCRIPTION

## Description

Pip is about to drop 3.9, so we probably can too. I don't think there are any pressing fixes we need to get out for 3.9.

- **feat: drop Python 3.9 support**
- **chore: more 3.10 changes the model missed**
- **chore: use pattern matching in a few places**

:robot: Used Copilot:gpt-5-mini for the first commit.

<!-- Describe what changes you made and why -->

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

- [ ] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing ``Add custom backend support - by :user:`yourname` ``

## Checklist

- [ ] Tests pass locally (`tox`)
- [ ] Code follows project style (`tox -e fix`)
- [ ] Type checks pass (`tox -e type`)
- [ ] Documentation builds (`tox -e docs`)
