### PR TITLE
docs: reorganize testing docs for copy/paste

### DIFF
--- a/docs/development/contributing.rst
+++ b/docs/development/contributing.rst
@@ -61,7 +61,7 @@ It is also possible to run only the integrations tests in parallel.
 
     tox -- -n auto --only-integration
 
-The test matrix coverts all supported Python versions and implementations, and with the module being invoked directly
+The test matrix covers all supported Python versions and implementations, and with the module being invoked directly
 from path, sdist install, or wheel install. To run tests only for Python 3.9.
 
 .. code-block:: console

--- a/docs/development/contributing.rst
+++ b/docs/development/contributing.rst
@@ -49,32 +49,27 @@ check. To run tests we use ``tox``.
 
     tox
 
-Integration tests take a long time to run, so they are disabled by
-default. Passing either ``--run-integration`` or ``--only-integration`` arguments through ``tox`` to ``pytest`` will run
-them, where the latter will disable unit tests and only run integration tests. Even though these tests are disabled by
-default, they will be run in CI where test suite run durations are not a big issue. CI still runs both test suites.
+Tests run in parallel by default, but if you pass any arguments, you need to include ``-n auto`` if you want to keep
+parallel runs.
 
-.. code-block:: console
-
-    tox -- --run-integration
-
-It is also possible to run only the integrations tests in parallel.
+Integration tests take a long time to run, so they are disabled by default. Passing either ``--run-integration`` or
+``--only-integration`` arguments through ``tox`` to ``pytest`` will run them, where the latter will disable unit tests
+and only run integration tests. CI still runs both test suites.
 
 .. code-block:: console
 
     tox -- -n auto --only-integration
 
 The project has a fairly large environment matrix, running tests for all supported Python versions and implementations,
-and with the module being invoked directly from path, sdist install, or wheel install. To run tests only for Python 3.9.
-
-.. code-block:: console
-
-    tox -e py39
-and with the module being invoked directly from path, sdist install, or wheel install. To run tests only for Python 3.14:
+and with the module being invoked directly from path, sdist install, or wheel install. To run tests only for Python
+3.14:
 
 .. code-block:: console
 
     tox -e py314
+
+and with the module being invoked directly from path, sdist install, or wheel install.
+
 Additionally, there are environments for type checking and documentation building, plus extras like checking code with
 minimum versions of dependencies. For type checking,
 
@@ -82,7 +77,7 @@ minimum versions of dependencies. For type checking,
 
     tox -e type
 
-You can also run unit tests against a specific Python version with wheel installation using ``tox -e py39-wheel``. Code
+You can also run unit tests against a specific Python version with wheel installation using ``tox -e py314-wheel``. Code
 coverage is tracked to ensure all code paths are tested. Aim for complete coverage of any new code you add. The CI
 system will report coverage metrics on your pull request and runs the test suite across all supported operating systems.
 

--- a/docs/development/contributing.rst
+++ b/docs/development/contributing.rst
@@ -41,27 +41,41 @@ issues using GitHub's issue linking syntax.
  Running Tests
 ***************
 
-Due to its nature, build has a somewhat complex test suite with two sets of tests: unit tests and integration tests.
-Unit tests verify the actual code implementation, while integration tests run build on real world projects as a sanity
-check. Integration tests take a long time to run and are not very helpful for tracking down issues, so they are disabled
-by default. They can be enabled by passing either ``--run-integration`` or ``--only-integration`` arguments to pytest,
-where the latter will disable unit tests and only run integration tests. Even though these tests are disabled by
-default, they will be run in CI where test suite run durations are not a big issue.
+``build`` has with two sets of tests: unit tests and integration tests. Unit tests verify the code, while
+integration tests validate build functionality on real world projects. To run tests we use ``tox``.
 
-To run the test suite, use tox which automates running tests on different environments. Simply run ``tox`` in the
-project directory to execute the full test suite. The project has a fairly large environment matrix, running tests for
-all supported Python versions and implementations, and with the module being invoked directly from path, sdist install,
-or wheel install. Additionally, there are environments for type checking and documentation building, plus extras like
-checking code with minimum versions of dependencies.
+.. code-block:: console
 
-Some example commands for this project include running type checking with ``tox -e type``, running only unit tests
-against Python 3.9 with ``tox -e py39``, running both unit and integration tests with ``tox -- --run-integration``,
-running only integration tests with ``tox -- --only-integration``, or running only integration tests with parallel tasks
-using ``tox -- -n auto --only-integration``. You can also run unit tests against a specific Python version with wheel
-installation using ``tox -e py39-wheel``.
+    tox
 
-Code coverage is tracked to ensure all code paths are tested. Aim for complete coverage of any new code you add. The CI
-system will report coverage metrics on your pull request and runs the test suite across all supported operating systems.
+Integration tests take a long time to run and are disabled by default. Passing either ``--run-integration`` or
+``--only-integration`` arguments through ``tox`` to ``pytest`` to run them. CI still runs both test suites.
+
+.. code-block:: console
+
+    tox -- --run-integration
+
+It is also possible to run only the integrations tests in parallel.
+
+.. code-block:: console
+
+    tox -- -n auto --only-integration
+
+The test matrix coverts all supported Python versions and implementations, and with the module being invoked directly
+from path, sdist install, or wheel install. To run tests only for Python 3.9.
+
+.. code-block:: console
+
+    tox -e py39
+
+Additional environments lint and build docs, and test code with minimum versions of dependencies. For type checking,
+
+.. code-block:: console
+
+    tox -e type
+
+Test generate code coverage, so try to get complete coverage of any new code you add. The CI
+system will report coverage metrics on your pull request and run all tests across all supported operating systems.
 
 ************************
  Code Style and Linting

--- a/docs/development/contributing.rst
+++ b/docs/development/contributing.rst
@@ -41,8 +41,8 @@ issues using GitHub's issue linking syntax.
  Running Tests
 ***************
 
-``build`` has with two sets of tests: unit tests and integration tests. Unit tests verify the code, while
-integration tests validate build functionality on real world projects. To run tests we use ``tox``.
+``build`` has with two sets of tests: unit tests and integration tests. Unit tests verify the code, while integration
+tests validate build functionality on real world projects. To run tests we use ``tox``.
 
 .. code-block:: console
 
@@ -74,8 +74,8 @@ Additional environments lint and build docs, and test code with minimum versions
 
     tox -e type
 
-Test generate code coverage, so try to get complete coverage of any new code you add. The CI
-system will report coverage metrics on your pull request and run all tests across all supported operating systems.
+Test generate code coverage, so try to get complete coverage of any new code you add. The CI system will report coverage
+metrics on your pull request and run all tests across all supported operating systems.
 
 ************************
  Code Style and Linting

--- a/docs/development/contributing.rst
+++ b/docs/development/contributing.rst
@@ -41,15 +41,18 @@ issues using GitHub's issue linking syntax.
  Running Tests
 ***************
 
-``build`` has with two sets of tests: unit tests and integration tests. Unit tests verify the code, while integration
-tests validate build functionality on real world projects. To run tests we use ``tox``.
+Due to its nature, ``build`` has a somewhat complex test suite with two sets of tests: unit tests and integration tests.
+Unit tests verify the actual code implementation, while integration tests run build on real world projects as a sanity
+check. To run tests we use ``tox``.
 
 .. code-block:: console
 
     tox
 
-Integration tests take a long time to run and are disabled by default. Passing either ``--run-integration`` or
-``--only-integration`` arguments through ``tox`` to ``pytest`` to run them. CI still runs both test suites.
+Integration tests take a long time to run and are not very helpful for tracking down issues, so they are disabled by
+default. Passing either ``--run-integration`` or ``--only-integration`` arguments through ``tox`` to ``pytest`` will run
+them, where the latter will disable unit tests and only run integration tests. Even though these tests are disabled by
+default, they will be run in CI where test suite run durations are not a big issue. CI still runs both test suites.
 
 .. code-block:: console
 
@@ -61,21 +64,23 @@ It is also possible to run only the integrations tests in parallel.
 
     tox -- -n auto --only-integration
 
-The test matrix covers all supported Python versions and implementations, and with the module being invoked directly
-from path, sdist install, or wheel install. To run tests only for Python 3.9.
+The project has a fairly large environment matrix, running tests for all supported Python versions and implementations,
+and with the module being invoked directly from path, sdist install, or wheel install. To run tests only for Python 3.9.
 
 .. code-block:: console
 
     tox -e py39
 
-Additional environments lint and build docs, and test code with minimum versions of dependencies. For type checking,
+Additionally, there are environments for type checking and documentation building, plus extras like checking code with
+minimum versions of dependencies. For type checking,
 
 .. code-block:: console
 
     tox -e type
 
-Test generate code coverage, so try to get complete coverage of any new code you add. The CI system will report coverage
-metrics on your pull request and run all tests across all supported operating systems.
+You can also run unit tests against a specific Python version with wheel installation using ``tox -e py39-wheel``. Code
+coverage is tracked to ensure all code paths are tested. Aim for complete coverage of any new code you add. The CI
+system will report coverage metrics on your pull request and runs the test suite across all supported operating systems.
 
 ************************
  Code Style and Linting

--- a/docs/development/contributing.rst
+++ b/docs/development/contributing.rst
@@ -49,7 +49,7 @@ check. To run tests we use ``tox``.
 
     tox
 
-Integration tests take a long time to run and are not very helpful for tracking down issues, so they are disabled by
+Integration tests take a long time to run, so they are disabled by
 default. Passing either ``--run-integration`` or ``--only-integration`` arguments through ``tox`` to ``pytest`` will run
 them, where the latter will disable unit tests and only run integration tests. Even though these tests are disabled by
 default, they will be run in CI where test suite run durations are not a big issue. CI still runs both test suites.
@@ -70,7 +70,11 @@ and with the module being invoked directly from path, sdist install, or wheel in
 .. code-block:: console
 
     tox -e py39
+and with the module being invoked directly from path, sdist install, or wheel install. To run tests only for Python 3.14:
 
+.. code-block:: console
+
+    tox -e py314
 Additionally, there are environments for type checking and documentation building, plus extras like checking code with
 minimum versions of dependencies. For type checking,
 


### PR DESCRIPTION
## Description

<!-- Describe what changes you made and why -->

Make it easier to scan and copy/paste the needed command. I forgot how to run tests, and my reading skills were all time low today.

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

- [ ] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing ``Add custom backend support - by :user:`yourname` ``

## Checklist

- [ ] Tests pass locally (`tox`)
- [ ] Code follows project style (`tox -e fix`)
- [ ] Type checks pass (`tox -e type`)
- [ ] Documentation builds (`tox -e docs`)
