### PR TITLE
refactor: safe_extractall to use pathlib.Path

### DIFF
--- a/src/build/_compat/tarfile.py
+++ b/src/build/_compat/tarfile.py
@@ -33,13 +33,13 @@ else:
 # manually before extraction.
 if (3, 10, 13) <= sys.version_info < (3, 11) or (3, 11, 5) <= sys.version_info < (3, 12) or sys.version_info >= (3, 12):
 
-    def safe_extractall(tar: tarfile.TarFile, path: Path) -> None:  # pragma: no cover
+    def safe_extractall(tar: tarfile.TarFile, path: Path | str) -> None:  # pragma: no cover
         """Extract every member of ``tar`` into ``path`` via the PEP 706 ``data`` filter."""
         tar.extractall(path, filter='data')
 
 else:
 
-    def safe_extractall(tar: tarfile.TarFile, path: Path) -> None:  # pragma: no cover
+    def safe_extractall(tar: tarfile.TarFile, path: Path | str) -> None:  # pragma: no cover
         """Validate every member of ``tar``, then extract into ``path``.
 
         Reached on 3.10.0-3.10.12 / 3.11.0-3.11.4 where the stdlib ``data`` filter is missing. Device or special files,
@@ -47,7 +47,7 @@ else:
         any write hits the disk.
 
         """
-        base = path.resolve()
+        base = Path(path).resolve()
         for member in tar.getmembers():
             _validate_safe_member(member, base)
         tar.extractall(path)  # noqa: S202

--- a/src/build/_compat/tarfile.py
+++ b/src/build/_compat/tarfile.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import sys
 import tarfile
 
@@ -8,6 +7,8 @@ import tarfile
 TYPE_CHECKING = False
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     TarFile = tarfile.TarFile
 
 # Per https://peps.python.org/pep-0706/, the "data" filter will become
@@ -32,13 +33,13 @@ else:
 # manually before extraction.
 if (3, 10, 13) <= sys.version_info < (3, 11) or (3, 11, 5) <= sys.version_info < (3, 12) or sys.version_info >= (3, 12):
 
-    def safe_extractall(tar: tarfile.TarFile, path: str) -> None:  # pragma: no cover
+    def safe_extractall(tar: tarfile.TarFile, path: Path) -> None:  # pragma: no cover
         """Extract every member of ``tar`` into ``path`` via the PEP 706 ``data`` filter."""
         tar.extractall(path, filter='data')
 
 else:
 
-    def safe_extractall(tar: tarfile.TarFile, path: str) -> None:  # pragma: no cover
+    def safe_extractall(tar: tarfile.TarFile, path: Path) -> None:  # pragma: no cover
         """Validate every member of ``tar``, then extract into ``path``.
 
         Reached on 3.10.0-3.10.12 / 3.11.0-3.11.4 where the stdlib ``data`` filter is missing. Device or special files,
@@ -46,33 +47,26 @@ else:
         any write hits the disk.
 
         """
-        base = os.path.realpath(path)
+        base = path.resolve()
         for member in tar.getmembers():
             _validate_safe_member(member, base)
         tar.extractall(path)  # noqa: S202
 
 
-def _validate_safe_member(member: tarfile.TarInfo, base: str) -> None:
+def _validate_safe_member(member: tarfile.TarInfo, base: Path) -> None:
     if member.ischr() or member.isblk() or member.isfifo():
-        msg = f'refusing to extract special device file {member.name!r}'
+        msg = f"refusing to extract special device file {member.name!r}"
         raise tarfile.TarError(msg)
-    target = os.path.realpath(os.path.join(base, member.name))
-    if not _within_base(target, base):
-        msg = f'refusing to extract {member.name!r}: path escapes destination'
+    target = (base / member.name).resolve(strict=False)
+    if not target.is_relative_to(base):
+        msg = f"refusing to extract {member.name!r}: path escapes destination"
         raise tarfile.TarError(msg)
     if member.issym() or member.islnk():
-        link_base = os.path.dirname(target) if member.issym() else base
-        link_target = os.path.realpath(os.path.join(link_base, member.linkname))
-        if not _within_base(link_target, base):
-            msg = f'refusing to extract {member.name!r}: link target escapes destination'
+        link_base = target.parent if member.issym() else base
+        link_target = (link_base / member.linkname).resolve(strict=False)
+        if not link_target.is_relative_to(base):
+            msg = f"refusing to extract {member.name!r}: link target escapes destination"
             raise tarfile.TarError(msg)
-
-
-def _within_base(path: str, base: str) -> bool:
-    try:
-        return os.path.commonpath([path, base]) == base
-    except ValueError:
-        return False
 
 
 __all__ = [

--- a/src/build/_compat/tarfile.py
+++ b/src/build/_compat/tarfile.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import sys
 import tarfile
 
+from pathlib import Path
+
 
 TYPE_CHECKING = False
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     TarFile = tarfile.TarFile
 
 # Per https://peps.python.org/pep-0706/, the "data" filter will become
@@ -55,17 +55,17 @@ else:
 
 def _validate_safe_member(member: tarfile.TarInfo, base: Path) -> None:
     if member.ischr() or member.isblk() or member.isfifo():
-        msg = f"refusing to extract special device file {member.name!r}"
+        msg = f'refusing to extract special device file {member.name!r}'
         raise tarfile.TarError(msg)
     target = (base / member.name).resolve(strict=False)
     if not target.is_relative_to(base):
-        msg = f"refusing to extract {member.name!r}: path escapes destination"
+        msg = f'refusing to extract {member.name!r}: path escapes destination'
         raise tarfile.TarError(msg)
     if member.issym() or member.islnk():
         link_base = target.parent if member.issym() else base
         link_target = (link_base / member.linkname).resolve(strict=False)
         if not link_target.is_relative_to(base):
-            msg = f"refusing to extract {member.name!r}: link target escapes destination"
+            msg = f'refusing to extract {member.name!r}: link target escapes destination'
             raise tarfile.TarError(msg)
 
 

--- a/tests/test_compat_tarfile.py
+++ b/tests/test_compat_tarfile.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from io import BytesIO
-from os.path import join, realpath
 from pathlib import Path
 from tarfile import CHRTYPE, LNKTYPE, SYMTYPE, TarError, TarInfo
 from tarfile import open as tar_open
 
 import pytest
 
-from build._compat.tarfile import _validate_safe_member, _within_base, safe_extractall
+from build._compat.tarfile import _validate_safe_member, safe_extractall
 
 
 FileMember = Callable[[str, bytes], TarInfo]
@@ -38,51 +37,43 @@ def test_safe_extractall_extracts_clean_archive(
 
 
 def test_validate_safe_member_accepts_clean_file(tmp_path: Path, file_member: FileMember) -> None:
-    base = realpath(str(tmp_path))
+    base = tmp_path.resolve()
     _validate_safe_member(file_member('pkg/file.txt', b'x'), base)
 
 
 def test_validate_safe_member_rejects_path_traversal(tmp_path: Path, file_member: FileMember) -> None:
-    base = realpath(str(tmp_path))
+    base = tmp_path.resolve()
     with pytest.raises(TarError, match='escapes destination'):
         _validate_safe_member(file_member('../evil.txt', b'x'), base)
 
 
 def test_validate_safe_member_rejects_absolute_symlink(tmp_path: Path, link_member: LinkMember) -> None:
-    base = realpath(str(tmp_path))
+    base = tmp_path.resolve()
     with pytest.raises(TarError, match='link target escapes'):
         _validate_safe_member(link_member('pkg/evil', '/etc/passwd'), base)
 
 
 def test_validate_safe_member_rejects_relative_escape_symlink(tmp_path: Path, link_member: LinkMember) -> None:
-    base = realpath(str(tmp_path))
+    base = tmp_path.resolve()
     with pytest.raises(TarError, match='link target escapes'):
         _validate_safe_member(link_member('pkg/evil', '../../outside'), base)
 
 
 def test_validate_safe_member_accepts_safe_symlink(tmp_path: Path, link_member: LinkMember) -> None:
-    base = realpath(str(tmp_path))
+    base = tmp_path.resolve()
     _validate_safe_member(link_member('pkg/link', 'real.txt'), base)
 
 
 def test_validate_safe_member_rejects_escaping_hardlink(tmp_path: Path, link_member: LinkMember) -> None:
-    base = realpath(str(tmp_path))
+    base = tmp_path.resolve()
     with pytest.raises(TarError, match='link target escapes'):
         _validate_safe_member(link_member('pkg/evil', '../../outside', hard=True), base)
 
 
 def test_validate_safe_member_rejects_device_file(tmp_path: Path, device_member: DeviceMember) -> None:
-    base = realpath(str(tmp_path))
+    base = tmp_path.resolve()
     with pytest.raises(TarError, match='special device file'):
         _validate_safe_member(device_member('pkg/null'), base)
-
-
-def test_within_base_handles_value_error(tmp_path: Path) -> None:
-    base = str(tmp_path)
-    assert _within_base(base, base) is True
-    assert _within_base(join(base, 'inside'), base) is True
-    assert _within_base('/totally/elsewhere', base) is False
-    assert _within_base('relative', base) is False
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

<!-- Describe what changes you made and why -->

Cleanup from https://github.com/pypa/cibuildwheel/pull/2856.

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

- [ ] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing ``Add custom backend support - by :user:`yourname` ``

## Checklist

- [ ] Tests pass locally (`tox`)
- [ ] Code follows project style (`tox -e fix`)
- [ ] Type checks pass (`tox -e type`)
- [ ] Documentation builds (`tox -e docs`)
