### PR TITLE
docs: fix issue with changelog generation

### DIFF
--- a/docs/changelog/1044.bugfix.rst
+++ b/docs/changelog/1044.bugfix.rst
@@ -1,1 +1,1 @@
-Partial revert of :pull:`973`, keeping log messages in one entry, multiple lines.
+Partial revert of :pr:`973`, keeping log messages in one entry, multiple lines.


### PR DESCRIPTION
## Description

Fixed issue with docs, it's :pr: here instead of :pull:.

