### PR TITLE
✨ feat(cli): warn on valueless config settings

### DIFF
--- a/docs/changelog/640.removal.rst
+++ b/docs/changelog/640.removal.rst
@@ -1,0 +1,2 @@
+build now warns when you pass a config setting without a value (e.g. ``-C--my-flag``), since pip rejects that form.
+Write ``-C--my-flag=`` instead; it means the same thing and works in both tools - by :user:`gaborbernat`.

--- a/docs/explanation/build-backends.rst
+++ b/docs/explanation/build-backends.rst
@@ -285,6 +285,10 @@ With scikit-build-core, you can configure CMake:
 
 Each backend interprets these settings differently. See :doc:`../how-to/config-settings` for backend-specific examples.
 
+Config settings map keys to values, so every key needs a value. Drop the ``=VALUE`` and the key gets an empty value,
+which suits backends that act on a flag's presence alone. build accepts this shorthand but warns about it, because pip
+only takes the explicit ``KEY=VALUE`` form. Write ``KEY=`` for an empty value and your command runs under both tools.
+
 ******************
  Dynamic Metadata
 ******************

--- a/docs/how-to/config-settings.rst
+++ b/docs/how-to/config-settings.rst
@@ -22,16 +22,16 @@ The basic syntax is:
 
     $ python -m build -C KEY=VALUE
 
-Or for options without values (equivalent to ``-C KEY=""``):
+Or for options without values:
 
 .. code-block:: console
 
-    $ python -m build -C KEY
+    $ python -m build -C KEY=
 
 .. note::
 
-    The ``-C KEY`` syntax (without ``=``) is supported by build but not by pip. For maximum compatibility, use ``-C
-    KEY=""`` explicitly when you need an empty value.
+    build also accepts the bare ``-C KEY`` form (without ``=``) and reads it as ``-C KEY=``, but warns you because pip
+    rejects it. Write ``-C KEY=`` to keep the command working in both tools.
 
 Multiple settings can be provided:
 

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -538,8 +538,10 @@ def main_parser() -> argparse.ArgumentParser:
         action='append',
         help='settings to pass to the backend.  Multiple settings can be provided. '
         'Settings beginning with a hyphen will erroneously be interpreted as options to build if separated '
-        'by a space; use ``--config-setting=--my-setting -C--my-other-setting`` instead',
-        metavar='KEY[=VALUE]',
+        'by a space; use ``--config-setting=--my-setting -C--my-other-setting`` instead. '
+        'A setting passed without ``=VALUE`` is given an empty value, but this form is not supported by pip; '
+        'write ``KEY=`` instead for compatibility',
+        metavar='KEY=[VALUE]',
     )
     config_exclusive_group.add_argument(
         '--config-json',
@@ -582,15 +584,20 @@ def _parse_config_settings(raw_config_settings: list[str]) -> dict[str, str | li
     config_settings = dict[str, str | list[str]]()
 
     for arg in raw_config_settings:
-        setting, _, value = arg.partition('=')
-        if setting not in config_settings:
+        setting, sep, value = arg.partition('=')
+        if not sep:
+            warnings.warn(
+                f'Config setting {setting!r} was passed without a value; this form is not supported by pip. '
+                f'Write {setting}= instead to be compatible with both tools',
+                stacklevel=2,
+            )
+        existing = config_settings.get(setting)
+        if existing is None:
             config_settings[setting] = value
+        elif isinstance(existing, list):
+            existing.append(value)
         else:
-            existing = config_settings[setting]
-            if isinstance(existing, list):
-                existing.append(value)
-            else:
-                config_settings[setting] = [existing, value]
+            config_settings[setting] = [existing, value]
 
     return config_settings
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -97,7 +97,7 @@ def make_kwargs(
             ['--installer', 'uv'], (cwd, out), make_kwargs(installer='uv'), 'build_package_via_sdist', id='installer'
         ),
         pytest.param(
-            ['-C--flag1', '-C--flag2'],
+            ['-C--flag1=', '-C--flag2='],
             (cwd, out),
             make_kwargs(config_settings={'--flag1': '', '--flag2': ''}),
             'build_package_via_sdist',
@@ -763,6 +763,23 @@ def test_build_package_via_sdist_empty_distributions(mocker: pytest_mock.MockerF
 def test_parse_config_settings_triple_duplicate() -> None:
     result = build.__main__._parse_config_settings(['--flag=a', '--flag=b', '--flag=c'])
     assert result == {'--flag': ['a', 'b', 'c']}
+
+
+@pytest.mark.parametrize(
+    ('arg', 'value', 'warns'),
+    [
+        pytest.param('--flag', '', True, id='bare-key-warns'),
+        pytest.param('--flag=', '', False, id='empty-value'),
+        pytest.param('--flag=value', 'value', False, id='with-value'),
+    ],
+)
+def test_parse_config_settings_pip_compatibility(arg: str, value: str, warns: bool, recwarn: pytest.WarningsRecorder) -> None:
+    assert build.__main__._parse_config_settings([arg]) == {'--flag': value}
+
+    messages = [str(warning.message) for warning in recwarn]
+    config_warnings = [m for m in messages if "Config setting '--flag' was passed without a value" in m]
+    assert messages == config_warnings  # no unrelated warnings are emitted either way
+    assert bool(config_warnings) == warns
 
 
 def test_build_metadata_runner_without_extra_environ(


### PR DESCRIPTION
People reach for the same `-C` / `--config-settings` flag whether they build with build or install with pip, and they expect a command that works in one to work in the other. build quietly accepts a valueless setting such as `-C--with-c-extensions` and treats it as an empty value, while pip refuses anything without an `=`. Someone who copies a working build command into a pip invocation hits a confusing rejection. Today people get past it by reading pip's error closely enough to learn they must append `=`, or by lifting the workaround from issue threads such as cibuildwheel's. Henry raised the inconsistency in #640 and asked the two tools to agree.

build now warns when a setting arrives without a value and shows the `-C KEY=` form that both tools accept. ✨ The shorthand keeps working, so existing scripts and pipelines keep running, and the warning moves people toward a spelling they can reuse with pip. The how-to guide, the backend explanation, and the CLI help now give the same guidance, so anyone who reads one of them lands on the portable form.

Someone relying on the bare form sees a single warning with the exact fix, and nothing they run today stops working. Closes #640.

## Workarounds people use today

Issue #640 has no comments; the discussion and the workaround live in the cibuildwheel thread it points to:

- [cibuildwheel#1513 (comment)](https://github.com/pypa/cibuildwheel/issues/1513#issuecomment-1591178953) — the portable form people settle on: append `=` so `-C--with-c-extensions=` is accepted by both build and pip.
- [cibuildwheel#1513 (comment)](https://github.com/pypa/cibuildwheel/issues/1513#issuecomment-1594343986) — the proposal to normalize everything to `key=value` pairs to paper over the mismatch.
- [pip `--config-settings` docs](https://pip.pypa.io/en/stable/cli/pip_install/) — pip's "Settings take the form `KEY=VALUE`" rule that forces the workaround in the first place.


### Seen in the wild on GitHub

Build scripts write config settings in the portable `--config-setting=KEY=VALUE` form that both build and pip accept, never the bare `-C KEY`:

- [Mercurial `build-one-linux-wheel.sh` (L23-L35)](https://github.com/saschazepter/hg/blob/c274076ac4fc65076f13e14c6d3756cd65966d3d/contrib/build-one-linux-wheel.sh#L23-L35) — passes the flag as `--config-setting=--global-option=--rust` to `python -m build`.
- [Streamlink `build-and-sign.sh` (L60)](https://github.com/streamlink/streamlink/blob/79324b9e8ae37650e71764590211a9b5f2d840cc/script/build-and-sign.sh#L60) — `python -m build ... --config-setting="--build-option=--plat-name=..."` with an explicit value.
- [LightGBM `build-python.sh` (L145)](https://github.com/lightgbm-org/LightGBM/blob/1c0970bbb764a140cca525f5c26e85bc01624779/build-python.sh#L145) — every setting carries an explicit `=`, even boolean flags like `cmake.define.USE_CUDA=ON`, fed to `python -m build` (L379).
