### PR TITLE
ci: try to improve release docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,8 +9,8 @@
 - Fix release pipeline generating ``CHANGELOG.rst`` entries with inconsistent heading levels, which broke ``sphinx -W``
   and pinned Read the Docs ``stable`` at 1.4.0 - by :user:`gaborbernat`. (:issue:`1031`)
 - Revert :pr:`1039` from build 1.4.3, no longer check direct_url (for now) - by :user:`henryiii` (:issue:`1039`)
-- Add ``--ignore-installed`` to pip install command to prevent issues with packages already present in the isolated build
-  environment - by :user:`henryiii` (:issue:`1037`) (:issue:`1040`)
+- Add ``--ignore-installed`` to pip install command to prevent issues with packages already present in the isolated
+  build environment - by :user:`henryiii` (:issue:`1037`) (:issue:`1040`)
 - Partial revert of :pr:`973`, keeping log messages in one entry, multiple lines. (:issue:`1044`)
 
 ***************

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -66,6 +66,7 @@ def create_release_commit(repo: Repo, version: Version) -> Commit:
     print('build changelog from fragments with towncrier')
     check_call(['towncrier', 'build', '--yes', '--version', version.public], cwd=str(ROOT_SRC_DIR))  # noqa: S603
     call(['pre-commit', 'run', '--all-files'], cwd=str(ROOT_SRC_DIR))
+    call(['pre-commit', 'run', '--all-files'], cwd=str(ROOT_SRC_DIR))
     repo.git.add('src/build/__init__.py', 'CHANGELOG.rst', 'docs/changelog/*')
     check_call(['pre-commit', 'run', '--all-files', '--show-diff-on-failure'], cwd=str(ROOT_SRC_DIR))
     if repo.is_dirty(index=False, working_tree=True, untracked_files=False):

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,6 @@ base_python = python3.14
 set_env =
     PYTHONUTF8 = 1
 commands =
-    pre-commit run docstrfmt --all-files
     proselint check docs
     sphinx-build -W -n -b html docs {env:READTHEDOCS_OUTPUT:{envtmpdir}}/html
     python -c 'import os; print("Documentation available under file://" + os.environ.get("READTHEDOCS_OUTPUT", "{envtmpdir}") + "/html/index.html")'


### PR DESCRIPTION
## Description

This should hopefully work better, not producing broken docs on release

<!-- Describe what changes you made and why -->

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

- [ ] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing ``Add custom backend support - by :user:`yourname` ``

## Checklist

- [ ] Tests pass locally (`tox`)
- [ ] Code follows project style (`tox -e fix`)
- [ ] Type checks pass (`tox -e type`)
- [ ] Documentation builds (`tox -e docs`)
