### PR TITLE
fix: api should not ignore installed, only CLI

### DIFF
--- a/docs/changelog/1056.bugfix.rst
+++ b/docs/changelog/1056.bugfix.rst
@@ -1,0 +1,1 @@
+Make ``--ignore-installed`` opt-in from the API via ``fresh=True`` - by :user:`henryiii`

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -179,7 +179,7 @@ def _bootstrap_build_env(
                     install = partial(install, constraints=set(map(str.strip, dependency_constraints_file)))
 
             # first install the build dependencies
-            install(builder.build_system_requires)
+            install(builder.build_system_requires, fresh=True)
             # then get the extra required dependencies from the backend (which was installed in the call above :P)
             install(builder.get_requires_for_build(distribution, config_settings))
 

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -179,7 +179,7 @@ def _bootstrap_build_env(
                     install = partial(install, constraints=set(map(str.strip, dependency_constraints_file)))
 
             # first install the build dependencies
-            install(builder.build_system_requires, fresh=True)
+            install(builder.build_system_requires, _fresh=True)
             # then get the extra required dependencies from the backend (which was installed in the call above :P)
             install(builder.get_requires_for_build(distribution, config_settings))
 

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -166,14 +166,12 @@ class DefaultIsolatedEnv(IsolatedEnv):
         requirements: Collection[str],
         constraints: Collection[str] = [],
         *,
-        fresh: bool = False,
+        _fresh: bool = False,  # Used internally by CLI to support preset PYTHONPATH
     ) -> None:
         """
         Install packages from PEP 508 requirements in the isolated build environment.
 
         :param requirements: PEP 508 requirement specification to install
-        :param fresh: Whether to overwrite already installed packages while installing
-            these requirements
 
         :note: Passing non-PEP 508 strings will result in undefined behavior, you *should not* rely on it. It is
                merely an implementation detail, it may change any time without warning.
@@ -185,7 +183,7 @@ class DefaultIsolatedEnv(IsolatedEnv):
             'Installing packages in isolated environment:\n' + '\n'.join(f'- {r}' for r in sorted(requirements)),
             kind=('step',),
         )
-        self._env_backend.install_dependencies(requirements, constraints, fresh=fresh)
+        self._env_backend.install_dependencies(requirements, constraints, _fresh=_fresh)
 
 
 class _EnvBackend(typing.Protocol):  # pragma: no cover
@@ -199,7 +197,7 @@ class _EnvBackend(typing.Protocol):  # pragma: no cover
         requirements: Collection[str],
         constraints: Collection[str],
         *,
-        fresh: bool = False,
+        _fresh: bool = False,
     ) -> None: ...
 
     @property
@@ -343,7 +341,7 @@ class _PipBackend(_EnvBackend):
         requirements: Collection[str],
         constraints: Collection[str],
         *,
-        fresh: bool = False,
+        _fresh: bool = False,
     ) -> None:
         with contextlib.ExitStack() as exit_stack:
             if self._has_valid_outer_pip:
@@ -355,7 +353,7 @@ class _PipBackend(_EnvBackend):
                 cmd += [f'-{"v" * (verbosity - 1)}']
 
             cmd += ['install']
-            if fresh:
+            if _fresh:
                 cmd += ['--ignore-installed']
             cmd += ['--use-pep517', '--no-warn-script-location', '--no-compile', '--no-input']
 
@@ -412,7 +410,7 @@ class _UvBackend(_EnvBackend):
         requirements: Collection[str],
         constraints: Collection[str],
         *,
-        fresh: bool = False,
+        _fresh: bool = False,
     ) -> None:
         with contextlib.ExitStack() as exit_stack:
             cmd = [self._uv_bin, 'pip']
@@ -420,10 +418,7 @@ class _UvBackend(_EnvBackend):
             if (verbosity := _ctx.verbosity) > 1:
                 cmd += [f'-{"v" * min(2, verbosity - 1)}']
 
-            cmd += ['install', *requirements]
-            if fresh:
-                cmd += ['--reinstall']
-            cmd += ['--python', self.python_executable]
+            cmd += ['install', *requirements, '--python', self.python_executable]
 
             if constraints:
                 with tempfile.NamedTemporaryFile(

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -161,11 +161,19 @@ class DefaultIsolatedEnv(IsolatedEnv):
             'PYTHONPATH': '',
         }
 
-    def install(self, requirements: Collection[str], constraints: Collection[str] = []) -> None:
+    def install(
+        self,
+        requirements: Collection[str],
+        constraints: Collection[str] = [],
+        *,
+        fresh: bool = False,
+    ) -> None:
         """
         Install packages from PEP 508 requirements in the isolated build environment.
 
         :param requirements: PEP 508 requirement specification to install
+        :param fresh: Whether to overwrite already installed packages while installing
+            these requirements
 
         :note: Passing non-PEP 508 strings will result in undefined behavior, you *should not* rely on it. It is
                merely an implementation detail, it may change any time without warning.
@@ -177,7 +185,7 @@ class DefaultIsolatedEnv(IsolatedEnv):
             'Installing packages in isolated environment:\n' + '\n'.join(f'- {r}' for r in sorted(requirements)),
             kind=('step',),
         )
-        self._env_backend.install_dependencies(requirements, constraints)
+        self._env_backend.install_dependencies(requirements, constraints, fresh=fresh)
 
 
 class _EnvBackend(typing.Protocol):  # pragma: no cover
@@ -186,7 +194,13 @@ class _EnvBackend(typing.Protocol):  # pragma: no cover
 
     def create(self, path: str) -> None: ...
 
-    def install_dependencies(self, requirements: Collection[str], constraints: Collection[str]) -> None: ...
+    def install_dependencies(
+        self,
+        requirements: Collection[str],
+        constraints: Collection[str],
+        *,
+        fresh: bool,
+    ) -> None: ...
 
     @property
     def display_name(self) -> str: ...
@@ -324,7 +338,13 @@ class _PipBackend(_EnvBackend):
                         env=_pip_env(),
                     )
 
-    def install_dependencies(self, requirements: Collection[str], constraints: Collection[str]) -> None:
+    def install_dependencies(
+        self,
+        requirements: Collection[str],
+        constraints: Collection[str],
+        *,
+        fresh: bool,
+    ) -> None:
         with contextlib.ExitStack() as exit_stack:
             if self._has_valid_outer_pip:
                 cmd = [sys.executable, '-m', 'pip', '--python', self.python_executable]
@@ -334,7 +354,10 @@ class _PipBackend(_EnvBackend):
             if (verbosity := _ctx.verbosity) > 1:
                 cmd += [f'-{"v" * (verbosity - 1)}']
 
-            cmd += ['install', '--ignore-installed', '--use-pep517', '--no-warn-script-location', '--no-compile', '--no-input']
+            cmd += ['install']
+            if fresh:
+                cmd += ['--ignore-installed']
+            cmd += ['--use-pep517', '--no-warn-script-location', '--no-compile', '--no-input']
 
             # pip does not honour environment markers in command line arguments
             # but it does from requirement files.
@@ -385,7 +408,11 @@ class _UvBackend(_EnvBackend):
         self.python_executable, self.scripts_dir, _ = _find_executable_and_scripts(self._env_path)
 
     def install_dependencies(  # pragma: no cover -- uv tests are skipped on PyPy, covered on CPython
-        self, requirements: Collection[str], constraints: Collection[str]
+        self,
+        requirements: Collection[str],
+        constraints: Collection[str],
+        *,
+        fresh: bool,
     ) -> None:
         with contextlib.ExitStack() as exit_stack:
             cmd = [self._uv_bin, 'pip']
@@ -394,6 +421,8 @@ class _UvBackend(_EnvBackend):
                 cmd += [f'-{"v" * min(2, verbosity - 1)}']
 
             cmd += ['install', *requirements]
+            if fresh:
+                cmd += ['--reinstall']
             cmd += ['--python', self.python_executable]
 
             if constraints:

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -199,7 +199,7 @@ class _EnvBackend(typing.Protocol):  # pragma: no cover
         requirements: Collection[str],
         constraints: Collection[str],
         *,
-        fresh: bool,
+        fresh: bool = False,
     ) -> None: ...
 
     @property
@@ -343,7 +343,7 @@ class _PipBackend(_EnvBackend):
         requirements: Collection[str],
         constraints: Collection[str],
         *,
-        fresh: bool,
+        fresh: bool = False,
     ) -> None:
         with contextlib.ExitStack() as exit_stack:
             if self._has_valid_outer_pip:
@@ -412,7 +412,7 @@ class _UvBackend(_EnvBackend):
         requirements: Collection[str],
         constraints: Collection[str],
         *,
-        fresh: bool,
+        fresh: bool = False,
     ) -> None:
         with contextlib.ExitStack() as exit_stack:
             cmd = [self._uv_bin, 'pip']

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -54,7 +54,7 @@ def project_wheel_metadata(
                 source_dir,
                 runner=runner,
             )
-            env.install(builder.build_system_requires)
+            env.install(builder.build_system_requires, fresh=True)
             env.install(builder.get_requires_for_build('wheel'))
             return _project_wheel_metadata(builder)
     else:

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -54,7 +54,7 @@ def project_wheel_metadata(
                 source_dir,
                 runner=runner,
             )
-            env.install(builder.build_system_requires, fresh=True)
+            env.install(builder.build_system_requires, _fresh=True)
             env.install(builder.get_requires_for_build('wheel'))
             return _project_wheel_metadata(builder)
     else:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -226,18 +226,20 @@ def test_install_short_circuits(
 
 @pytest.mark.parametrize('verbosity', range(3))
 @pytest.mark.parametrize('constraints', [[], ['foo']])
+@pytest.mark.parametrize('fresh', [False, True])
 @pytest.mark.usefixtures('local_pip')
 def test_default_impl_install_cmd_well_formed(
     mocker: pytest_mock.MockerFixture,
     verbosity: int,
     constraints: list[str],
+    fresh: bool,
 ) -> None:
     mocker.patch.object(build.env._ctx, 'verbosity', verbosity)  # type: ignore[attr-defined]
 
     with build.env.DefaultIsolatedEnv() as env:
         run_subprocess = mocker.patch('build.env.run_subprocess')
 
-        env.install(['some', 'requirements'], constraints)
+        env.install(['some', 'requirements'], constraints, fresh=fresh)
 
         run_subprocess.assert_called_once_with(
             [
@@ -246,7 +248,7 @@ def test_default_impl_install_cmd_well_formed(
                 'pip',
                 *([f'-{"v" * (verbosity - 1)}'] if verbosity > 1 else []),
                 'install',
-                '--ignore-installed',
+                *(['--ignore-installed'] if fresh else []),
                 '--use-pep517',
                 '--no-warn-script-location',
                 '--no-compile',
@@ -261,19 +263,21 @@ def test_default_impl_install_cmd_well_formed(
 
 @pytest.mark.parametrize('verbosity', range(3))
 @pytest.mark.parametrize('constraints', [[], ['foo']])
+@pytest.mark.parametrize('fresh', [False, True])
 @pytest.mark.skipif(IS_PYPY, reason='uv cannot find PyPy executable')
 @pytest.mark.skipif(MISSING_UV, reason='uv executable not found')
 def test_uv_impl_install_cmd_well_formed(  # pragma: no cover -- uv tests are skipped on PyPy, covered on CPython
     mocker: pytest_mock.MockerFixture,
     verbosity: int,
     constraints: list[str],
+    fresh: bool,
 ) -> None:
     mocker.patch.object(build.env._ctx, 'verbosity', verbosity)  # type: ignore[attr-defined]
 
     with build.env.DefaultIsolatedEnv(installer='uv') as env:
         run_subprocess = mocker.patch('build.env.run_subprocess')
 
-        env.install(['some', 'requirements'], constraints)
+        env.install(['some', 'requirements'], constraints, fresh=fresh)
 
         run_subprocess.assert_called_once_with(
             [
@@ -283,6 +287,7 @@ def test_uv_impl_install_cmd_well_formed(  # pragma: no cover -- uv tests are sk
                 'install',
                 'some',
                 'requirements',
+                *(['--reinstall'] if fresh else []),
                 '--python',
                 mocker.ANY,
                 *(['-c', mocker.ANY] if constraints else []),
@@ -603,6 +608,6 @@ def test_pythonpath_does_not_interfere_with_outer_pip(
     monkeypatch.setenv('PYTHONPATH', str(tmp_path))
 
     with build.env.DefaultIsolatedEnv(installer='pip') as env:
-        env.install({'flit_core'})
+        env.install({'flit_core'}, fresh=True)
 
         assert subprocess.check_call([env.python_executable, '-c', 'import flit_core']) == 0

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -239,7 +239,7 @@ def test_default_impl_install_cmd_well_formed(
     with build.env.DefaultIsolatedEnv() as env:
         run_subprocess = mocker.patch('build.env.run_subprocess')
 
-        env.install(['some', 'requirements'], constraints, fresh=fresh)
+        env.install(['some', 'requirements'], constraints, _fresh=fresh)
 
         run_subprocess.assert_called_once_with(
             [
@@ -277,7 +277,7 @@ def test_uv_impl_install_cmd_well_formed(  # pragma: no cover -- uv tests are sk
     with build.env.DefaultIsolatedEnv(installer='uv') as env:
         run_subprocess = mocker.patch('build.env.run_subprocess')
 
-        env.install(['some', 'requirements'], constraints, fresh=fresh)
+        env.install(['some', 'requirements'], constraints, _fresh=fresh)
 
         run_subprocess.assert_called_once_with(
             [
@@ -287,7 +287,6 @@ def test_uv_impl_install_cmd_well_formed(  # pragma: no cover -- uv tests are sk
                 'install',
                 'some',
                 'requirements',
-                *(['--reinstall'] if fresh else []),
                 '--python',
                 mocker.ANY,
                 *(['-c', mocker.ANY] if constraints else []),
@@ -608,6 +607,6 @@ def test_pythonpath_does_not_interfere_with_outer_pip(
     monkeypatch.setenv('PYTHONPATH', str(tmp_path))
 
     with build.env.DefaultIsolatedEnv(installer='pip') as env:
-        env.install({'flit_core'}, fresh=True)
+        env.install({'flit_core'}, _fresh=True)
 
         assert subprocess.check_call([env.python_executable, '-c', 'import flit_core']) == 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -310,7 +310,7 @@ def test_build_isolated(mocker: pytest_mock.MockerFixture, package_test_flit: st
 
     build.__main__.build_package(package_test_flit, '.', ['sdist'])
 
-    install.assert_any_call({'flit_core >=2,<4'}, fresh=True)
+    install.assert_any_call({'flit_core >=2,<4'}, _fresh=True)
 
     required_cmd.assert_called_with('sdist', None)
     install.assert_any_call(['dep1', 'dep2'])
@@ -513,7 +513,7 @@ foo==wot
     with pytest.raises(build.BuildBackendException, match=re.escape("Backend 'flit_core.buildapi' is not available.")):
         build.__main__.build_package(package_test_flit, tmp_path, ['wheel'], dependency_constraints_txt=constraints_txt_path)
 
-    install.assert_any_call({'flit_core >=2,<4'}, constraints={'flit-core==12.34', 'foo==wot'}, fresh=True)
+    install.assert_any_call({'flit_core >=2,<4'}, constraints={'flit-core==12.34', 'foo==wot'}, _fresh=True)
 
 
 @pytest.mark.pypy3323bug

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -310,7 +310,7 @@ def test_build_isolated(mocker: pytest_mock.MockerFixture, package_test_flit: st
 
     build.__main__.build_package(package_test_flit, '.', ['sdist'])
 
-    install.assert_any_call({'flit_core >=2,<4'})
+    install.assert_any_call({'flit_core >=2,<4'}, fresh=True)
 
     required_cmd.assert_called_with('sdist', None)
     install.assert_any_call(['dep1', 'dep2'])
@@ -513,7 +513,7 @@ foo==wot
     with pytest.raises(build.BuildBackendException, match=re.escape("Backend 'flit_core.buildapi' is not available.")):
         build.__main__.build_package(package_test_flit, tmp_path, ['wheel'], dependency_constraints_txt=constraints_txt_path)
 
-    install.assert_called_with({'flit_core >=2,<4'}, constraints={'flit-core==12.34', 'foo==wot'})
+    install.assert_any_call({'flit_core >=2,<4'}, constraints={'flit-core==12.34', 'foo==wot'}, fresh=True)
 
 
 @pytest.mark.pypy3323bug

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import importlib.util
 import re
+import unittest.mock
 
 import pytest
+import pytest_mock
 
 import build.util
 
@@ -50,3 +52,25 @@ def test_with_get_requires(package_test_metadata: str) -> None:
     assert str(metadata['version']) == '1.0.0'
     assert metadata['summary'] == 'hello!'
     assert isinstance(metadata.json, dict)
+
+
+def test_project_wheel_metadata_installs_build_requires_fresh(mocker: pytest_mock.MockerFixture) -> None:
+    env = mocker.MagicMock()
+    env_cm = mocker.MagicMock()
+    env_cm.__enter__.return_value = env
+    env_cm.__exit__.return_value = False
+    mocker.patch('build.util.DefaultIsolatedEnv', return_value=env_cm)
+
+    builder = mocker.MagicMock()
+    builder.build_system_requires = {'dep1'}
+    builder.get_requires_for_build.return_value = {'dep2'}
+    mocker.patch('build.util.ProjectBuilder.from_isolated_env', return_value=builder)
+    metadata = unittest.mock.sentinel.metadata
+    mocker.patch('build.util._project_wheel_metadata', return_value=metadata)
+
+    assert build.util.project_wheel_metadata('/tmp/project') is metadata
+
+    assert env.install.call_args_list == [
+        mocker.call({'dep1'}, fresh=True),
+        mocker.call({'dep2'}),
+    ]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -71,6 +71,6 @@ def test_project_wheel_metadata_installs_build_requires_fresh(mocker: pytest_moc
     assert build.util.project_wheel_metadata('/tmp/project') is metadata
 
     assert env.install.call_args_list == [
-        mocker.call({'dep1'}, fresh=True),
+        mocker.call({'dep1'}, _fresh=True),
         mocker.call({'dep2'}),
     ]


### PR DESCRIPTION
## Description

Our recent change broke pyodide-build, which is manually using our API and pre-installing some dependencies that are patched for pyodide. This is a proposed fix, which keeps the API explicit (users need to opt-in with `fresh=True`), but our CLI opts into it.

When asking copilot CLI to do the fix, it also suggested `--reinstall` for uv to match pip's behavior. I haven't worked out yet if that's the best thing here, but that might not hurt to have.

:robot: Assisted-by: Copilot:GPT-5.4


<!-- Describe what changes you made and why -->

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

- [x] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing ``Add custom backend support - by :user:`yourname` ``

## Checklist

- [x] Tests pass locally (`tox`)
- [x] Code follows project style (`tox -e fix`)
- [x] Type checks pass (`tox -e type`)
- [x] Documentation builds (`tox -e docs`)
