### PR TITLE
fix: revert part of #973

### DIFF
--- a/docs/changelog/1044.bugfix.rst
+++ b/docs/changelog/1044.bugfix.rst
@@ -1,0 +1,1 @@
+Partial revert of :pull:`973`, keeping log messages in one entry, multiple lines.

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -106,7 +106,10 @@ def _make_logger() -> _ctx.Logger:
     def log(message: str, *, kind: tuple[str, ...] | None = None) -> None:
         if _ctx.verbosity >= -1:
             if kind is None:
-                print(fill(message, initial_indent='  '), file=sys.stderr)  # noqa: T201
+                (first, *rest) = message.splitlines()
+                _cprint('{bold}{}{reset}', fill(first, initial_indent='* '), file=sys.stderr)
+                for line in rest:
+                    print(fill(line, initial_indent='  '), file=sys.stderr)  # noqa: T201
             elif kind[0] == 'step':
                 _cprint('{bold}{}{reset}', fill(message, initial_indent='* '), file=sys.stderr)
 

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -106,12 +106,12 @@ def _make_logger() -> _ctx.Logger:
     def log(message: str, *, kind: tuple[str, ...] | None = None) -> None:
         if _ctx.verbosity >= -1:
             if kind is None:
+                print(fill(message, initial_indent='  '), file=sys.stderr)  # noqa: T201 # pragma: no cover
+            elif kind[0] == 'step':
                 (first, *rest) = message.splitlines()
                 _cprint('{bold}{}{reset}', fill(first, initial_indent='* '), file=sys.stderr)
                 for line in rest:
                     print(fill(line, initial_indent='  '), file=sys.stderr)  # noqa: T201
-            elif kind[0] == 'step':
-                _cprint('{bold}{}{reset}', fill(message, initial_indent='* '), file=sys.stderr)
 
             elif kind[0] == 'subprocess':
                 initial_indent = '> ' if kind[1] == 'cmd' else '< '

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -173,7 +173,10 @@ class DefaultIsolatedEnv(IsolatedEnv):
         if not requirements:
             return
 
-        _ctx.log('Installing packages in isolated environment:\n' + '\n'.join(f'- {r}' for r in sorted(requirements)))
+        _ctx.log(
+            'Installing packages in isolated environment:\n' + '\n'.join(f'- {r}' for r in sorted(requirements)),
+            kind=('step',),
+        )
         self._env_backend.install_dependencies(requirements, constraints)
 
 

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -173,9 +173,7 @@ class DefaultIsolatedEnv(IsolatedEnv):
         if not requirements:
             return
 
-        _ctx.log('Installing packages in isolated environment:', kind=('step',))
-        for r in sorted(requirements):
-            _ctx.log(f'- {r}')
+        _ctx.log('Installing packages in isolated environment:\n' + '\n'.join(f'- {r}' for r in sorted(requirements)))
         self._env_backend.install_dependencies(requirements, constraints)
 
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -129,8 +129,7 @@ def test_isolated_env_log(
 
     assert [(record.levelname, record.message) for record in caplog.records] == [
         ('INFO', 'Creating isolated environment: venv+pip...'),
-        ('INFO', 'Installing packages in isolated environment:'),
-        ('INFO', '- something'),
+        ('INFO', 'Installing packages in isolated environment:\n- something'),
     ]
 
 


### PR DESCRIPTION
## Description

Undo the splitting up of log messages in #973, keeping other changes.

<!-- Describe what changes you made and why -->

:robot: Assisted-by: OpenCode:Gemma-4:31b (local)

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

- [x] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing ``Add custom backend support - by :user:`yourname` ``

## Checklist

- [ ] Tests pass locally (`tox`)
- [ ] Code follows project style (`tox -e fix`)
- [ ] Type checks pass (`tox -e type`)
- [ ] Documentation builds (`tox -e docs`)
