### PR TITLE
tests: skip test_uv_install_strips_pythonpath with missing uv

### DIFF
--- a/docs/changelog/1062.misc.rst
+++ b/docs/changelog/1062.misc.rst
@@ -1,0 +1,1 @@
+Skip ``test_uv_install_strips_pythonpath`` with missing ``uv`` - by :user:`mtelka`

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -37,6 +37,7 @@ def test_make_extra_environ_overrides_pythonpath() -> None:
         assert env._env_backend.scripts_dir in extra['PATH']
 
 
+@pytest.mark.skipif(MISSING_UV, reason='uv executable not found')
 def test_uv_install_strips_pythonpath(
     mocker: pytest_mock.MockerFixture,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Description

This makes sure the `test_uv_install_strips_pythonpath` test is skipped if there is missing `uv`.
This fixes #1062.

## Changelog

- [x] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing ``Add custom backend support - by :user:`yourname` ``

## Checklist

- [x] Tests pass locally (`tox`)
- [x] Code follows project style (`tox -e fix`)
- [x] Type checks pass (`tox -e type`)
- [x] Documentation builds (`tox -e docs`)
