### PR TITLE
fix: ignore installed when running pip

### DIFF
--- a/docs/changelog/1040.bugfix.rst
+++ b/docs/changelog/1040.bugfix.rst
@@ -1,0 +1,1 @@
+Add ``--ignore-installed`` to pip install command to prevent issues with packages already present in the isolated build environment - by :user:`henryiii` (:issue:`1037`)

--- a/docs/changelog/1040.bugfix.rst
+++ b/docs/changelog/1040.bugfix.rst
@@ -1,1 +1,2 @@
-Add ``--ignore-installed`` to pip install command to prevent issues with packages already present in the isolated build environment - by :user:`henryiii` (:issue:`1037`)
+Add ``--ignore-installed`` to pip install command to prevent issues with packages already present in the isolated build
+environment - by :user:`henryiii` (:issue:`1037`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ test = [
   'setuptools >= 56.0.0; python_version == "3.11"',
   'setuptools >= 67.8.0; python_version >= "3.12"',
   "setuptools_scm >= 6",
+  "pip >= 22.3",
   { include-group = "extra" },
 ]
 typing = [

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -333,7 +333,7 @@ class _PipBackend(_EnvBackend):
             if (verbosity := _ctx.verbosity) > 1:
                 cmd += [f'-{"v" * (verbosity - 1)}']
 
-            cmd += ['install', '--use-pep517', '--no-warn-script-location', '--no-compile', '--no-input']
+            cmd += ['install', '--ignore-installed', '--use-pep517', '--no-warn-script-location', '--no-compile', '--no-input']
 
             # pip does not honour environment markers in command line arguments
             # but it does from requirement files.

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -1,5 +1,7 @@
 importlib-metadata==4.6
 packaging==24.0
+pip==22.3; python_version < "3.12"
+pip==23.2; python_version >= "3.12"
 pyproject_hooks==1.0
 setuptools==42.0.0; python_version < "3.10"
 setuptools==56.0.0; python_version == "3.10"

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -235,6 +235,7 @@ def test_default_impl_install_cmd_well_formed(
                 'pip',
                 *([f'-{"v" * (verbosity - 1)}'] if verbosity > 1 else []),
                 'install',
+                '--ignore-installed',
                 '--use-pep517',
                 '--no-warn-script-location',
                 '--no-compile',

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import importlib.util
 import logging
+import pathlib
 import shutil
 import subprocess
 import sys
@@ -574,3 +575,19 @@ def test_uv_install_respects_existing_keyring_env(  # pragma: no cover -- uv tes
 
     (install_call,) = run_subprocess.call_args_list
     assert install_call.kwargs['env']['UV_KEYRING_PROVIDER'] == 'disabled'
+
+
+@pytest.mark.network
+def test_pythonpath_does_not_interfere_with_outer_pip(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    flit_core = tmp_path.joinpath('flit_core-0.0.0.dist-info/')
+    flit_core.mkdir()
+
+    monkeypatch.setenv('PYTHONPATH', str(tmp_path))
+
+    with build.env.DefaultIsolatedEnv(installer='pip') as env:
+        env.install({'flit_core'})
+
+        assert subprocess.check_call([env.python_executable, '-c', 'import flit_core']) == 0

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,6 @@ skip_missing_interpreters = true
 [testenv]
 description =
     run test suite with {basepython}
-deps =
-    pip
 pass_env =
     LC_ALL
     PIP_*


### PR DESCRIPTION
## Description

Fixes #1037. Alternative, to, and closes #1038.

This isn't normally possible, as it's a new environment, but `PYTHONPATH` can cause pip to see stuff that's not in there.

Should not be required for uv, since it doesn't need `PYTHONPATH` to run, while pip might.

:robot: Assisted-by: OpenCode:Kimi-K2.5


<!-- Describe what changes you made and why -->

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

- [x] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing ``Add custom backend support - by :user:`yourname` ``

## Checklist

- [x] Tests pass locally (`tox`)
- [x] Code follows project style (`tox -e fix`)
- [x] Type checks pass (`tox -e type`)
- [x] Documentation builds (`tox -e docs`)
