### PR TITLE
Replace kind=('...',) with kind='...'

### DIFF
--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -103,18 +103,19 @@ def _make_logger() -> _ctx.Logger:
 
     fill = partial(textwrap.fill, subsequent_indent='  ', width=max_terminal_width)
 
-    def log(message: str, *, kind: tuple[str, ...] | None = None) -> None:
+    def log(message: str, *, kind: str | None = None) -> None:
         if _ctx.verbosity >= -1:
-            match kind:
-                case ('step', *_):
+            split = kind.split('-') if kind else None
+            match split:
+                case ['step']:
                     (first, *rest) = message.splitlines()
                     _cprint('{bold}{}{reset}', fill(first, initial_indent='* '), file=sys.stderr)
                     for line in rest:
                         print(fill(line, initial_indent='  '), file=sys.stderr)  # noqa: T201
-                case ('subprocess', 'cmd'):
+                case ['subprocess', 'cmd']:
                     for line in message.splitlines():
                         _cprint('{dim}{}{reset}', fill(line, initial_indent='> '), file=sys.stderr)
-                case ('subprocess', 'stdout' | 'stderr'):
+                case ['subprocess', 'stdout' | 'stderr']:
                     for line in message.splitlines():
                         _cprint('{dim}{}{reset}', fill(line, initial_indent='< '), file=sys.stderr)
                 case _:
@@ -339,7 +340,7 @@ def build_package_via_sdist(
         with tarfile.TarFile.open(sdist) as t:
             t.extractall(sdist_out)
             try:
-                _ctx.log(f'Building {_natural_language_list(distributions)} from sdist', kind=('step',))
+                _ctx.log(f'Building {_natural_language_list(distributions)} from sdist', kind='step')
                 srcdir = os.path.join(sdist_out, sdist_name[: -len('.tar.gz')])
                 for distribution in distributions:
                     out = _build(

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -255,7 +255,7 @@ class ProjectBuilder:
             (``sdist`` or ``wheel``)
         :param config_settings: Config settings for the build backend
         """
-        _ctx.log(f'Getting build dependencies for {distribution}...', kind=('step',))
+        _ctx.log(f'Getting build dependencies for {distribution}...', kind='step')
         hook_name = f'get_requires_for_build_{distribution}'
         get_requires = getattr(self._hook, hook_name)
 
@@ -293,7 +293,7 @@ class ProjectBuilder:
         :param config_settings: Config settings for the build backend
         :returns: The full path to the prepared metadata directory
         """
-        _ctx.log(f'Getting metadata for {distribution}...', kind=('step',))
+        _ctx.log(f'Getting metadata for {distribution}...', kind='step')
         try:
             return self._call_backend(
                 f'prepare_metadata_for_build_{distribution}',
@@ -323,7 +323,7 @@ class ProjectBuilder:
             previous ``prepare`` call on the same ``distribution`` kind
         :returns: The full path to the built distribution
         """
-        _ctx.log(f'Building {distribution}...', kind=('step',))
+        _ctx.log(f'Building {distribution}...', kind='step')
 
         kwargs = {} if metadata_directory is None else {'metadata_directory': metadata_directory}
         return self._call_backend(f'build_{distribution}', output_directory, config_settings, **kwargs)

--- a/src/build/_ctx.py
+++ b/src/build/_ctx.py
@@ -18,14 +18,14 @@ if TYPE_CHECKING:
 
 
 class Logger(typing.Protocol):  # pragma: no cover
-    def __call__(self, message: str, *, kind: tuple[str, ...] | None = None) -> None: ...
+    def __call__(self, message: str, *, kind: str | None = None) -> None: ...
 
 
 _package_name = __spec__.parent
 _default_logger = logging.getLogger(_package_name)
 
 
-def _log_default(message: str, *, kind: tuple[str, ...] | None = None) -> None:  # noqa: ARG001
+def _log_default(message: str, *, kind: str | None = None) -> None:  # noqa: ARG001
     # the log function that works in tests, real log function is set in __main__
     _default_logger.log(logging.INFO, message, stacklevel=2)
 
@@ -37,12 +37,12 @@ VERBOSITY = contextvars.ContextVar('VERBOSITY', default=0)
 def log_subprocess_error(error: subprocess.CalledProcessError) -> None:
     log = LOGGER.get()
 
-    log(subprocess.list2cmdline(error.cmd), kind=('subprocess', 'cmd'))
+    log(subprocess.list2cmdline(error.cmd), kind='subprocess-cmd')
 
     for stream_name in ('stdout', 'stderr'):
         stream = getattr(error, stream_name)
         if stream:
-            log(stream.decode() if isinstance(stream, bytes) else stream, kind=('subprocess', stream_name))
+            log(stream.decode() if isinstance(stream, bytes) else stream, kind=f'subprocess-{stream_name}')
 
 
 def run_subprocess(cmd: Sequence[StrPath], cwd: str | None = None, env: Mapping[str, str] | None = None) -> None:
@@ -59,13 +59,13 @@ def run_subprocess(cmd: Sequence[StrPath], cwd: str | None = None, env: Mapping[
                 cmd, cwd=cwd, encoding='utf-8', env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
             ) as process,
         ):
-            log(subprocess.list2cmdline(cmd), kind=('subprocess', 'cmd'))
+            log(subprocess.list2cmdline(cmd), kind='subprocess-cmd')
 
             @executor.submit
             def log_stream() -> None:
                 assert process.stdout
                 for line in process.stdout:
-                    log(line, kind=('subprocess', 'stdout'))
+                    log(line, kind='subprocess-stdout')
 
             concurrent.futures.wait([log_stream])
 

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -174,8 +174,7 @@ class DefaultIsolatedEnv(IsolatedEnv):
             return
 
         _ctx.log(
-            'Installing packages in isolated environment:\n' + '\n'.join(f'- {r}' for r in sorted(requirements)),
-            kind='step'
+            'Installing packages in isolated environment:\n' + '\n'.join(f'- {r}' for r in sorted(requirements)), kind='step'
         )
         self._env_backend.install_dependencies(requirements, constraints)
 

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -127,7 +127,7 @@ class DefaultIsolatedEnv(IsolatedEnv):
             else:
                 self._env_backend = _PipBackend()
 
-            _ctx.log(f'Creating isolated environment: {self._env_backend.display_name}...', kind=('step',))
+            _ctx.log(f'Creating isolated environment: {self._env_backend.display_name}...', kind='step')
             self._env_backend.create(self._path)
 
         except Exception:  # cleanup folder if creation fails
@@ -175,7 +175,7 @@ class DefaultIsolatedEnv(IsolatedEnv):
 
         _ctx.log(
             'Installing packages in isolated environment:\n' + '\n'.join(f'- {r}' for r in sorted(requirements)),
-            kind=('step',),
+            kind='step'
         )
         self._env_backend.install_dependencies(requirements, constraints)
 

--- a/tests/test_ctx_logger.py
+++ b/tests/test_ctx_logger.py
@@ -49,7 +49,7 @@ def test_ctx_custom_logger_with_custom_verbosity(mocker: pytest_mock.MockerFixtu
     ('verbosity', 'kwarg_origins'),
     [
         (0, []),
-        (1, [('subprocess', 'cmd'), ('subprocess', 'stdout')]),
+        (1, ['subprocess-cmd', 'subprocess-stdout']),
     ],
 )
 def test_custom_subprocess_runner_ctx_logging(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -833,7 +833,7 @@ def test_handle_build_error_build_backend_exception(mocker: pytest_mock.MockerFi
 def test_log_unknown_kind(mocker: pytest_mock.MockerFixture) -> None:
     mocker.patch('build.__main__._cprint')
     log = build.__main__._make_logger()
-    log('message', kind=('unknown',))
+    log('message', kind='unknown')
 
 
 def test_build_no_isolation_skip_dependency_check(mocker: pytest_mock.MockerFixture, package_test_flit: str) -> None:


### PR DESCRIPTION
## Description

To improve readability of log calls.

No AI is used (unfortunately).

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

- [ ] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing ``Add custom backend support - by :user:`yourname` ``

## Checklist

- [ ] Tests pass locally (`tox`)
- [ ] Code follows project style (`tox -e fix`)
- [ ] Type checks pass (`tox -e type`)
- [ ] Documentation builds (`tox -e docs`)
