### PR TITLE
fix: PYTHONPATH only partially removed

### DIFF
--- a/docs/changelog/1038.bugfix.rst
+++ b/docs/changelog/1038.bugfix.rst
@@ -1,1 +1,3 @@
-Keep ``PYTHONPATH`` out of the return for ``_pip_env`` - by :user:`henryiii`
+Keep ``PYTHONPATH`` out of the return for ``_pip_env``; also exclude ``PYTHONPATH``-only paths when detecting a usable
+outer pip, so environments where pip is only reachable via ``PYTHONPATH`` (e.g. Nix dev shells) no longer attempt to
+invoke it with ``PYTHONPATH`` cleared - by :user:`henryiii`

--- a/docs/changelog/1038.bugfix.rst
+++ b/docs/changelog/1038.bugfix.rst
@@ -1,0 +1,1 @@
+Keep ``PYTHONPATH`` out of the return for ``_pip_env`` - by :user:`henryiii`

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -196,10 +196,14 @@ def _has_keyring_cli() -> bool:
     return shutil.which('keyring') is not None
 
 
-def _pip_env() -> dict[str, str] | None:
+def _pip_env() -> dict[str, str]:
+    env = os.environ.copy()
+    # Clear PYTHONPATH to avoid interference from the outer environment.
+    # The isolated build environment should not inherit PYTHONPATH.
+    env.pop('PYTHONPATH', None)
     if 'PIP_KEYRING_PROVIDER' not in os.environ and _has_keyring_cli():
-        return {**os.environ, 'PIP_KEYRING_PROVIDER': 'subprocess'}
-    return None
+        env['PIP_KEYRING_PROVIDER'] = 'subprocess'
+    return env
 
 
 class _PipBackend(_EnvBackend):

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -219,7 +219,13 @@ class _PipBackend(_EnvBackend):
 
         # Version to have added the `--python` option.
         # `pip install --python` is nonfunctional on Gentoo debundled pip.
-        if dist := _has_dependency('pip', '22.3'):  # pragma: no cover
+        #
+        # Only look for pip in paths that don't come from PYTHONPATH. Subprocesses
+        # run with PYTHONPATH cleared, so pip that is only reachable via PYTHONPATH
+        # (e.g. Nix dev shells) would not be found when invoked as `python -m pip`.
+        pythonpath_dirs = {os.path.realpath(p) for p in os.environ.get('PYTHONPATH', '').split(os.pathsep) if p}
+        search_path = [p for p in sys.path if os.path.realpath(p) not in pythonpath_dirs]
+        if dist := _has_dependency('pip', '22.3', path=search_path):  # pragma: no cover
             files = dist.files
             if files:
                 return any(str(f).startswith('pip/_vendor') for f in files)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -565,6 +565,44 @@ def test_uv_install_dependencies_passes_keyring_env(  # pragma: no cover -- uv t
     assert install_call.kwargs['env']['UV_KEYRING_PROVIDER'] == 'subprocess'
 
 
+def test_has_valid_outer_pip_ignores_pythonpath_pip(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """pip only reachable via PYTHONPATH is not detected as a valid outer pip (e.g. Nix dev shells)."""
+    dist_info = tmp_path / 'pip-25.0.dist-info'
+    dist_info.mkdir()
+    (dist_info / 'METADATA').write_text('Metadata-Version: 2.1\nName: pip\nVersion: 25.0\n')
+    (dist_info / 'RECORD').write_text('pip/_vendor/something.py,,\n')
+
+    monkeypatch.setenv('PYTHONPATH', str(tmp_path))
+    # Restrict sys.path to only the PYTHONPATH dir so the filtered search_path is empty
+    monkeypatch.setattr(sys, 'path', [str(tmp_path)])
+
+    backend = build.env._PipBackend.__new__(build.env._PipBackend)
+    assert backend._has_valid_outer_pip is None
+
+
+def test_has_valid_outer_pip_passes_filtered_path_to_dependency_check(
+    mocker: pytest_mock.MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """PYTHONPATH entries are excluded from the pip search path."""
+    pythonpath_dir = str(tmp_path / 'nix-pip')
+    regular_dir = str(tmp_path / 'regular')
+
+    monkeypatch.setenv('PYTHONPATH', pythonpath_dir)
+    monkeypatch.setattr(sys, 'path', [pythonpath_dir, regular_dir])
+
+    has_dependency = mocker.patch('build.env._has_dependency', return_value=None)
+
+    backend = build.env._PipBackend.__new__(build.env._PipBackend)
+    _ = backend._has_valid_outer_pip
+
+    has_dependency.assert_called_once_with('pip', '22.3', path=[regular_dir])
+
+
 @pytest.mark.skipif(IS_PYPY, reason='uv cannot find PyPy executable')
 @pytest.mark.skipif(MISSING_UV, reason='uv executable not found')
 def test_uv_install_respects_existing_keyring_env(  # pragma: no cover -- uv tests are skipped on PyPy

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -506,18 +506,22 @@ def test_has_keyring_cli_missing(mocker: pytest_mock.MockerFixture) -> None:
     assert build.env._has_keyring_cli() is False
 
 
-def test_pip_env_with_keyring(mocker: pytest_mock.MockerFixture) -> None:
+def test_pip_env_with_keyring(mocker: pytest_mock.MockerFixture, monkeypatch: pytest.MonkeyPatch) -> None:
     mocker.patch('shutil.which', return_value='/usr/bin/keyring')
+    monkeypatch.setenv('PYTHONPATH', 'INVALID')
 
     result = build.env._pip_env()
 
-    assert result is not None
+    assert 'PYTHONPATH' not in result
     assert result['PIP_KEYRING_PROVIDER'] == 'subprocess'
 
 
-def test_pip_env_without_keyring(mocker: pytest_mock.MockerFixture) -> None:
+def test_pip_env_without_keyring(mocker: pytest_mock.MockerFixture, monkeypatch: pytest.MonkeyPatch) -> None:
     mocker.patch('shutil.which', return_value=None)
-    assert build.env._pip_env() is None
+    monkeypatch.setenv('PYTHONPATH', 'INVALID')
+    result = build.env._pip_env()
+    assert 'PYTHONPATH' not in result
+    assert 'PIP_KEYRING_PROVIDER' not in result
 
 
 def test_pip_env_respects_existing_env_var(
@@ -526,7 +530,10 @@ def test_pip_env_respects_existing_env_var(
 ) -> None:
     mocker.patch('shutil.which', return_value='/usr/bin/keyring')
     monkeypatch.setenv('PIP_KEYRING_PROVIDER', 'import')
-    assert build.env._pip_env() is None
+    monkeypatch.setenv('PYTHONPATH', 'INVALID')
+    result = build.env._pip_env()
+    assert 'PYTHONPATH' not in result
+    assert result['PIP_KEYRING_PROVIDER'] == 'import'
 
 
 @pytest.mark.usefixtures('local_pip')


### PR DESCRIPTION
## Description

Remove the `PYTHONPATH` setting from `_pip_env`. From the "possible solution", I think this should help #1037?


:robot: Assisted-by: OpenCode:Kimi-K2.5 - used to quickly implement the suggestion and a few tests, then iterated by hand on this to just remove vs. override.

<!-- Describe what changes you made and why -->

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

- [x] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing ``Add custom backend support - by :user:`yourname` ``

## Checklist

- [x] Tests pass locally (`tox`)
- [x] Code follows project style (`tox -e fix`)
- [x] Type checks pass (`tox -e type`)
- [x] Documentation builds (`tox -e docs`)
