### PR TITLE
chore: report coverage failure lines

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,9 @@ set_env =
 commands =
     pytest -ra --cov --cov-config pyproject.toml \
       --cov-report=html:{envdir}/htmlcov --cov-context=test \
-      --cov-report=xml:{toxworkdir}/coverage.{envname}.xml {posargs:-n auto}
+      --cov-report=xml:{toxworkdir}/coverage.{envname}.xml \
+      --cov-report term-missing \
+      {posargs:-n auto}
 dependency_groups =
     test
 


### PR DESCRIPTION
## Description

Report the coverage failure lines in the terminal. This is much nicer if it fails.

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

- [ ] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing ``Add custom backend support - by :user:`yourname` ``

I don't think it needs one? Or could be `misc`.

## Checklist

- [x] Tests pass locally (`tox`)
- [x] Code follows project style (`tox -e fix`)
- [x] Type checks pass (`tox -e type`)
- [x] Documentation builds (`tox -e docs`)
