### PR TITLE
tests: fix issue with uv run

### DIFF
--- a/docs/changelog/1048.misc.rst
+++ b/docs/changelog/1048.misc.rst
@@ -1,0 +1,1 @@
+Make it easier to run our tests with ``uv run`` - by :user:`henryiii`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,10 @@ dev = [
 include = ["tests/", ".gitignore", "CHANGELOG.rst", "docs/", ".dockerignore", "tox.ini"]
 exclude = ["**/__pycache__", "docs/_build", "**/*.egg-info", "tests/packages/*/build", "docs/changelog/template.jinja2"]
 
+[tool.uv]
+# Our docs dependencies do not support 3.9, so remove it from the uv solve
+environments = ["python_version >= '3.10'"]
+
 
 [tool.coverage]
 run.plugins = ["covdefaults"]

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -342,12 +342,17 @@ def test_external_uv_detection_success(
     caplog: pytest.LogCaptureFixture,
     mocker: pytest_mock.MockerFixture,
 ) -> None:
+    # Ensure INFO logs are captured
+    caplog.set_level(logging.INFO)
     mocker.patch.dict(sys.modules, {'uv': None})
 
     with build.env.DefaultIsolatedEnv(installer='uv'):
         pass
 
-    assert any(r.message == f'Using external uv from {shutil.which("uv")}' for r in caplog.records)
+    # Only check that we logged using an external uv binary (do not rely on
+    # which() at assertion time because it can find the environment one).
+    # And .text is used instead of .records so a failure message is helpful.
+    assert 'Using external uv' in caplog.text
 
 
 def test_external_uv_detection_failure(


### PR DESCRIPTION
## Description

Running `uv run pytest` wasn't working. This should fix the issues with that.
Was looking at #1047 and this finally annoyed me enough to fix it.


## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

- [x] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing ``Add custom backend support - by :user:`yourname` ``

## Checklist

- [x] Tests pass locally (`tox`)
- [x] Code follows project style (`tox -e fix`)
- [x] Type checks pass (`tox -e type`)
- [x] Documentation builds (`tox -e docs`)
