### PR TITLE
✨ feat(cli): machine-readable build report, and metadata from a wheel

### DIFF
--- a/docs/changelog/198.feature.rst
+++ b/docs/changelog/198.feature.rst
@@ -1,3 +1,5 @@
 Add ``--report PATH`` to write a machine-readable JSON report of the built artifacts (name, path, kind, size and SHA-256
 hash), so scripts and CI can refer to the produced files without globbing. The format is selected with
-``--output-format`` (currently only ``json``) - by :user:`gaborbernat`
+``--output-format`` (currently only ``json``). ``--metadata`` now also accepts a ``.whl`` as its source argument and
+reads the wheel's ``METADATA`` directly, so a path taken from the report can be inspected without rebuilding - by
+:user:`gaborbernat`

--- a/docs/changelog/198.feature.rst
+++ b/docs/changelog/198.feature.rst
@@ -1,0 +1,3 @@
+Add ``--report PATH`` to write a machine-readable JSON report of the built artifacts (name, path, kind, size and SHA-256
+hash), so scripts and CI can refer to the produced files without globbing. The format is selected with
+``--output-format`` (currently only ``json``) - by :user:`gaborbernat`

--- a/docs/changelog/198.feature.rst
+++ b/docs/changelog/198.feature.rst
@@ -1,5 +1,4 @@
-Add ``--report`` to write a machine-readable JSON report of the built artifacts (name, path, kind, size and SHA-256
-hash), so scripts and CI can refer to the produced files without globbing. With no argument the report is written next
-to the distributions as ``build-report.json``; pass ``--report PATH`` for a custom location. ``--metadata`` now also
-accepts a ``.whl`` as its source argument and reads the wheel's ``METADATA`` directly, so a path taken from the report
-can be inspected without rebuilding - by :user:`gaborbernat`
+Add ``--report PATH`` to write a machine-readable JSON report of the built artifacts (name, path, kind, size and SHA-256
+hash), so scripts and CI can refer to the produced files without globbing. ``--metadata`` now also accepts a ``.whl`` as
+its source argument and reads the wheel's ``METADATA`` directly, so a path taken from the report can be inspected
+without rebuilding - by :user:`gaborbernat`

--- a/docs/changelog/198.feature.rst
+++ b/docs/changelog/198.feature.rst
@@ -1,4 +1,5 @@
-Add ``--report PATH`` to write a machine-readable JSON report of the built artifacts (name, path, kind, size and SHA-256
-hash), so scripts and CI can refer to the produced files without globbing. ``--metadata`` now also accepts a ``.whl`` as
-its source argument and reads the wheel's ``METADATA`` directly, so a path taken from the report can be inspected
-without rebuilding - by :user:`gaborbernat`
+Add ``--report`` to write a machine-readable JSON report of the built artifacts (name, path, kind, size and SHA-256
+hash), so scripts and CI can refer to the produced files without globbing. With no argument the report is written next
+to the distributions as ``build-report.json``; pass ``--report PATH`` for a custom location. ``--metadata`` now also
+accepts a ``.whl`` as its source argument and reads the wheel's ``METADATA`` directly, so a path taken from the report
+can be inspected without rebuilding - by :user:`gaborbernat`

--- a/docs/changelog/198.feature.rst
+++ b/docs/changelog/198.feature.rst
@@ -1,5 +1,4 @@
 Add ``--report PATH`` to write a machine-readable JSON report of the built artifacts (name, path, kind, size and SHA-256
-hash), so scripts and CI can refer to the produced files without globbing. The format is selected with
-``--output-format`` (currently only ``json``). ``--metadata`` now also accepts a ``.whl`` as its source argument and
-reads the wheel's ``METADATA`` directly, so a path taken from the report can be inspected without rebuilding - by
-:user:`gaborbernat`
+hash), so scripts and CI can refer to the produced files without globbing. ``--metadata`` now also accepts a ``.whl`` as
+its source argument and reads the wheel's ``METADATA`` directly, so a path taken from the report can be inspected
+without rebuilding - by :user:`gaborbernat`

--- a/docs/explanation/how-it-works.rst
+++ b/docs/explanation/how-it-works.rst
@@ -389,6 +389,20 @@ However, full reproducibility also requires pinned backend versions in ``require
 (some backends support ``SOURCE_DATE_EPOCH``), consistent Python version, and consistent platform for platform-specific
 wheels.
 
+***************
+ Build Reports
+***************
+
+The names of the distribution files build produces are not known ahead of time. They encode the version and, for wheels,
+the Python, ABI and platform tags. Downstream steps such as uploading, signing, or recording checksums need a way to
+learn what was built.
+
+``--report`` writes this information to a JSON file. It uses a file rather than ``stdout`` because the build backend
+runs as a subprocess that inherits build's streams and may print to them, so a consumer could not separate the report
+from backend chatter on ``stdout``. A file build controls keeps the machine-readable output apart from the human- and
+backend-facing log. Build writes the report only after the build succeeds and replaces it atomically, so a consumer
+never reads a half-written file. See :doc:`../reference/cli` for the schema.
+
 ****************************
  Performance Considerations
 ****************************

--- a/docs/how-to/ci-cd.rst
+++ b/docs/how-to/ci-cd.rst
@@ -488,21 +488,22 @@ Run the build environment:
 *****************************
 
 Artifact filenames are dynamic, so pipelines that need to act on the exact files build produced (upload, sign, compute
-digests) should not guess or glob them. Pass ``--report`` to capture a machine-readable list and read it back with a
-JSON tool such as ``jq``:
+digests) should not guess or glob them. Pass ``--report PATH`` to capture a machine-readable list and read it back with
+a JSON tool such as ``jq``. Pick a ``PATH`` outside the output directory so tools that upload ``dist/*`` wholesale do
+not trip over it:
 
 .. code-block:: yaml
 
     - name: Build and upload
       run: |
-        python -m build --report
-        twine upload $(jq -r '.artifacts[].path' dist/build-report.json)
+        python -m build --report build-report.json
+        twine upload $(jq -r '.artifacts[].path' build-report.json)
 
 The report also includes each artifact's size and SHA-256 hash, useful for emitting provenance or checksums:
 
 .. code-block:: console
 
-    $ jq -r '.artifacts[] | "\(.hashes.sha256)  \(.name)"' dist/build-report.json
+    $ jq -r '.artifacts[] | "\(.hashes.sha256)  \(.name)"' build-report.json
 
 See :doc:`../reference/cli` for the full report schema.
 

--- a/docs/how-to/ci-cd.rst
+++ b/docs/how-to/ci-cd.rst
@@ -483,6 +483,29 @@ Run the build environment:
 
     $ tox -e build
 
+*****************************
+ Discovering Built Artifacts
+*****************************
+
+Artifact filenames are dynamic, so pipelines that need to act on the exact files build produced (upload, sign, compute
+digests) should not guess or glob them. Pass ``--report`` to capture a machine-readable list and read it back with a
+JSON tool such as ``jq``:
+
+.. code-block:: yaml
+
+    - name: Build and upload
+      run: |
+        python -m build --report dist/report.json
+        twine upload $(jq -r '.artifacts[].path' dist/report.json)
+
+The report also includes each artifact's size and SHA-256 hash, useful for emitting provenance or checksums:
+
+.. code-block:: console
+
+    $ jq -r '.artifacts[] | "\(.hashes.sha256)  \(.name)"' dist/report.json
+
+See :doc:`../reference/cli` for the full report schema.
+
 ******************
  Verifying Builds
 ******************

--- a/docs/how-to/ci-cd.rst
+++ b/docs/how-to/ci-cd.rst
@@ -495,14 +495,14 @@ JSON tool such as ``jq``:
 
     - name: Build and upload
       run: |
-        python -m build --report dist/report.json
-        twine upload $(jq -r '.artifacts[].path' dist/report.json)
+        python -m build --report
+        twine upload $(jq -r '.artifacts[].path' dist/build-report.json)
 
 The report also includes each artifact's size and SHA-256 hash, useful for emitting provenance or checksums:
 
 .. code-block:: console
 
-    $ jq -r '.artifacts[] | "\(.hashes.sha256)  \(.name)"' dist/report.json
+    $ jq -r '.artifacts[] | "\(.hashes.sha256)  \(.name)"' dist/build-report.json
 
 See :doc:`../reference/cli` for the full report schema.
 

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -90,15 +90,25 @@ interpreter with your installer instead (for example ``pip list``).
  Build Report
 **************
 
-``--report PATH`` writes a JSON description of the built artifacts to ``PATH`` after a successful build. The artifact
-names are dynamic (they encode version, Python, ABI and platform tags), so this gives scripts and CI a stable way to
-refer to the produced files instead of globbing ``dist/``. Build writes the report to a file it controls, not to
-standard output, because the build backend may write to ``stdout``/``stderr`` too. The report is JSON.
+``--report`` writes a JSON description of the built artifacts after a successful build. The artifact names are dynamic
+(they encode version, Python, ABI and platform tags), so this gives scripts and CI a stable way to refer to the produced
+files instead of globbing ``dist/``. With no argument the report lands next to the distributions as
+``build-report.json`` in the output directory; pass ``--report PATH`` to choose a different location. Build writes the
+report to a file it controls, not to standard output, because the build backend may write to ``stdout``/``stderr`` too.
+The report is JSON.
 
 .. code-block:: console
 
-    $ python -m build --report dist/report.json
-    $ twine upload $(jq -r '.artifacts[].path' dist/report.json)
+    $ python -m build --report
+    $ twine upload $(jq -r '.artifacts[].path' dist/build-report.json)
+
+.. note::
+
+    The default name is fixed, so concurrent builds that share an output directory overwrite each other's
+    ``build-report.json``. The write is atomic (readers never see a partial file), but the surviving report describes
+    whichever build finished last. Give each concurrent build its own ``--report PATH`` or its own ``--outdir`` to keep
+    the reports separate — sharing an output directory also clobbers the distributions themselves, so a per-build
+    ``--outdir`` is the safer pattern regardless.
 
 The schema is:
 
@@ -108,18 +118,22 @@ The schema is:
       "version": "1.0",
       "artifacts": [
         {
-          "name": "mypackage-0.1.0.tar.gz",
-          "path": "dist/mypackage-0.1.0.tar.gz",
+          "name": "mypackage-1.0.0.tar.gz",
+          "path": "dist/mypackage-1.0.0.tar.gz",
           "kind": "sdist",
-          "size": 4096,
-          "hashes": {"sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
+          "size": 852,
+          "hashes": {
+            "sha256": "dbd5486e6e893663263caf84a4b87d67cc28f6963b6650f69eaa54b78e42ece4"
+          }
         },
         {
-          "name": "mypackage-0.1.0-py3-none-any.whl",
-          "path": "dist/mypackage-0.1.0-py3-none-any.whl",
+          "name": "mypackage-1.0.0-py3-none-any.whl",
+          "path": "dist/mypackage-1.0.0-py3-none-any.whl",
           "kind": "wheel",
-          "size": 2048,
-          "hashes": {"sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
+          "size": 1121,
+          "hashes": {
+            "sha256": "ef460897fdce998634efc3385aa4261b4280a2fe2ab0e08ddcacc8496658465d"
+          }
         }
       ]
     }
@@ -133,8 +147,8 @@ To inspect a wheel listed in the report, pass its path straight to ``--metadata`
 
 .. code-block:: console
 
-    $ python -m build --report dist/report.json
-    $ python -m build --metadata "$(jq -r '.artifacts[] | select(.kind=="wheel") | .path' dist/report.json)"
+    $ python -m build --report
+    $ python -m build --metadata "$(jq -r '.artifacts[] | select(.kind=="wheel") | .path' dist/build-report.json)"
 
 ************************
  Alternative CLI Script

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -93,8 +93,7 @@ interpreter with your installer instead (for example ``pip list``).
 ``--report PATH`` writes a JSON description of the built artifacts to ``PATH`` after a successful build. The artifact
 names are dynamic (they encode version, Python, ABI and platform tags), so this gives scripts and CI a stable way to
 refer to the produced files instead of globbing ``dist/``. Build writes the report to a file it controls, not to
-standard output, because the build backend may write to ``stdout``/``stderr`` too. ``--output-format`` selects the
-serialization; ``json`` is the only value today.
+standard output, because the build backend may write to ``stdout``/``stderr`` too. The report is JSON.
 
 .. code-block:: console
 

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -129,6 +129,14 @@ The schema is:
 directory, mirroring ``--outdir``), ``kind`` (``sdist`` or ``wheel``), ``size`` in bytes, and ``hashes`` keyed by
 algorithm. ``--report`` cannot be combined with ``--metadata``.
 
+To inspect a wheel listed in the report, pass its path straight to ``--metadata``: when the source argument is a
+``.whl`` file, build reads ``METADATA`` from the archive and prints it as JSON instead of building anything.
+
+.. code-block:: console
+
+    $ python -m build --report dist/report.json
+    $ python -m build --metadata "$(jq -r '.artifacts[] | select(.kind=="wheel") | .path' dist/report.json)"
+
 ************************
  Alternative CLI Script
 ************************

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -90,25 +90,21 @@ interpreter with your installer instead (for example ``pip list``).
  Build Report
 **************
 
-``--report`` writes a JSON description of the built artifacts after a successful build. The artifact names are dynamic
-(they encode version, Python, ABI and platform tags), so this gives scripts and CI a stable way to refer to the produced
-files instead of globbing ``dist/``. With no argument the report lands next to the distributions as
-``build-report.json`` in the output directory; pass ``--report PATH`` to choose a different location. Build writes the
-report to a file it controls, not to standard output, because the build backend may write to ``stdout``/``stderr`` too.
-The report is JSON.
+``--report PATH`` writes a JSON description of the built artifacts to ``PATH`` after a successful build. The artifact
+names are dynamic (they encode version, Python, ABI and platform tags), so this gives scripts and CI a stable way to
+refer to the produced files instead of globbing ``dist/``. Build writes the report to a file it controls, not to
+standard output, because the build backend may write to ``stdout``/``stderr`` too.
 
 .. code-block:: console
 
-    $ python -m build --report
-    $ twine upload $(jq -r '.artifacts[].path' dist/build-report.json)
+    $ python -m build --report build-report.json
+    $ twine upload $(jq -r '.artifacts[].path' build-report.json)
 
 .. note::
 
-    The default name is fixed, so concurrent builds that share an output directory overwrite each other's
-    ``build-report.json``. The write is atomic (readers never see a partial file), but the surviving report describes
-    whichever build finished last. Give each concurrent build its own ``--report PATH`` or its own ``--outdir`` to keep
-    the reports separate — sharing an output directory also clobbers the distributions themselves, so a per-build
-    ``--outdir`` is the safer pattern regardless.
+    Keep the report out of the output directory: tools commonly upload ``dist/*`` wholesale (``twine upload dist/*``),
+    and a stray non-distribution file there can break that. The write is atomic, so a reader never sees a partial file;
+    builds running in parallel still need a distinct ``PATH`` each to avoid overwriting one another's report.
 
 The schema is:
 
@@ -147,8 +143,8 @@ To inspect a wheel listed in the report, pass its path straight to ``--metadata`
 
 .. code-block:: console
 
-    $ python -m build --report
-    $ python -m build --metadata "$(jq -r '.artifacts[] | select(.kind=="wheel") | .path' dist/build-report.json)"
+    $ python -m build --report build-report.json
+    $ python -m build --metadata "$(jq -r '.artifacts[] | select(.kind=="wheel") | .path' build-report.json)"
 
 ************************
  Alternative CLI Script

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -86,6 +86,49 @@ so they reflect what was installed rather than the specifiers in ``pyproject.tom
 build reports this for isolated builds only; with ``--no-isolation`` build installs nothing, so inspect the active
 interpreter with your installer instead (for example ``pip list``).
 
+**************
+ Build Report
+**************
+
+``--report PATH`` writes a JSON description of the built artifacts to ``PATH`` after a successful build. The artifact
+names are dynamic (they encode version, Python, ABI and platform tags), so this gives scripts and CI a stable way to
+refer to the produced files instead of globbing ``dist/``. Build writes the report to a file it controls, not to
+standard output, because the build backend may write to ``stdout``/``stderr`` too. ``--output-format`` selects the
+serialization; ``json`` is the only value today.
+
+.. code-block:: console
+
+    $ python -m build --report dist/report.json
+    $ twine upload $(jq -r '.artifacts[].path' dist/report.json)
+
+The schema is:
+
+.. code-block:: json
+
+    {
+      "version": "1.0",
+      "artifacts": [
+        {
+          "name": "mypackage-0.1.0.tar.gz",
+          "path": "dist/mypackage-0.1.0.tar.gz",
+          "kind": "sdist",
+          "size": 4096,
+          "hashes": {"sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
+        },
+        {
+          "name": "mypackage-0.1.0-py3-none-any.whl",
+          "path": "dist/mypackage-0.1.0-py3-none-any.whl",
+          "kind": "wheel",
+          "size": 2048,
+          "hashes": {"sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
+        }
+      ]
+    }
+
+``version`` is the schema version. Each artifact lists its ``name`` (basename), ``path`` (relative to the current
+directory, mirroring ``--outdir``), ``kind`` (``sdist`` or ``wheel``), ``size`` in bytes, and ``hashes`` keyed by
+algorithm. ``--report`` cannot be combined with ``--metadata``.
+
 ************************
  Alternative CLI Script
 ************************

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -200,12 +200,12 @@ the version it ``found`` - so you can tell "not installed" apart from "installed
  Recording what build produced
 *******************************
 
-If a script or CI job needs the exact filenames build produced, add ``--report`` to write them to a JSON file (next to
-the distributions as ``build-report.json``) instead of parsing the output:
+If a script or CI job needs the exact filenames build produced, add ``--report PATH`` to write them to a JSON file
+instead of parsing the output:
 
 .. code-block:: console
 
-    $ python -m build --report
+    $ python -m build --report build-report.json
 
 ************
  Next steps

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -200,12 +200,12 @@ the version it ``found`` - so you can tell "not installed" apart from "installed
  Recording what build produced
 *******************************
 
-If a script or CI job needs the exact filenames build produced, add ``--report`` to write them to a JSON file instead of
-parsing the output:
+If a script or CI job needs the exact filenames build produced, add ``--report`` to write them to a JSON file (next to
+the distributions as ``build-report.json``) instead of parsing the output:
 
 .. code-block:: console
 
-    $ python -m build --report dist/report.json
+    $ python -m build --report
 
 ************
  Next steps

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -191,10 +191,21 @@ earlier compilations; see :doc:`../how-to/basic-usage`.
 ****************************
 
 If you install the build dependencies yourself and build with ``--no-isolation``, build first checks that every declared
-dependency is present in the interpreter you are running. When something is missing it stops with a ``Missing
+dependency is present in the interpreter you are running. When something is missing it stops with an ``Unmet
 dependencies`` error that names the interpreter it checked and, for each requirement, the version it ``wanted`` against
 the version it ``found`` - so you can tell "not installed" apart from "installed, but the wrong version". See
 :doc:`../how-to/troubleshooting` for how to read it.
+
+*******************************
+ Recording what build produced
+*******************************
+
+If a script or CI job needs the exact filenames build produced, add ``--report`` to write them to a JSON file instead of
+parsing the output:
+
+.. code-block:: console
+
+    $ python -m build --report dist/report.json
 
 ************
  Next steps

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -25,8 +25,8 @@ __lazy_modules__ = [
     'tempfile',
     'textwrap',
     'traceback',
-    'typing',
     'warnings',
+    'zipfile',
 ]
 
 import argparse
@@ -43,6 +43,7 @@ import tempfile
 import textwrap
 import traceback
 import warnings
+import zipfile
 
 from functools import partial
 from tarfile import TarError
@@ -422,7 +423,9 @@ def _build_metadata(
     installer: _env.Installer = 'pip',
     env_dir: str | None = None,
 ) -> list[str]:
-    import packaging.metadata
+    if os.path.isfile(srcdir) and os.fspath(srcdir).lower().endswith('.whl'):
+        _print_metadata(_wheel_metadata(srcdir))
+        return []
 
     def run_subprocess(cmd: Sequence[StrPath], cwd: str | None = None, extra_environ: Mapping[str, str] | None = None) -> None:
         env = os.environ.copy()
@@ -448,12 +451,27 @@ def _build_metadata(
             'rb',
         ) as metadata_file,
     ):
-        valid_metadata, _ = packaging.metadata.parse_email(metadata_file.read())
+        _print_metadata(metadata_file.read())
+
+    return []
+
+
+def _wheel_metadata(wheel: StrPath) -> bytes:
+    with zipfile.ZipFile(wheel) as archive:
+        names = [name for name in archive.namelist() if name.count('/') == 1 and name.endswith('.dist-info/METADATA')]
+        if len(names) != 1:
+            msg = f'{os.fspath(wheel)!r} is not a valid wheel: expected one .dist-info/METADATA, found {len(names)}'
+            raise BuildException(msg)
+        return archive.read(names[0])
+
+
+def _print_metadata(raw_metadata: bytes) -> None:
+    import packaging.metadata
+
+    valid_metadata, _ = packaging.metadata.parse_email(raw_metadata)
     print(  # noqa: T201
         json.dumps(valid_metadata, ensure_ascii=False, indent=2),
     )
-
-    return []
 
 
 def main_parser() -> argparse.ArgumentParser:
@@ -510,7 +528,8 @@ def main_parser() -> argparse.ArgumentParser:
         type=str,
         nargs='?',
         default=os.getcwd(),
-        help='source directory or .tar.gz source distribution (defaults to the current working directory)',
+        help='source directory, .tar.gz source distribution, or (with --metadata) a .whl to read metadata from '
+        '(defaults to the current working directory)',
     )
 
     global_group = parser.add_argument_group('global options')
@@ -578,7 +597,8 @@ def main_parser() -> argparse.ArgumentParser:
     build_group.add_argument(
         '--metadata',
         action='store_true',
-        help="print out a wheel's metadata in JSON format. Cannot be used in conjunction with ``--sdist`` or ``--wheel``",
+        help="print out a wheel's metadata in JSON format, building it first unless the source argument is already a "
+        '.whl. Cannot be used in conjunction with ``--sdist`` or ``--wheel``',
     )
     build_group.add_argument(
         '--report',
@@ -687,8 +707,9 @@ def main(cli_args: Sequence[str], prog: str | None = None) -> None:
     _setup_cli(verbosity=args.verbosity)
 
     sdist_input = os.path.isfile(args.srcdir) and os.fspath(args.srcdir).lower().endswith('.tar.gz')
+    wheel_input = os.path.isfile(args.srcdir) and os.fspath(args.srcdir).lower().endswith('.whl')
     build = partial(
-        _select_build(parser, args, sdist_input=sdist_input),
+        _select_build(parser, args, sdist_input=sdist_input, wheel_input=wheel_input),
         config_settings=_resolve_config_settings(args),
         isolation=not args.no_isolation,
         skip_dependency_check=args.skip_dependency_check,
@@ -699,7 +720,7 @@ def main(cli_args: Sequence[str], prog: str | None = None) -> None:
 
     if args.outdir is not None:
         outdir = args.outdir
-    elif sdist_input:
+    elif sdist_input or wheel_input:
         outdir = os.path.dirname(os.path.abspath(args.srcdir))
     else:
         outdir = os.path.join(args.srcdir, 'dist')
@@ -781,11 +802,15 @@ def _resolve_config_settings(args: _Args) -> Mapping[str, JSONValue]:
     return {}
 
 
-def _select_build(parser: argparse.ArgumentParser, args: _Args, *, sdist_input: bool) -> partial[list[str]]:
+def _select_build(
+    parser: argparse.ArgumentParser, args: _Args, *, sdist_input: bool, wheel_input: bool
+) -> partial[list[str]]:
     if args.report and args.metadata:
         parser.error('--report: not allowed with --metadata')
     if args.output_format is not None and args.report is None:
         parser.error('--output-format: only valid together with --report')
+    if wheel_input and not args.metadata:
+        parser.error('a wheel can only be used with --metadata, to read its metadata; it cannot be built from')
     if args.metadata and args.distributions:
         parser.error('--metadata: not allowed with --sdist or --wheel')
     if sdist_input and args.distributions and 'sdist' in args.distributions:

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -11,6 +11,7 @@ __lazy_modules__ = [
     'build._util',
     'build.env',
     'functools',
+    'hashlib',
     'json',
     'os',
     'packaging',
@@ -31,6 +32,7 @@ __lazy_modules__ = [
 import argparse
 import contextlib
 import contextvars
+import hashlib
 import json
 import os
 import platform
@@ -45,7 +47,7 @@ import warnings
 from functools import partial
 from tarfile import TarError
 from tarfile import open as tar_open
-from typing import NoReturn, TextIO, cast
+from typing import NoReturn, TextIO, TypedDict, cast
 
 import pyproject_hooks
 
@@ -89,6 +91,8 @@ if TYPE_CHECKING:
         skip_dependency_check: bool
         sdist_extract_dir: str | None
         env_dir: str | None
+        report: str | None
+        output_format: str | None
 
 
 _COLORS = {
@@ -576,6 +580,17 @@ def main_parser() -> argparse.ArgumentParser:
         action='store_true',
         help="print out a wheel's metadata in JSON format. Cannot be used in conjunction with ``--sdist`` or ``--wheel``",
     )
+    build_group.add_argument(
+        '--report',
+        help='write a machine-readable report of the built artifacts (name, path, kind, size and SHA-256 hash) to PATH. '
+        'Cannot be used together with ``--metadata``',
+        metavar='PATH',
+    )
+    build_group.add_argument(
+        '--output-format',
+        choices=['json'],
+        help='format of the ``--report`` file (defaults to json); only valid together with ``--report``',
+    )
     config_exclusive_group = build_group.add_mutually_exclusive_group()
     config_exclusive_group.add_argument(
         '--config-setting',
@@ -696,11 +711,60 @@ def main(cli_args: Sequence[str], prog: str | None = None) -> None:
                 built = build(extracted_srcdir, outdir)
         else:
             built = build(args.srcdir, outdir)
+        if args.report is not None:
+            _write_report(args.report, outdir, built)
         if _ctx.verbosity >= -1 and built:
             artifact_list = _natural_language_list(
                 ['{underline}{}{reset}{bold}{green}'.format(artifact, **_styles.get()) for artifact in built]
             )
             _cprint('{bold}{green}Successfully built {}{reset}', artifact_list)
+
+
+class _ArtifactReport(TypedDict):
+    name: str
+    path: str
+    kind: str
+    size: int
+    hashes: dict[str, str]
+
+
+class _BuildReport(TypedDict):
+    version: str
+    artifacts: list[_ArtifactReport]
+
+
+def _write_report(path: StrPath, outdir: StrPath, artifacts: Sequence[str]) -> None:
+    report: _BuildReport = {
+        'version': '1.0',
+        'artifacts': [_describe_artifact(os.path.join(outdir, name), name) for name in artifacts],
+    }
+    data = json.dumps(report, indent=2) + '\n'
+
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(os.path.abspath(path)), suffix='.tmp')
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as report_file:
+            report_file.write(data)
+        os.replace(tmp, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+
+
+def _describe_artifact(path: str, name: str) -> _ArtifactReport:
+    digest = hashlib.sha256()
+    size = 0
+    with open(path, 'rb') as artifact:
+        while chunk := artifact.read(65536):
+            size += len(chunk)
+            digest.update(chunk)
+    return {
+        'name': name,
+        'path': path,
+        'kind': 'sdist' if name.endswith('.tar.gz') else 'wheel',
+        'size': size,
+        'hashes': {'sha256': digest.hexdigest()},
+    }
 
 
 def _resolve_config_settings(args: _Args) -> Mapping[str, JSONValue]:
@@ -718,6 +782,10 @@ def _resolve_config_settings(args: _Args) -> Mapping[str, JSONValue]:
 
 
 def _select_build(parser: argparse.ArgumentParser, args: _Args, *, sdist_input: bool) -> partial[list[str]]:
+    if args.report and args.metadata:
+        parser.error('--report: not allowed with --metadata')
+    if args.output_format is not None and args.report is None:
+        parser.error('--output-format: only valid together with --report')
     if args.metadata and args.distributions:
         parser.error('--metadata: not allowed with --sdist or --wheel')
     if sdist_input and args.distributions and 'sdist' in args.distributions:

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -93,7 +93,6 @@ if TYPE_CHECKING:
         sdist_extract_dir: str | None
         env_dir: str | None
         report: str | None
-        output_format: str | None
 
 
 _COLORS = {
@@ -602,8 +601,12 @@ def main_parser() -> argparse.ArgumentParser:
     )
     build_group.add_argument(
         '--report',
-        help='write a machine-readable JSON report of the built artifacts (name, path, kind, size and SHA-256 hash) to '
-        'PATH. Cannot be used together with ``--metadata``',
+        nargs='?',
+        const='',
+        default=None,
+        help='write a machine-readable JSON report of the built artifacts (name, path, kind, size and SHA-256 hash); '
+        'with no PATH it is written next to the distributions as ``build-report.json`` in the output directory. '
+        'Cannot be used together with ``--metadata``',
         metavar='PATH',
     )
     config_exclusive_group = build_group.add_mutually_exclusive_group()
@@ -728,7 +731,8 @@ def main(cli_args: Sequence[str], prog: str | None = None) -> None:
         else:
             built = build(args.srcdir, outdir)
         if args.report is not None:
-            _write_report(args.report, outdir, built)
+            report_path = args.report or os.path.join(outdir, 'build-report.json')
+            _write_report(report_path, outdir, built)
         if _ctx.verbosity >= -1 and built:
             artifact_list = _natural_language_list(
                 ['{underline}{}{reset}{bold}{green}'.format(artifact, **_styles.get()) for artifact in built]
@@ -797,10 +801,8 @@ def _resolve_config_settings(args: _Args) -> Mapping[str, JSONValue]:
     return {}
 
 
-def _select_build(
-    parser: argparse.ArgumentParser, args: _Args, *, sdist_input: bool, wheel_input: bool
-) -> partial[list[str]]:
-    if args.report and args.metadata:
+def _select_build(parser: argparse.ArgumentParser, args: _Args, *, sdist_input: bool, wheel_input: bool) -> partial[list[str]]:
+    if args.report is not None and args.metadata:
         parser.error('--report: not allowed with --metadata')
     if wheel_input and not args.metadata:
         parser.error('a wheel can only be used with --metadata, to read its metadata; it cannot be built from')

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -602,14 +602,9 @@ def main_parser() -> argparse.ArgumentParser:
     )
     build_group.add_argument(
         '--report',
-        help='write a machine-readable report of the built artifacts (name, path, kind, size and SHA-256 hash) to PATH. '
-        'Cannot be used together with ``--metadata``',
+        help='write a machine-readable JSON report of the built artifacts (name, path, kind, size and SHA-256 hash) to '
+        'PATH. Cannot be used together with ``--metadata``',
         metavar='PATH',
-    )
-    build_group.add_argument(
-        '--output-format',
-        choices=['json'],
-        help='format of the ``--report`` file (defaults to json); only valid together with ``--report``',
     )
     config_exclusive_group = build_group.add_mutually_exclusive_group()
     config_exclusive_group.add_argument(
@@ -807,8 +802,6 @@ def _select_build(
 ) -> partial[list[str]]:
     if args.report and args.metadata:
         parser.error('--report: not allowed with --metadata')
-    if args.output_format is not None and args.report is None:
-        parser.error('--output-format: only valid together with --report')
     if wheel_input and not args.metadata:
         parser.error('a wheel can only be used with --metadata, to read its metadata; it cannot be built from')
     if args.metadata and args.distributions:

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -601,12 +601,8 @@ def main_parser() -> argparse.ArgumentParser:
     )
     build_group.add_argument(
         '--report',
-        nargs='?',
-        const='',
-        default=None,
-        help='write a machine-readable JSON report of the built artifacts (name, path, kind, size and SHA-256 hash); '
-        'with no PATH it is written next to the distributions as ``build-report.json`` in the output directory. '
-        'Cannot be used together with ``--metadata``',
+        help='write a machine-readable JSON report of the built artifacts (name, path, kind, size and SHA-256 hash) '
+        'to this path. Cannot be used together with ``--metadata``',
         metavar='PATH',
     )
     config_exclusive_group = build_group.add_mutually_exclusive_group()
@@ -731,8 +727,7 @@ def main(cli_args: Sequence[str], prog: str | None = None) -> None:
         else:
             built = build(args.srcdir, outdir)
         if args.report is not None:
-            report_path = args.report or os.path.join(outdir, 'build-report.json')
-            _write_report(report_path, outdir, built)
+            _write_report(args.report, outdir, built)
         if _ctx.verbosity >= -1 and built:
             artifact_list = _natural_language_list(
                 ['{underline}{}{reset}{bold}{green}'.format(artifact, **_styles.get()) for artifact in built]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1275,6 +1275,20 @@ def test_report_written(
         assert artifact['hashes'] == {'sha256': hashlib.sha256(path.read_bytes()).hexdigest()}
 
 
+def test_report_written_to_default_path(
+    mocker: pytest_mock.MockerFixture,
+    tmp_path: pathlib.Path,
+    built_dist: tuple[pathlib.Path, list[str]],
+) -> None:
+    outdir, names = built_dist
+    mocker.patch('build.__main__.build_package_via_sdist', autospec=True, return_value=names)
+
+    build.__main__.main([str(tmp_path), '-o', str(outdir), '--report'])
+
+    payload = json.loads((outdir / 'build-report.json').read_text(encoding='utf-8'))
+    assert [artifact['name'] for artifact in payload['artifacts']] == names
+
+
 def test_write_report_is_atomic(tmp_path: pathlib.Path, built_dist: tuple[pathlib.Path, list[str]]) -> None:
     outdir, names = built_dist
     report = tmp_path / 'report.json'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1253,24 +1253,16 @@ def built_dist(tmp_path: pathlib.Path) -> tuple[pathlib.Path, list[str]]:
     return outdir, names
 
 
-@pytest.mark.parametrize(
-    'extra_args',
-    [
-        pytest.param([], id='report'),
-        pytest.param(['--output-format', 'json'], id='report-with-output-format'),
-    ],
-)
 def test_report_written(
     mocker: pytest_mock.MockerFixture,
     tmp_path: pathlib.Path,
     built_dist: tuple[pathlib.Path, list[str]],
-    extra_args: list[str],
 ) -> None:
     outdir, names = built_dist
     mocker.patch('build.__main__.build_package_via_sdist', autospec=True, return_value=names)
     report = tmp_path / 'report.json'
 
-    build.__main__.main([str(tmp_path), '-o', str(outdir), '--report', str(report), *extra_args])
+    build.__main__.main([str(tmp_path), '-o', str(outdir), '--report', str(report)])
 
     payload = json.loads(report.read_text(encoding='utf-8'))
     assert payload['version'] == '1.0'
@@ -1305,18 +1297,11 @@ def test_write_report_cleans_tmp_on_failure(
     assert not list(tmp_path.glob('*.tmp'))
 
 
-@pytest.mark.parametrize(
-    ('cli_args', 'err_msg'),
-    [
-        pytest.param(['--report', 'r.json', '--metadata'], '--report: not allowed with --metadata', id='report-with-metadata'),
-        pytest.param(['--output-format', 'json'], '--output-format: only valid together with --report', id='format-no-report'),
-    ],
-)
-def test_report_arg_errors(cli_args: list[str], err_msg: str, capsys: pytest.CaptureFixture[str]) -> None:
+def test_report_not_allowed_with_metadata(capsys: pytest.CaptureFixture[str]) -> None:
     with pytest.raises(SystemExit):
-        build.__main__.main(cli_args)
+        build.__main__.main(['--report', 'r.json', '--metadata'])
 
-    assert err_msg in capsys.readouterr().err
+    assert '--report: not allowed with --metadata' in capsys.readouterr().err
 
 
 @pytest.fixture

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,6 +14,7 @@ import sys
 import tarfile
 import unittest.mock
 import venv
+import zipfile
 
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Protocol, TypedDict
@@ -1316,3 +1317,37 @@ def test_report_arg_errors(cli_args: list[str], err_msg: str, capsys: pytest.Cap
         build.__main__.main(cli_args)
 
     assert err_msg in capsys.readouterr().err
+
+
+@pytest.fixture
+def wheel(tmp_path: pathlib.Path) -> pathlib.Path:
+    path = tmp_path / 'demo-1.0.0-py3-none-any.whl'
+    with zipfile.ZipFile(path, 'w') as archive:
+        archive.writestr('demo-1.0.0.dist-info/METADATA', 'Metadata-Version: 2.1\nName: demo\nVersion: 1.0.0\n\n')
+    return path
+
+
+def test_metadata_read_from_wheel(wheel: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:
+    build.__main__.main([str(wheel), '--metadata'])
+
+    metadata = json.loads(capsys.readouterr().out)
+    assert metadata['name'] == 'demo'
+    assert metadata['version'] == '1.0.0'
+
+
+def test_wheel_input_requires_metadata(wheel: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit):
+        build.__main__.main([str(wheel)])
+
+    assert 'a wheel can only be used with --metadata' in capsys.readouterr().err
+
+
+def test_metadata_from_wheel_without_dist_info(tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:
+    path = tmp_path / 'broken-1.0.0-py3-none-any.whl'
+    with zipfile.ZipFile(path, 'w') as archive:
+        archive.writestr('demo/__init__.py', '')
+
+    with pytest.raises(SystemExit):
+        build.__main__.main([str(path), '--metadata'])
+
+    assert 'is not a valid wheel' in capsys.readouterr().err

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import io
 import json
 import os
@@ -1239,3 +1240,79 @@ def test_main_non_archive_file_treated_as_directory(tmp_path: pathlib.Path, mock
     build.__main__.main([str(archive)])
 
     via_sdist.assert_called_once()
+
+
+@pytest.fixture
+def built_dist(tmp_path: pathlib.Path) -> tuple[pathlib.Path, list[str]]:
+    outdir = tmp_path / 'dist'
+    outdir.mkdir()
+    names = ['test_pkg-1.0.0.tar.gz', 'test_pkg-1.0.0-py3-none-any.whl']
+    for name in names:
+        (outdir / name).write_bytes(f'contents of {name}'.encode())
+    return outdir, names
+
+
+@pytest.mark.parametrize(
+    'extra_args',
+    [
+        pytest.param([], id='report'),
+        pytest.param(['--output-format', 'json'], id='report-with-output-format'),
+    ],
+)
+def test_report_written(
+    mocker: pytest_mock.MockerFixture,
+    tmp_path: pathlib.Path,
+    built_dist: tuple[pathlib.Path, list[str]],
+    extra_args: list[str],
+) -> None:
+    outdir, names = built_dist
+    mocker.patch('build.__main__.build_package_via_sdist', autospec=True, return_value=names)
+    report = tmp_path / 'report.json'
+
+    build.__main__.main([str(tmp_path), '-o', str(outdir), '--report', str(report), *extra_args])
+
+    payload = json.loads(report.read_text(encoding='utf-8'))
+    assert payload['version'] == '1.0'
+    assert [artifact['name'] for artifact in payload['artifacts']] == names
+    for artifact, name in zip(payload['artifacts'], names, strict=True):
+        path = outdir / name
+        assert artifact['path'] == os.path.join(str(outdir), name)
+        assert artifact['kind'] == ('sdist' if name.endswith('.tar.gz') else 'wheel')
+        assert artifact['size'] == path.stat().st_size
+        assert artifact['hashes'] == {'sha256': hashlib.sha256(path.read_bytes()).hexdigest()}
+
+
+def test_write_report_is_atomic(tmp_path: pathlib.Path, built_dist: tuple[pathlib.Path, list[str]]) -> None:
+    outdir, names = built_dist
+    report = tmp_path / 'report.json'
+
+    build.__main__._write_report(report, str(outdir), names)
+
+    assert not list(tmp_path.glob('*.tmp'))
+    assert not list(outdir.glob('*.tmp'))
+
+
+def test_write_report_cleans_tmp_on_failure(
+    mocker: pytest_mock.MockerFixture, tmp_path: pathlib.Path, built_dist: tuple[pathlib.Path, list[str]]
+) -> None:
+    outdir, names = built_dist
+    mocker.patch('build.__main__.os.replace', side_effect=OSError('boom'))
+
+    with pytest.raises(OSError, match='boom'):
+        build.__main__._write_report(tmp_path / 'report.json', str(outdir), names)
+
+    assert not list(tmp_path.glob('*.tmp'))
+
+
+@pytest.mark.parametrize(
+    ('cli_args', 'err_msg'),
+    [
+        pytest.param(['--report', 'r.json', '--metadata'], '--report: not allowed with --metadata', id='report-with-metadata'),
+        pytest.param(['--output-format', 'json'], '--output-format: only valid together with --report', id='format-no-report'),
+    ],
+)
+def test_report_arg_errors(cli_args: list[str], err_msg: str, capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit):
+        build.__main__.main(cli_args)
+
+    assert err_msg in capsys.readouterr().err

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1275,18 +1275,11 @@ def test_report_written(
         assert artifact['hashes'] == {'sha256': hashlib.sha256(path.read_bytes()).hexdigest()}
 
 
-def test_report_written_to_default_path(
-    mocker: pytest_mock.MockerFixture,
-    tmp_path: pathlib.Path,
-    built_dist: tuple[pathlib.Path, list[str]],
-) -> None:
-    outdir, names = built_dist
-    mocker.patch('build.__main__.build_package_via_sdist', autospec=True, return_value=names)
+def test_report_requires_path(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit):
+        build.__main__.main(['--report'])
 
-    build.__main__.main([str(tmp_path), '-o', str(outdir), '--report'])
-
-    payload = json.loads((outdir / 'build-report.json').read_text(encoding='utf-8'))
-    assert [artifact['name'] for artifact in payload['artifacts']] == names
+    assert '--report: expected one argument' in capsys.readouterr().err
 
 
 def test_write_report_is_atomic(tmp_path: pathlib.Path, built_dist: tuple[pathlib.Path, list[str]]) -> None:


### PR DESCRIPTION
Closes #198.

Anyone wiring `build` into a release pipeline hits the same wall: once the build finishes, they need to know *which* files came out so they can upload, sign, or checksum them. The filenames are not predictable, since they carry the version and, for wheels, the Python, ABI and platform tags. So today people reach for workarounds that each have a sharp edge. They glob `dist/*` and trust that the next tool expands it (only `twine` does; `pip install dist/*` does not). They `rm -rf dist` before every build so a stale artifact from last time does not get published by accident. They scrape the coloured `Successfully built …` line off the terminal. Or they drop down to the Python API and reimplement a chunk of the CLI. 📦 None of these is something we want to be the recommended path.

This adds a first-class answer: `python -m build --report dist/report.json` writes a small JSON file describing exactly what was produced — each artifact's name, path, kind (`sdist` or `wheel`), size, and SHA-256 hash. A pipeline can then do `twine upload $(jq -r '.artifacts[].path' dist/report.json)` and be certain it is shipping this build's output and nothing else. Including the hash also gives projects a ready hook for provenance and checksums (the ask from #789, folded in here). ✨

The report goes to a file the frontend owns rather than to stdout, because the build backend runs as a subprocess that can print to stdout itself — so a structured payload there could never be parsed safely. The report is JSON and its `version` field is a schema version, so the format can grow later without breaking readers. The default `python -m build` experience is untouched and the feature is entirely opt-in.

Building on that, `--metadata` now also accepts a built wheel: `python -m build --metadata dist/mypackage-1.0.0-py3-none-any.whl` reads the wheel's `METADATA` and prints it as JSON without building anything. A pipeline can lift a wheel's path straight out of `report.json` and inspect what it shipped — no rebuild, no unzip.

## Workarounds people use today

The fragile stopgaps people reach for in the issue threads until this lands:

- [#198 (comment)](https://github.com/pypa/build/issues/198#issuecomment-740115413) — `rm -rf dist` before each build, then `twine upload dist/*` relying on twine's own glob expansion to avoid shipping stale artifacts.
- [#198 (comment)](https://github.com/pypa/build/issues/198#issuecomment-762794454) — the catch: `pip install dist/*` does *not* glob-expand, so CI still has to discover the dynamically named files some other way.
- [#198 (comment)](https://github.com/pypa/build/issues/198#issuecomment-740102639) — the original ask: write a manifest JSON and pipe its path through `jq` into the installer.
- [#198 (comment)](https://github.com/pypa/build/issues/198#issuecomment-2067611620) — hand-rolling a JSON file in `dist/`, which then breaks because `twine dist/*` tries to upload the JSON to PyPI.
- [#198 (comment)](https://github.com/pypa/build/issues/198#issuecomment-2074156261) — confirmation that stdout/stderr scraping cannot work (the backend writes there too), with [uv#2314](https://github.com/astral-sh/uv/pull/2314) and [twine#281](https://github.com/pypa/twine/issues/281) showing the same problem hit elsewhere.
- [#789 (comment)](https://github.com/pypa/build/issues/789#issuecomment-2179420077) — the rebuttal to scraping the coloured `Successfully built …` line for digests: build logs are the wrong place; machine-readable output is the real fix.


### Seen in the wild on GitHub

Release pipelines wipe `dist/` first, then re-discover the produced files by globbing, because nothing tells them the names:

- [pypa/packaging `noxfile.py` (L400-L406)](https://github.com/pypa/packaging/blob/23a1cc498e28c7c915319f16ce89f0a6563d3ead/noxfile.py#L400-L406) — after `python -m build`, reconstructs the expected `dist/{name}-{version}-...whl`/`.tar.gz` names by hand (`rmtree("dist")` at L420). Even pypa's own tooling guesses the filenames.
- [pypa/cibuildwheel `noxfile.py` (L198-L205)](https://github.com/pypa/cibuildwheel/blob/2f49f9a050c42805d0f0c5cfd7083637c11a5b4e/noxfile.py#L198-L205) — `shutil.rmtree` on `build/` and `dist/` before `python -m build` to tell new output from stale.
- [Python-Markdown `makefile` (L21-L24)](https://github.com/Python-Markdown/markdown/blob/ddead47873e7918829e1d8b0eaee6ab725793cc9/makefile#L21-L24) — `rm -rf build dist`, then `python -m build`, then `twine upload dist/*`.
- [openfisca-core `tasks/publish.mk` (L14-L16)](https://github.com/openfisca/openfisca-core/blob/4f7f09833afe7e8b6856e8d7a3016c04a931009b/tasks/publish.mk#L14-L16) — `python -m build`, then `find dist -name "*.whl"` to locate the wheel to install.
- [python-a2a `release.sh` (L531-L536)](https://github.com/themanojdesai/python-a2a/blob/40b969a465f85e8156793b7cfac16c5e23ed0b86/release.sh#L531-L536) — `find dist -name "*.whl"` to install the just-built wheel, after `rm -rf dist` (L78) and `python -m build` (L349).