### PR TITLE
chore: drop 3.9 branches for version_info checks

### DIFF
--- a/src/build/_compat/tarfile.py
+++ b/src/build/_compat/tarfile.py
@@ -14,8 +14,7 @@ if TYPE_CHECKING:
 # the default in Python 3.14. The first series of releases with the filter
 # had a broken filter that could not process symlinks correctly.
 elif (
-    (3, 9, 18) <= sys.version_info < (3, 10)
-    or (3, 10, 13) <= sys.version_info < (3, 11)
+    (3, 10, 13) <= sys.version_info < (3, 11)
     or (3, 11, 5) <= sys.version_info < (3, 12)
     or (3, 12) <= sys.version_info < (3, 14)
 ):
@@ -32,8 +31,7 @@ else:
 # only reached on 3.10.0-3.10.12 / 3.11.0-3.11.4 and validates each member
 # manually before extraction.
 if (
-    (3, 9, 18) <= sys.version_info < (3, 10)
-    or (3, 10, 13) <= sys.version_info < (3, 11)
+    (3, 10, 13) <= sys.version_info < (3, 11)
     or (3, 11, 5) <= sys.version_info < (3, 12)
     or sys.version_info >= (3, 12)
 ):

--- a/src/build/_compat/tarfile.py
+++ b/src/build/_compat/tarfile.py
@@ -30,11 +30,7 @@ else:
 # ship the stdlib ``data`` filter we delegate to it; the fallback branch is
 # only reached on 3.10.0-3.10.12 / 3.11.0-3.11.4 and validates each member
 # manually before extraction.
-if (
-    (3, 10, 13) <= sys.version_info < (3, 11)
-    or (3, 11, 5) <= sys.version_info < (3, 12)
-    or sys.version_info >= (3, 12)
-):
+if (3, 10, 13) <= sys.version_info < (3, 11) or (3, 11, 5) <= sys.version_info < (3, 12) or sys.version_info >= (3, 12):
 
     def safe_extractall(tar: tarfile.TarFile, path: str) -> None:  # pragma: no cover
         """Extract every member of ``tar`` into ``path`` via the PEP 706 ``data`` filter."""


### PR DESCRIPTION
## Description

Noticed when getting the versions from here.

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

- [ ] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing ``Add custom backend support - by :user:`yourname` ``

## Checklist

- [ ] Tests pass locally (`tox`)
- [ ] Code follows project style (`tox -e fix`)
- [ ] Type checks pass (`tox -e type`)
- [ ] Documentation builds (`tox -e docs`)
