### PR TITLE
✨ feat(cli): add --json-output build report

### DIFF
--- a/docs/changelog/198.feature.rst
+++ b/docs/changelog/198.feature.rst
@@ -1,0 +1,3 @@
+Add a ``--json-output PATH`` option that writes a JSON report of the built distributions, listing each filename and
+absolute path, to ``PATH`` or to standard output when ``PATH`` is ``-``. A script can read the artifact names from it
+instead of globbing ``dist/`` or parsing the build backend's output - by :user:`gaborbernat`.

--- a/docs/explanation/how-it-works.rst
+++ b/docs/explanation/how-it-works.rst
@@ -230,6 +230,23 @@ This:
 
 Useful for tools that need package metadata without building the full package.
 
+***************************
+ Reporting Built Artifacts
+***************************
+
+The backend settles a distribution's filename only when it produces the file: the name encodes the version, Python tag
+and platform, and the backend may emit a pure-Python wheel, a platform-specific wheel, or something in between.
+``--json-output`` reports the filenames once the build finishes rather than predicting them:
+
+.. code-block:: console
+
+    $ python -m build --json-output report.json
+
+build cannot hand the result back over stdout or stderr, because a PEP 517 backend may write to those streams and muddy
+any output a caller tries to parse. A caller-chosen file avoids that, and using stdout only on request with ``-`` keeps
+the report out of ``dist/``, where a ``dist/*`` glob like ``twine upload`` would pick it up. See :doc:`../reference/cli`
+for the report schema.
+
 ****************
  Error Handling
 ****************

--- a/docs/how-to/ci-cd.rst
+++ b/docs/how-to/ci-cd.rst
@@ -226,6 +226,20 @@ Combine building and publishing in a release workflow using the `PyPA publish ac
 
           - uses: pypa/gh-action-pypi-publish@release/v1
 
+Capturing built filenames
+=========================
+
+When a later step needs the exact filenames (which encode the version, Python tag and platform), reach for
+``--json-output`` instead of a glob. It skips stale artifacts and does not depend on the build backend's output:
+
+.. code-block:: console
+
+    $ python -m build --json-output report.json
+    $ twine upload $(jq -r '.artifacts[].path' report.json)
+    $ pip install "$(jq -r '.artifacts[] | select(.distribution == "wheel") | .path' report.json)"
+
+Write the report outside ``dist/`` so tools that glob ``dist/*``, such as ``twine``, leave it alone.
+
 ***********
  GitLab CI
 ***********

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -22,6 +22,69 @@ archive, since the archive already is an sdist.
     :title: python -m build
     :usage_width: 97
 
+*************************
+ Machine-Readable Output
+*************************
+
+A distribution's filename depends on its version, Python tag and platform, which the build backend settles at build
+time. ``--json-output`` writes the resulting filenames to a file, or to standard output with ``-``, so a script can read
+them without globbing ``dist/`` or parsing human output:
+
+.. code-block:: console
+
+    $ python -m build --json-output report.json
+    $ python -m build --json-output -
+
+Report format
+=============
+
+The report is a single JSON object. A default ``python -m build`` run, which builds an sdist and then a wheel from it,
+produces:
+
+.. code-block:: json
+
+    {
+      "version": 1,
+      "artifacts": [
+        {"distribution": "sdist", "name": "pkg-1.0.tar.gz", "path": "/home/me/pkg/dist/pkg-1.0.tar.gz"},
+        {"distribution": "wheel", "name": "pkg-1.0-py3-none-any.whl", "path": "/home/me/pkg/dist/pkg-1.0-py3-none-any.whl"}
+      ]
+    }
+
+The top-level object has these fields:
+
+``version`` (integer)
+    Schema version of the report, so a consumer can guard against a layout it does not understand. The current value is
+    ``1``; a backward-incompatible change to the format will raise it.
+
+``artifacts`` (array of objects)
+    One entry per distribution build produced, in the order build built them. A ``--sdist``-only run lists a single
+    sdist; ``--wheel`` lists a single wheel; the default run lists the sdist followed by the wheel. A run that builds
+    nothing leaves this empty (``[]``).
+
+Each entry in ``artifacts`` has these fields:
+
+``distribution`` (string)
+    The kind of distribution: ``"sdist"`` for a source distribution or ``"wheel"`` for a wheel.
+
+``name`` (string)
+    The bare filename the backend produced, for example ``pkg-1.0-cp312-cp312-manylinux_2_17_x86_64.whl``. It is the
+    basename of ``path``.
+
+``path`` (string)
+    The absolute path to the file, under ``--outdir`` (``dist/`` by default). Hand this straight to an installer or
+    uploader.
+
+For example, to upload every artifact, or to install only the wheel:
+
+.. code-block:: console
+
+    $ twine upload $(jq -r '.artifacts[].path' report.json)
+    $ pip install "$(jq -r '.artifacts[] | select(.distribution == "wheel") | .path' report.json)"
+
+With ``-``, build sends the ``Successfully built`` summary to standard error and leaves the JSON document alone on
+standard output. You cannot combine ``--json-output`` with ``--metadata``.
+
 ********************
  Isolation Behavior
 ********************

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -165,6 +165,27 @@ against its contents, which catches missing files in the sdist:
 
 The wheel lands next to the sdist. Pass ``--outdir`` to write somewhere else.
 
+*******************************
+ Capturing the built filenames
+*******************************
+
+The filenames above change with every version and platform. When a script needs them, ask build to record them instead
+of guessing:
+
+.. code-block:: console
+
+    $ python -m build --json-output report.json
+    $ cat report.json
+    {
+      "version": 1,
+      "artifacts": [
+        {"distribution": "sdist", "name": "mypackage-0.1.0.tar.gz", "path": ".../dist/mypackage-0.1.0.tar.gz"},
+        {"distribution": "wheel", "name": "mypackage-0.1.0-py3-none-any.whl", "path": ".../dist/mypackage-0.1.0-py3-none-any.whl"}
+      ]
+    }
+
+Use ``-`` in place of a path to write the report to standard output. See :doc:`../reference/cli` for the full schema.
+
 ************
  Next steps
 ************

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -518,6 +518,12 @@ def main_parser() -> argparse.ArgumentParser:
         action='store_true',
         help="print out a wheel's metadata in JSON format. Cannot be used in conjunction with ``--sdist`` or ``--wheel``",
     )
+    build_group.add_argument(
+        '--json-output',
+        help='write a machine-readable JSON report of the built distributions to the given path '
+        '(use ``-`` for standard output).  Cannot be used in conjunction with ``--metadata``',
+        metavar='PATH',
+    )
     config_exclusive_group = build_group.add_mutually_exclusive_group()
     config_exclusive_group.add_argument(
         '--config-setting',
@@ -624,7 +630,34 @@ def main(cli_args: Sequence[str], prog: str | None = None) -> None:
             artifact_list = _natural_language_list(
                 ['{underline}{}{reset}{bold}{green}'.format(artifact, **_styles.get()) for artifact in built]
             )
-            _cprint('{bold}{green}Successfully built {}{reset}', artifact_list)
+            # keep stdout clean when the JSON report is piped through it
+            summary_file = sys.stderr if args.json_output == '-' else None
+            _cprint('{bold}{green}Successfully built {}{reset}', artifact_list, file=summary_file)
+        if args.json_output is not None:
+            _write_json_output(args.json_output, built, outdir)
+
+
+def _write_json_output(path: str, built: Sequence[str], outdir: StrPath) -> None:
+    report = json.dumps(
+        {
+            'version': 1,
+            'artifacts': [
+                {
+                    'distribution': 'wheel' if name.endswith('.whl') else 'sdist',
+                    'name': name,
+                    'path': os.path.abspath(os.path.join(outdir, name)),
+                }
+                for name in built
+            ],
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+    if path == '-':
+        sys.stdout.write(report + '\n')
+    else:
+        with open(path, 'w', encoding='utf-8') as report_file:
+            report_file.write(report + '\n')
 
 
 def _resolve_config_settings(args: argparse.Namespace) -> dict[str, Any]:
@@ -644,6 +677,8 @@ def _resolve_config_settings(args: argparse.Namespace) -> dict[str, Any]:
 def _select_build(parser: argparse.ArgumentParser, args: argparse.Namespace, *, sdist_input: bool) -> partial[list[str]]:
     if args.metadata and args.distributions:
         parser.error('--metadata: not allowed with --sdist or --wheel')
+    if args.metadata and args.json_output is not None:
+        parser.error('--metadata: not allowed with --json-output')
     if sdist_input and args.distributions and 'sdist' in args.distributions:
         parser.error(
             'cannot build a source distribution from a source distribution; '

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -815,6 +815,51 @@ def test_metadata_with_distributions_error() -> None:
         build.__main__.main(['--metadata', '--sdist'])
 
 
+@pytest.fixture
+def mock_build(mocker: pytest_mock.MockerFixture) -> None:
+    built = ['test_pkg-1.0.0.tar.gz', 'test_pkg-1.0.0-py3-none-any.whl']
+    for hook in ('build_package', 'build_package_via_sdist'):
+        mocker.patch.object(
+            build.__main__,
+            hook,
+            new=mocker.create_autospec(getattr(build.__main__, hook), return_value=built),
+        )
+
+
+@pytest.mark.usefixtures('mock_build')
+def test_json_output_to_file(tmp_path: pathlib.Path) -> None:
+    report_path = tmp_path / 'report.json'
+    outdir = tmp_path / 'dist'
+    build.__main__.main([str(tmp_path), '-n', '-o', str(outdir), '--json-output', str(report_path)])
+
+    assert json.loads(report_path.read_text(encoding='utf-8')) == {
+        'version': 1,
+        'artifacts': [
+            {'distribution': 'sdist', 'name': 'test_pkg-1.0.0.tar.gz', 'path': str(outdir / 'test_pkg-1.0.0.tar.gz')},
+            {
+                'distribution': 'wheel',
+                'name': 'test_pkg-1.0.0-py3-none-any.whl',
+                'path': str(outdir / 'test_pkg-1.0.0-py3-none-any.whl'),
+            },
+        ],
+    }
+
+
+@pytest.mark.usefixtures('mock_build')
+def test_json_output_to_stdout(tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:
+    build.__main__.main([str(tmp_path), '-n', '--json-output', '-'])
+
+    captured = capsys.readouterr()
+    assert [artifact['distribution'] for artifact in json.loads(captured.out)['artifacts']] == ['sdist', 'wheel']
+    assert 'Successfully built' not in captured.out
+    assert 'Successfully built' in ANSI_STRIP.sub('', captured.err)
+
+
+def test_json_output_with_metadata_error() -> None:
+    with pytest.raises(SystemExit):
+        build.__main__.main(['--metadata', '--json-output', '-'])
+
+
 def test_entrypoint(mocker: pytest_mock.MockerFixture) -> None:
     main = mocker.patch('build.__main__.main')
     build.__main__.entrypoint()


### PR DESCRIPTION
Anyone scripting a release hits the same wall: the files `build` produces have names they cannot predict. The version, Python tag and platform all land in the filename, and only the backend decides them at build time. So the moment a pipeline wants to upload, install, or attach what it just built, it has to go guess. 📦

Today people work around this, and every route has a sharp edge. Globbing `dist/*` quietly sweeps up stale artifacts from an earlier run, so the fix becomes `rm -rf dist` before every build. Choosing a fresh output folder then globbing runs into `pip install foo/*` not expanding globs at all. `twine upload dist/*` only works because twine happens to expand globs itself. Asking pip to resolve names with `--find-links` means knowing the project name up front and paying for a full pip invocation. Parsing standard output looks tempting until a backend writes its own chatter there and corrupts whatever you scraped. Writing a manifest into `dist/` then gets picked up by `twine dist/*` and breaks the upload. None of these is safe to hand a new contributor.

This adds `--json-output PATH`, which records what the build actually produced once it finishes: each distribution's filename and absolute path, as JSON. Point it at a file, or pass `-` to send the report to standard output (the success summary steps aside to standard error so the JSON stays clean). A release job can now read the exact artifacts straight from the report instead of guessing. ✨

```sh
python -m build --json-output report.json
twine upload $(jq -r '.artifacts[].path' report.json)
```

The report sits where you ask, so it stays out of `dist/` and away from tools that glob it. It reports rather than predicts, which is the only honest option when the backend owns both the filenames and the output streams. Reference, how-to, tutorial and explanation docs all cover it.

Closes #198