### PR TITLE
✨ feat(cli): accept sdist tarball as srcdir argument

### DIFF
--- a/docs/changelog/311.feature.rst
+++ b/docs/changelog/311.feature.rst
@@ -1,0 +1,4 @@
+The positional ``srcdir`` argument now accepts a ``.tar.gz`` source distribution. ``python -m build pkg-1.0.tar.gz``
+checks the filename and ``PKG-INFO``, extracts the archive into a temporary directory, and runs a wheel build against
+the extracted source. ``--metadata`` works the same way. ``--sdist`` errors, since the archive already is an sdist - by
+:user:`gaborbernat`.

--- a/docs/changelog/311.feature.rst
+++ b/docs/changelog/311.feature.rst
@@ -1,4 +1,5 @@
 The positional ``srcdir`` argument now accepts a ``.tar.gz`` source distribution. ``python -m build pkg-1.0.tar.gz``
-checks the filename and ``PKG-INFO``, extracts the archive into a temporary directory, and runs a wheel build against
-the extracted source. ``--metadata`` works the same way. ``--sdist`` errors, since the archive already is an sdist - by
+checks the filename and ``PKG-INFO``, validates every archive member to reject path traversal, escaping
+symlinks/hardlinks and device files, extracts into a temporary directory, and runs a wheel build against the extracted
+source. ``--metadata`` works the same way. ``--sdist`` errors, since the archive already is an sdist - by
 :user:`gaborbernat`.

--- a/docs/explanation/how-it-works.rst
+++ b/docs/explanation/how-it-works.rst
@@ -99,6 +99,11 @@ By default, ``python -m build`` creates both sdist and wheel following this stra
 This "build wheel from sdist" strategy ensures your sdist is complete. If files are missing from the sdist, the wheel
 build will fail, alerting you to the problem.
 
+If the positional argument is a ``.tar.gz`` rather than a directory, the default is **wheel-only**: build checks the
+archive, extracts it into a temporary directory, and runs the wheel build against the extracted source. There is no
+sdist step. The archive already is an sdist, and PEP 517 has no hook for turning one sdist into another, so ``--sdist``
+against an sdist errors out.
+
 ***************************
  Build Isolation Explained
 ***************************

--- a/docs/how-to/basic-usage.rst
+++ b/docs/how-to/basic-usage.rst
@@ -76,6 +76,22 @@ Or explicitly:
 
     $ python -m build --srcdir path/to/project
 
+*************************************
+ Building from a source distribution
+*************************************
+
+The positional argument also accepts a ``.tar.gz`` `source distribution
+<https://packaging.python.org/en/latest/specifications/source-distribution-format/>`_. Build checks the filename and the
+presence of ``PKG-INFO``, extracts the archive into a temporary directory, and runs the wheel build against the
+extracted source. The wheel lands next to the input archive.
+
+.. code-block:: console
+
+    $ python -m build dist/mypackage-1.0.0.tar.gz
+
+No flag means the same as ``--wheel``. ``--metadata`` works the same way. ``--sdist`` errors out, since the archive
+already is an sdist.
+
 *********************************
  Specifying the output directory
 *********************************
@@ -234,7 +250,7 @@ Build from the sdist to ensure it's complete:
 .. code-block:: console
 
     $ python -m build --sdist
-    $ python -m build --wheel dist/mypackage-1.0.0.tar.gz
+    $ python -m build dist/mypackage-1.0.0.tar.gz
 
 Or test installation:
 

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -10,6 +10,11 @@ a `binary distribution (wheel) <https://packaging.python.org/en/latest/specifica
 built from the sdist. If this is undesirable, you can pass ``--sdist`` and/or ``--wheel`` to build distributions
 independently of each other.
 
+The positional ``srcdir`` argument also accepts a ``.tar.gz`` source distribution. Build checks the filename and the
+presence of ``PKG-INFO``, extracts the archive into a temporary directory, and runs the wheel build against the
+extracted source. The default ``--outdir`` is the directory containing the archive. ``--sdist`` errors against an
+archive, since the archive already is an sdist.
+
 .. sphinx_argparse_cli::
     :module: build.__main__
     :func: main_parser

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -151,6 +151,20 @@ on your computer. It:
 3. Invoked the **build backend** to create the distribution files
 4. Cleaned up the temporary environment when done
 
+**********************************
+ Building a wheel from your sdist
+**********************************
+
+You can also point build at the source distribution you just produced. Build checks the archive and runs a wheel build
+against its contents, which catches missing files in the sdist:
+
+.. code-block:: console
+
+    $ python -m build dist/mypackage-0.1.0.tar.gz
+    Successfully built mypackage-0.1.0-py3-none-any.whl
+
+The wheel lands next to the sdist. Pass ``--outdir`` to write somewhere else.
+
 ************
  Next steps
 ************

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -10,10 +10,13 @@ __lazy_modules__ = [
     'functools',
     'json',
     'os',
+    'packaging.utils',
+    'packaging.version',
     'platform',
     'pyproject_hooks',
     'shutil',
     'subprocess',
+    'tarfile',
     'tempfile',
     'textwrap',
     'traceback',
@@ -36,14 +39,20 @@ import traceback
 import warnings
 
 from functools import partial
+from tarfile import TarError
+from tarfile import open as tar_open
 from typing import Any, NoReturn, TextIO
 
 import pyproject_hooks
+
+from packaging.utils import InvalidSdistFilename, parse_sdist_filename
+from packaging.version import InvalidVersion
 
 import build
 import build.env as _env
 
 from build import ProjectBuilder, _ctx
+from build._compat.tarfile import TarFile
 from build._exceptions import BuildBackendException, BuildException, FailedProcessError
 from build.env import DefaultIsolatedEnv
 
@@ -321,8 +330,6 @@ def build_package_via_sdist(
     :param isolation: Isolate the build in a separate environment
     :param skip_dependency_check: Do not perform the dependency check
     """
-    from ._compat import tarfile
-
     if 'sdist' in distributions:
         msg = 'Only binary distributions are allowed but sdist was specified'
         raise ValueError(msg)
@@ -332,29 +339,22 @@ def build_package_via_sdist(
     )
 
     sdist_name = os.path.basename(sdist)
-    sdist_out = tempfile.mkdtemp(prefix='build-via-sdist-')
     built: list[str] = []
     if distributions:
-        # extract sdist
-        with tarfile.TarFile.open(sdist) as t:
-            t.extractall(sdist_out)
-            try:
-                _ctx.log(f'Building {_natural_language_list(distributions)} from sdist', kind=('step',))
-                srcdir = os.path.join(sdist_out, sdist_name[: -len('.tar.gz')])
-                for distribution in distributions:
-                    out = _build(
-                        isolation,
-                        srcdir,
-                        outdir,
-                        distribution,
-                        config_settings,
-                        skip_dependency_check,
-                        dependency_constraints_txt,
-                        installer,
-                    )
-                    built.append(os.path.basename(out))
-            finally:
-                shutil.rmtree(sdist_out, ignore_errors=True)
+        with _extract_sdist(sdist, sdist_name[: -len('.tar.gz')]) as extracted_srcdir:
+            _ctx.log(f'Building {_natural_language_list(distributions)} from sdist', kind=('step',))
+            for distribution in distributions:
+                out = _build(
+                    isolation,
+                    extracted_srcdir,
+                    outdir,
+                    distribution,
+                    config_settings,
+                    skip_dependency_check,
+                    dependency_constraints_txt,
+                    installer,
+                )
+                built.append(os.path.basename(out))
     return [sdist_name, *built]
 
 
@@ -455,7 +455,7 @@ def main_parser() -> argparse.ArgumentParser:
         type=str,
         nargs='?',
         default=os.getcwd(),
-        help='source directory (defaults to the current working directory)',
+        help='source directory or .tar.gz source distribution (defaults to the current working directory)',
     )
 
     global_group = parser.add_argument_group('global options')
@@ -596,48 +596,109 @@ def main(cli_args: Sequence[str], prog: str | None = None) -> None:
 
     _setup_cli(verbosity=args.verbosity)
 
-    config_settings = dict[str, Any]()
+    sdist_input = os.path.isfile(args.srcdir) and os.fspath(args.srcdir).lower().endswith('.tar.gz')
+    build = partial(
+        _select_build(parser, args, sdist_input=sdist_input),
+        config_settings=_resolve_config_settings(args),
+        isolation=not args.no_isolation,
+        skip_dependency_check=args.skip_dependency_check,
+        dependency_constraints_txt=args.dependency_constraints_txt,
+        installer=args.installer,
+    )
 
-    # Handle --config-json
-    if args.config_json:
-        try:
-            config_settings = json.loads(args.config_json)
-            if not isinstance(config_settings, dict):
-                _error('--config-json must contain a JSON object (dict), not a list or primitive value')
-        except json.JSONDecodeError as e:
-            _error(f'Invalid JSON in --config-json: {e}')
-
-    # Handle --config-setting (original logic)
-    elif args.config_settings:
-        config_settings = _parse_config_settings(args.config_settings)
-
-    # outdir is relative to srcdir only if omitted.
-    outdir = os.path.join(args.srcdir, 'dist') if args.outdir is None else args.outdir
-
-    if args.metadata and args.distributions:
-        parser.error('--metadata: not allowed with --sdist or --wheel')
-    elif args.metadata:
-        build = partial(_build_metadata, distributions=['wheel'])
-    elif args.distributions:
-        build = partial(build_package, distributions=args.distributions)
+    if args.outdir is not None:
+        outdir = args.outdir
+    elif sdist_input:
+        outdir = os.path.dirname(os.path.abspath(args.srcdir))
     else:
-        build = partial(build_package_via_sdist, distributions=['wheel'])
+        outdir = os.path.join(args.srcdir, 'dist')
 
     with _handle_build_error():
-        built = build(
-            args.srcdir,
-            outdir,
-            config_settings=config_settings,
-            isolation=not args.no_isolation,
-            skip_dependency_check=args.skip_dependency_check,
-            dependency_constraints_txt=args.dependency_constraints_txt,
-            installer=args.installer,
-        )
+        if sdist_input:
+            top_level = _validate_sdist_archive(args.srcdir)
+            with _extract_sdist(args.srcdir, top_level) as extracted_srcdir:
+                built = build(extracted_srcdir, outdir)
+        else:
+            built = build(args.srcdir, outdir)
         if _ctx.verbosity >= -1 and built:
             artifact_list = _natural_language_list(
                 ['{underline}{}{reset}{bold}{green}'.format(artifact, **_styles.get()) for artifact in built]
             )
             _cprint('{bold}{green}Successfully built {}{reset}', artifact_list)
+
+
+def _resolve_config_settings(args: argparse.Namespace) -> dict[str, Any]:
+    if args.config_json:
+        try:
+            config_settings = json.loads(args.config_json)
+        except json.JSONDecodeError as e:
+            _error(f'Invalid JSON in --config-json: {e}')
+        if not isinstance(config_settings, dict):
+            _error('--config-json must contain a JSON object (dict), not a list or primitive value')
+        return config_settings
+    if args.config_settings:
+        return _parse_config_settings(args.config_settings)
+    return {}
+
+
+def _select_build(parser: argparse.ArgumentParser, args: argparse.Namespace, *, sdist_input: bool) -> partial[list[str]]:
+    if args.metadata and args.distributions:
+        parser.error('--metadata: not allowed with --sdist or --wheel')
+    if sdist_input and args.distributions and 'sdist' in args.distributions:
+        parser.error(
+            'cannot build a source distribution from a source distribution; '
+            'pass --wheel to build a wheel from the sdist (see https://github.com/pypa/build/issues/311)'
+        )
+    if args.metadata:
+        return partial(_build_metadata, distributions=['wheel'])
+    if sdist_input:
+        return partial(build_package, distributions=args.distributions or ['wheel'])
+    if args.distributions:
+        return partial(build_package, distributions=args.distributions)
+    return partial(build_package_via_sdist, distributions=['wheel'])
+
+
+def _validate_sdist_archive(archive: StrPath) -> str:
+    """Validate that ``archive`` is a PEP 625 source distribution and return its top-level directory name."""
+    name = os.path.basename(os.fspath(archive))
+    try:
+        parse_sdist_filename(name)
+    except (InvalidSdistFilename, InvalidVersion) as exc:
+        msg = f'{name!r} does not look like a source distribution: {exc}'
+        raise BuildException(msg) from exc
+
+    try:
+        with tar_open(archive) as tar:
+            members = tar.getmembers()
+    except (OSError, TarError) as exc:
+        msg = f'failed to read source distribution {archive}: {exc}'
+        raise BuildException(msg) from exc
+
+    top_levels = {m.name.split('/', 1)[0] for m in members if m.name}
+    top_levels.discard('')
+    if len(top_levels) != 1:
+        msg = f'source distribution {archive} must contain a single top-level directory, got: {sorted(top_levels)}'
+        raise BuildException(msg)
+
+    top = next(iter(top_levels))
+    if not any(m.name == f'{top}/PKG-INFO' and m.isfile() for m in members):
+        msg = (
+            f'source distribution {archive} does not contain {top}/PKG-INFO; '
+            'this does not appear to be a valid source distribution'
+        )
+        raise BuildException(msg)
+    return top
+
+
+@contextlib.contextmanager
+def _extract_sdist(archive: StrPath, top_level: str) -> Iterator[str]:
+    extract_dir = tempfile.mkdtemp(prefix='build-via-sdist-')
+    try:
+        with TarFile.open(archive) as tar:
+            tar.extractall(extract_dir)  # noqa: S202  # compat TarFile sets the PEP 706 data filter as default
+        yield os.path.join(extract_dir, top_level)
+    finally:
+        shutil.rmtree(extract_dir, ignore_errors=True)
 
 
 def entrypoint() -> None:

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -341,7 +341,7 @@ def build_package_via_sdist(
     sdist_name = os.path.basename(sdist)
     built: list[str] = []
     if distributions:
-        with _extract_sdist(sdist, sdist_name[: -len('.tar.gz')]) as extracted_srcdir:
+        with _extract_sdist(sdist, sdist_name.removesuffix('.tar.gz')) as extracted_srcdir:
             _ctx.log(f'Building {_natural_language_list(distributions)} from sdist', kind=('step',))
             for distribution in distributions:
                 out = _build(

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -52,7 +52,7 @@ import build
 import build.env as _env
 
 from build import ProjectBuilder, _ctx
-from build._compat.tarfile import TarFile
+from build._compat.tarfile import TarFile, safe_extractall
 from build._exceptions import BuildBackendException, BuildException, FailedProcessError
 from build.env import DefaultIsolatedEnv
 
@@ -695,7 +695,7 @@ def _extract_sdist(archive: StrPath, top_level: str) -> Iterator[str]:
     extract_dir = tempfile.mkdtemp(prefix='build-via-sdist-')
     try:
         with TarFile.open(archive) as tar:
-            tar.extractall(extract_dir)  # noqa: S202  # compat TarFile sets the PEP 706 data filter as default
+            safe_extractall(tar, extract_dir)
         yield os.path.join(extract_dir, top_level)
     finally:
         shutil.rmtree(extract_dir, ignore_errors=True)

--- a/src/build/_compat/tarfile.py
+++ b/src/build/_compat/tarfile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 import tarfile
 
@@ -26,6 +27,61 @@ else:
     TarFile = tarfile.TarFile  # pragma: no cover
 
 
+# Same availability matrix as the TarFile subclass above. On runtimes that
+# ship the stdlib ``data`` filter we delegate to it; the fallback branch is
+# only reached on 3.10.0-3.10.12 / 3.11.0-3.11.4 and validates each member
+# manually before extraction.
+if (
+    (3, 9, 18) <= sys.version_info < (3, 10)
+    or (3, 10, 13) <= sys.version_info < (3, 11)
+    or (3, 11, 5) <= sys.version_info < (3, 12)
+    or sys.version_info >= (3, 12)
+):
+
+    def safe_extractall(tar: tarfile.TarFile, path: str) -> None:  # pragma: no cover
+        """Extract every member of ``tar`` into ``path`` via the PEP 706 ``data`` filter."""
+        tar.extractall(path, filter='data')
+
+else:
+
+    def safe_extractall(tar: tarfile.TarFile, path: str) -> None:  # pragma: no cover
+        """Validate every member of ``tar``, then extract into ``path``.
+
+        Reached on 3.10.0-3.10.12 / 3.11.0-3.11.4 where the stdlib ``data`` filter is missing. Device or special files,
+        paths that escape ``path``, and symlinks/hardlinks whose targets resolve outside ``path`` are rejected before
+        any write hits the disk.
+
+        """
+        base = os.path.realpath(path)
+        for member in tar.getmembers():
+            _validate_safe_member(member, base)
+        tar.extractall(path)  # noqa: S202
+
+
+def _validate_safe_member(member: tarfile.TarInfo, base: str) -> None:
+    if member.ischr() or member.isblk() or member.isfifo():
+        msg = f'refusing to extract special device file {member.name!r}'
+        raise tarfile.TarError(msg)
+    target = os.path.realpath(os.path.join(base, member.name))
+    if not _within_base(target, base):
+        msg = f'refusing to extract {member.name!r}: path escapes destination'
+        raise tarfile.TarError(msg)
+    if member.issym() or member.islnk():
+        link_base = os.path.dirname(target) if member.issym() else base
+        link_target = os.path.realpath(os.path.join(link_base, member.linkname))
+        if not _within_base(link_target, base):
+            msg = f'refusing to extract {member.name!r}: link target escapes destination'
+            raise tarfile.TarError(msg)
+
+
+def _within_base(path: str, base: str) -> bool:
+    try:
+        return os.path.commonpath([path, base]) == base
+    except ValueError:
+        return False
+
+
 __all__ = [
     'TarFile',
+    'safe_extractall',
 ]

--- a/tests/test_compat_tarfile.py
+++ b/tests/test_compat_tarfile.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from io import BytesIO
+from os.path import join, realpath
+from pathlib import Path
+from tarfile import CHRTYPE, LNKTYPE, SYMTYPE, TarError, TarInfo
+from tarfile import open as tar_open
+
+import pytest
+
+from build._compat.tarfile import _validate_safe_member, _within_base, safe_extractall
+
+
+FileMember = Callable[[str, bytes], TarInfo]
+LinkMember = Callable[..., TarInfo]
+DeviceMember = Callable[[str], TarInfo]
+ArchiveBuilder = Callable[[Path, 'list[tuple[TarInfo, bytes | None]]'], None]
+
+
+def test_safe_extractall_extracts_clean_archive(
+    tmp_path: Path,
+    make_archive: ArchiveBuilder,
+    file_member: FileMember,
+) -> None:
+    archive = tmp_path / 'clean.tar'
+    body = b'meta'
+    make_archive(archive, [(file_member('pkg/PKG-INFO', body), body)])
+
+    out = tmp_path / 'out'
+    out.mkdir()
+    with tar_open(archive) as tar:
+        safe_extractall(tar, str(out))
+
+    assert (out / 'pkg' / 'PKG-INFO').read_bytes() == body
+
+
+def test_validate_safe_member_accepts_clean_file(tmp_path: Path, file_member: FileMember) -> None:
+    base = realpath(str(tmp_path))
+    _validate_safe_member(file_member('pkg/file.txt', b'x'), base)
+
+
+def test_validate_safe_member_rejects_path_traversal(tmp_path: Path, file_member: FileMember) -> None:
+    base = realpath(str(tmp_path))
+    with pytest.raises(TarError, match='escapes destination'):
+        _validate_safe_member(file_member('../evil.txt', b'x'), base)
+
+
+def test_validate_safe_member_rejects_absolute_symlink(tmp_path: Path, link_member: LinkMember) -> None:
+    base = realpath(str(tmp_path))
+    with pytest.raises(TarError, match='link target escapes'):
+        _validate_safe_member(link_member('pkg/evil', '/etc/passwd'), base)
+
+
+def test_validate_safe_member_rejects_relative_escape_symlink(tmp_path: Path, link_member: LinkMember) -> None:
+    base = realpath(str(tmp_path))
+    with pytest.raises(TarError, match='link target escapes'):
+        _validate_safe_member(link_member('pkg/evil', '../../outside'), base)
+
+
+def test_validate_safe_member_accepts_safe_symlink(tmp_path: Path, link_member: LinkMember) -> None:
+    base = realpath(str(tmp_path))
+    _validate_safe_member(link_member('pkg/link', 'real.txt'), base)
+
+
+def test_validate_safe_member_rejects_escaping_hardlink(tmp_path: Path, link_member: LinkMember) -> None:
+    base = realpath(str(tmp_path))
+    with pytest.raises(TarError, match='link target escapes'):
+        _validate_safe_member(link_member('pkg/evil', '../../outside', hard=True), base)
+
+
+def test_validate_safe_member_rejects_device_file(tmp_path: Path, device_member: DeviceMember) -> None:
+    base = realpath(str(tmp_path))
+    with pytest.raises(TarError, match='special device file'):
+        _validate_safe_member(device_member('pkg/null'), base)
+
+
+def test_within_base_handles_value_error(tmp_path: Path) -> None:
+    base = str(tmp_path)
+    assert _within_base(base, base) is True
+    assert _within_base(join(base, 'inside'), base) is True
+    assert _within_base('/totally/elsewhere', base) is False
+    assert _within_base('relative', base) is False
+
+
+@pytest.fixture
+def make_archive() -> ArchiveBuilder:
+    def _build(path: Path, members: list[tuple[TarInfo, bytes | None]]) -> None:
+        with tar_open(path, 'w') as tar:
+            for info, body in members:
+                tar.addfile(info, BytesIO(body) if body is not None else None)
+
+    return _build
+
+
+@pytest.fixture
+def file_member() -> FileMember:
+    def _build(name: str, body: bytes) -> TarInfo:
+        info = TarInfo(name=name)
+        info.size = len(body)
+        return info
+
+    return _build
+
+
+@pytest.fixture
+def link_member() -> LinkMember:
+    def _build(name: str, linkname: str, *, hard: bool = False) -> TarInfo:
+        info = TarInfo(name=name)
+        info.type = LNKTYPE if hard else SYMTYPE
+        info.linkname = linkname
+        return info
+
+    return _build
+
+
+@pytest.fixture
+def device_member() -> DeviceMember:
+    def _build(name: str) -> TarInfo:
+        info = TarInfo(name=name)
+        info.type = CHRTYPE
+        info.devmajor = 1
+        info.devminor = 3
+        return info
+
+    return _build

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,9 +10,11 @@ import pathlib
 import re
 import subprocess
 import sys
+import tarfile
 import unittest.mock
 import venv
 
+from collections.abc import Callable
 from typing import Any
 
 import pytest
@@ -881,3 +883,253 @@ def test_build_metadata_runner_without_extra_environ(
     assert captured_runners
     captured_runners[0](['echo', 'test'])
     ctx_run.assert_called_once_with(['echo', 'test'], None, mocker.ANY)
+
+
+WriteSdist = Callable[..., None]
+
+
+@pytest.fixture
+def write_sdist() -> WriteSdist:
+    def _write(
+        path: pathlib.Path,
+        top_level: str,
+        *,
+        with_pkg_info: bool = True,
+        extra: dict[str, str] | None = None,
+    ) -> None:
+        pkg_info = b'Metadata-Version: 2.2\nName: demo\nVersion: 1.0.0\n'
+        with tarfile.open(path, 'w:gz') as tar:
+            if with_pkg_info:
+                info = tarfile.TarInfo(name=f'{top_level}/PKG-INFO')
+                info.size = len(pkg_info)
+                tar.addfile(info, io.BytesIO(pkg_info))
+            body = b'[build-system]\nrequires = []\nbuild-backend = "noop"\n'
+            info = tarfile.TarInfo(name=f'{top_level}/pyproject.toml')
+            info.size = len(body)
+            tar.addfile(info, io.BytesIO(body))
+            for member_name, member_body in (extra or {}).items():
+                data = member_body.encode()
+                info = tarfile.TarInfo(name=member_name)
+                info.size = len(data)
+                tar.addfile(info, io.BytesIO(data))
+
+    return _write
+
+
+@pytest.fixture
+def sdist(tmp_path: pathlib.Path, write_sdist: WriteSdist) -> pathlib.Path:
+    archive = tmp_path / 'demo-1.0.0.tar.gz'
+    write_sdist(archive, 'demo-1.0.0')
+    return archive
+
+
+def test_validate_sdist_archive_happy(sdist: pathlib.Path) -> None:
+    assert build.__main__._validate_sdist_archive(str(sdist)) == 'demo-1.0.0'
+
+
+def test_validate_sdist_archive_top_level_name_mismatch(tmp_path: pathlib.Path, write_sdist: WriteSdist) -> None:
+    archive = tmp_path / 'demo-1.0.0.tar.gz'
+    write_sdist(archive, 'something-else-1.0')
+    assert build.__main__._validate_sdist_archive(str(archive)) == 'something-else-1.0'
+
+
+def _invalid_filename(tmp_path: pathlib.Path, write: WriteSdist) -> str:
+    archive = tmp_path / 'noversion.tar.gz'
+    write(archive, 'noversion')
+    return str(archive)
+
+
+def _invalid_version(tmp_path: pathlib.Path, write: WriteSdist) -> str:
+    archive = tmp_path / 'demo-not_a_version.tar.gz'
+    write(archive, 'demo-not_a_version')
+    return str(archive)
+
+
+def _corrupt_tar(tmp_path: pathlib.Path, _write: WriteSdist) -> str:
+    archive = tmp_path / 'demo-1.0.0.tar.gz'
+    archive.write_bytes(b'not a real tar.gz')
+    return str(archive)
+
+
+def _multiple_top_level(tmp_path: pathlib.Path, write: WriteSdist) -> str:
+    archive = tmp_path / 'demo-1.0.0.tar.gz'
+    write(archive, 'demo-1.0.0', extra={'other-1.0.0/PKG-INFO': 'x'})
+    return str(archive)
+
+
+def _missing_pkg_info(tmp_path: pathlib.Path, write: WriteSdist) -> str:
+    archive = tmp_path / 'demo-1.0.0.tar.gz'
+    write(archive, 'demo-1.0.0', with_pkg_info=False)
+    return str(archive)
+
+
+_REJECT_CASES: dict[str, Callable[[pathlib.Path, WriteSdist], str]] = {
+    'invalid-filename': _invalid_filename,
+    'invalid-version': _invalid_version,
+    'corrupt-tar': _corrupt_tar,
+    'multiple-top-level': _multiple_top_level,
+    'missing-pkg-info': _missing_pkg_info,
+}
+
+
+@pytest.mark.parametrize(
+    ('case', 'match'),
+    [
+        pytest.param('invalid-filename', 'does not look like a source distribution', id='invalid-filename'),
+        pytest.param('invalid-version', 'does not look like a source distribution', id='invalid-version'),
+        pytest.param('corrupt-tar', 'failed to read source distribution', id='corrupt-tar'),
+        pytest.param('multiple-top-level', 'single top-level directory', id='multiple-top-level'),
+        pytest.param('missing-pkg-info', 'does not contain demo-1.0.0/PKG-INFO', id='missing-pkg-info'),
+    ],
+)
+def test_validate_sdist_archive_rejects(
+    tmp_path: pathlib.Path,
+    write_sdist: WriteSdist,
+    case: str,
+    match: str,
+) -> None:
+    archive = _REJECT_CASES[case](tmp_path, write_sdist)
+    with pytest.raises(build.BuildException, match=match):
+        build.__main__._validate_sdist_archive(archive)
+
+
+def test_extract_sdist_yields_top_level(sdist: pathlib.Path) -> None:
+    with build.__main__._extract_sdist(str(sdist), 'demo-1.0.0') as extracted:
+        assert os.path.isdir(extracted)
+        assert os.path.isfile(os.path.join(extracted, 'PKG-INFO'))
+        extract_root = os.path.dirname(extracted)
+    assert not os.path.exists(extract_root)
+
+
+def _raise_inside_extract(sdist: pathlib.Path) -> None:
+    with build.__main__._extract_sdist(str(sdist), 'demo-1.0.0') as extracted:
+        msg = 'boom'
+        raise RuntimeError(msg, os.path.dirname(extracted))
+
+
+def test_extract_sdist_cleans_up_on_error(sdist: pathlib.Path) -> None:
+    with pytest.raises(RuntimeError, match='boom') as exc_info:
+        _raise_inside_extract(sdist)
+    _, extract_root = exc_info.value.args
+    assert not os.path.exists(extract_root)
+
+
+@pytest.mark.parametrize(
+    ('extra_args', 'expected_distributions', 'expected_outdir'),
+    [
+        pytest.param([], ['wheel'], None, id='no-flag'),
+        pytest.param(['--wheel'], ['wheel'], None, id='wheel-long'),
+        pytest.param(['-w'], ['wheel'], None, id='wheel-short'),
+        pytest.param(['--wheel', '-o', 'custom-out'], ['wheel'], 'custom-out', id='custom-outdir'),
+    ],
+)
+def test_main_sdist_input_wheel_dispatch(
+    sdist: pathlib.Path,
+    mocker: pytest_mock.MockerFixture,
+    extra_args: list[str],
+    expected_distributions: list[str],
+    expected_outdir: str | None,
+) -> None:
+    build_package = mocker.patch('build.__main__.build_package', return_value=['demo-1.0.0-py3-none-any.whl'])
+    via_sdist = mocker.patch('build.__main__.build_package_via_sdist')
+
+    build.__main__.main([str(sdist), *extra_args])
+
+    via_sdist.assert_not_called()
+    args, kwargs = build_package.call_args
+    extracted_srcdir, outdir = args
+    assert os.path.basename(extracted_srcdir) == 'demo-1.0.0'
+    assert kwargs['distributions'] == expected_distributions
+    expected = expected_outdir if expected_outdir is not None else os.path.dirname(os.path.abspath(sdist))
+    assert outdir == expected
+
+
+def test_main_sdist_input_metadata(sdist: pathlib.Path, mocker: pytest_mock.MockerFixture) -> None:
+    build_metadata = mocker.patch('build.__main__._build_metadata', return_value=[])
+
+    build.__main__.main([str(sdist), '--metadata'])
+
+    args, kwargs = build_metadata.call_args
+    extracted_srcdir, _outdir = args
+    assert os.path.basename(extracted_srcdir) == 'demo-1.0.0'
+    assert kwargs['distributions'] == ['wheel']
+
+
+@pytest.mark.parametrize(
+    'flags',
+    [
+        pytest.param(['--sdist'], id='sdist-only'),
+        pytest.param(['--sdist', '--wheel'], id='sdist-and-wheel'),
+    ],
+)
+def test_main_sdist_input_rejects_sdist_flag(
+    sdist: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+    flags: list[str],
+) -> None:
+    with pytest.raises(SystemExit):
+        build.__main__.main([str(sdist), *flags])
+    assert 'cannot build a source distribution from a source distribution' in capsys.readouterr().err
+
+
+def test_main_sdist_input_validation_error_surfaced(
+    tmp_path: pathlib.Path,
+    write_sdist: WriteSdist,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    archive = tmp_path / 'demo-1.0.0.tar.gz'
+    write_sdist(archive, 'demo-1.0.0', with_pkg_info=False)
+
+    with pytest.raises(SystemExit):
+        build.__main__.main([str(archive), '--wheel'])
+
+    assert 'PKG-INFO' in capsys.readouterr().err
+
+
+def test_main_sdist_input_passes_kwargs(sdist: pathlib.Path, mocker: pytest_mock.MockerFixture) -> None:
+    build_package = mocker.patch('build.__main__.build_package', return_value=['demo-1.0.0-py3-none-any.whl'])
+
+    build.__main__.main([str(sdist), '--wheel', '-n', '-x', '-Cflag=value'])
+
+    _args, kwargs = build_package.call_args
+    assert kwargs['isolation'] is False
+    assert kwargs['skip_dependency_check'] is True
+    assert kwargs['config_settings'] == {'flag': 'value'}
+    assert kwargs['installer'] is None
+
+
+def test_main_sdist_input_end_to_end(tmp_path: pathlib.Path, package_test_setuptools: str) -> None:
+    sdist_dir = tmp_path / 'dist'
+    sdist_dir.mkdir()
+    build.__main__.build_package(package_test_setuptools, str(sdist_dir), ['sdist'])
+    archive = next(sdist_dir.glob('*.tar.gz'))
+
+    out_dir = tmp_path / 'out'
+    build.__main__.main([str(archive), '--wheel', '-n', '-o', str(out_dir)])
+
+    wheels = list(out_dir.glob('*.whl'))
+    assert len(wheels) == 1
+    assert wheels[0].name.startswith('test_setuptools-1.0.0')
+
+
+def test_main_sdist_input_default_outdir_is_archive_parent(
+    tmp_path: pathlib.Path,
+    sdist: pathlib.Path,
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    build_package = mocker.patch('build.__main__.build_package', return_value=['demo-1.0.0-py3-none-any.whl'])
+
+    build.__main__.main([str(sdist)])
+
+    _, outdir = build_package.call_args.args
+    assert outdir == str(tmp_path)
+
+
+def test_main_non_archive_file_treated_as_directory(tmp_path: pathlib.Path, mocker: pytest_mock.MockerFixture) -> None:
+    archive = tmp_path / 'demo-1.0.0.zip'
+    archive.write_bytes(b'')
+    via_sdist = mocker.patch('build.__main__.build_package_via_sdist', return_value=['something'])
+
+    build.__main__.main([str(archive)])
+
+    via_sdist.assert_called_once()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -390,7 +390,9 @@ def test_build_package_via_sdist_passes_config_settings_to_build(mocker: pytest_
     )
 
     assert built == ['demo-1.0.0.tar.gz', 'demo-1.0.0-py3-none-any.whl']
-    tar_open.return_value.__enter__.return_value.extractall.assert_called_once_with('temp-sdist-dir')
+    extractall = tar_open.return_value.__enter__.return_value.extractall
+    extractall.assert_called_once()
+    assert extractall.call_args.args[0] == 'temp-sdist-dir'
     build_cmd.assert_has_calls(
         [
             unittest.mock.call(False, 'src', 'dist', 'sdist', config_settings, True, pathlib.Path('constraints.txt'), 'uv'),
@@ -1012,6 +1014,33 @@ def test_extract_sdist_cleans_up_on_error(sdist: pathlib.Path) -> None:
         _raise_inside_extract(sdist)
     _, extract_root = exc_info.value.args
     assert not os.path.exists(extract_root)
+
+
+def test_extract_sdist_rejects_path_traversal(tmp_path: pathlib.Path) -> None:
+    archive = tmp_path / 'demo-1.0.0.tar.gz'
+    body = b'evil\n'
+    with tarfile.open(archive, 'w:gz') as tar:
+        info = tarfile.TarInfo(name='../evil.txt')
+        info.size = len(body)
+        tar.addfile(info, io.BytesIO(body))
+
+    cm = build.__main__._extract_sdist(str(archive), 'demo-1.0.0')
+    with pytest.raises(tarfile.TarError):
+        cm.__enter__()
+    assert not (tmp_path / 'evil.txt').exists()
+
+
+def test_extract_sdist_rejects_absolute_symlink(tmp_path: pathlib.Path) -> None:
+    archive = tmp_path / 'demo-1.0.0.tar.gz'
+    with tarfile.open(archive, 'w:gz') as tar:
+        info = tarfile.TarInfo(name='demo-1.0.0/evil')
+        info.type = tarfile.SYMTYPE
+        info.linkname = '/etc/passwd'
+        tar.addfile(info)
+
+    cm = build.__main__._extract_sdist(str(archive), 'demo-1.0.0')
+    with pytest.raises(tarfile.TarError):
+        cm.__enter__()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #311.

Anyone testing a release artifact has had to extract the sdist by hand or run a separate `pip wheel` against the tarball before they could exercise the wheel build path. The positional `srcdir` argument now accepts a `.tar.gz` source distribution directly, matching the "build a wheel from an sdist" recipe that came out of the discussion on #311. 📦

When `srcdir` points at a `.tar.gz`, build first validates it: the filename must parse per PEP 625, the archive must open as tar, contain a single top-level directory, and include a `PKG-INFO`. The validated archive is extracted into a temporary directory and a wheel is built from the extracted source. The default `--outdir` for archive input is the directory containing the archive, matching the convention `pip wheel` already uses, so the wheel lands next to the sdist that produced it. ✨

The default for archive input is wheel-only rather than sdist+wheel: regenerating an sdist from another sdist is not a defined operation across backends, and the issue thread converged on rejecting it for now. Passing `--sdist` against an sdist input is therefore an error with a message pointing back at #311. `--metadata` and `--wheel` work as expected; `--config-setting`, `--no-isolation`, `--installer`, and friends are passed through unchanged. The public Python API (`build_package`, `build_package_via_sdist`, `ProjectBuilder`) keeps its directory-only contract — this is a CLI-only affordance, since broadening the API surface was outside the scope FFY00 had approved on the issue.

| Input | default | `--wheel` | `--sdist` | `--metadata` |
|---|---|---|---|---|
| directory | sdist + wheel via sdist | wheel | sdist | metadata |
| `.tar.gz` | wheel | wheel | error | metadata |

## Validation against real PyPI sdists

Built five sdists pulled from PyPI:

| Package | Backend | Result |
|---|---|---|
| `attrs-26.1.0` | hatch-vcs | wheel built |
| `click-8.3.3` | flit-core | wheel built |
| `idna-3.13` | flit-core | wheel built |
| `wheel-0.47.0` | flit-core | wheel built |
| `markupsafe-3.0.3` | setuptools + C ext | platform wheel built (native ext compiled) |

Error paths exercised manually:

- `--sdist <archive>`: parser rejects with the #311-pointed error
- corrupt `.tar.gz`: `BuildException`: "failed to read source distribution" with tarfile diagnostics
- filename without a version (`notavalid.tar.gz`): "does not look like a source distribution"
- `--metadata <archive>`: PKG-INFO surfaced as JSON
- default no-flag: wheel lands next to the input archive

## Source-built vs sdist-built wheel equivalence

Built the same package both ways and compared:

| Package | Backend | sha256 (source) == sha256 (sdist) |
|---|---|---|
| `build` (this repo) | flit-core | `87361bc1…` (byte-identical) |
| `attrs-26.1.0` | hatch-vcs | `94d456bc…` (byte-identical) |

For pure-Python wheels with deterministic backends, the sdist path produces a bit-for-bit identical wheel.