### PR TITLE
✨ feat(deps): show wanted vs found in missing-deps error

### DIFF
--- a/docs/changelog/504.feature.rst
+++ b/docs/changelog/504.feature.rst
@@ -1,4 +1,4 @@
-The ``Missing dependencies`` error reported by ``--no-isolation`` builds now lists, for each unmet requirement, the
+The ``Unmet dependencies`` error reported by ``--no-isolation`` builds now lists, for each unmet requirement, the
 version specifier that was ``wanted`` and the version that was ``found`` (or that the package is not installed), and
 names the interpreter the check ran against. This makes it clear whether a dependency is absent or merely the wrong
 version, and which environment was inspected - by :user:`gaborbernat`.

--- a/docs/changelog/504.feature.rst
+++ b/docs/changelog/504.feature.rst
@@ -1,0 +1,4 @@
+The ``Missing dependencies`` error reported by ``--no-isolation`` builds now lists, for each unmet requirement, the
+version specifier that was ``wanted`` and the version that was ``found`` (or that the package is not installed), and
+names the interpreter the check ran against. This makes it clear whether a dependency is absent or merely the wrong
+version, and which environment was inspected - by :user:`gaborbernat`.

--- a/docs/explanation/how-it-works.rst
+++ b/docs/explanation/how-it-works.rst
@@ -137,6 +137,16 @@ Use ``--no-isolation`` only when:
 - You're a Linux distribution packager providing dependencies externally
 - You understand the reproducibility implications
 
+Under ``--no-isolation`` build installs nothing; it instead validates that the declared dependencies are already present
+(use ``--skip-dependency-check`` to opt out), so a missing dependency is reported rather than silently producing a
+broken build. That check compares each declared requirement against the installed metadata of the *single interpreter
+running build*, discovered through ``importlib.metadata``. This explains two otherwise confusing outcomes, which the
+error message spells out per requirement (``wanted`` versus ``found``). A package can be present but reported missing
+because its installed version does not satisfy the specifier (``found`` shows that version). And a package you know is
+installed can read as ``not installed`` when it was installed for a *different* Python — a system or distribution
+package manager often targets an interpreter other than the one invoking build, and metadata is not shared across
+interpreters. The error names the interpreter checked so the mismatch is visible rather than left to guesswork.
+
 See :doc:`../how-to/basic-usage` for usage.
 
 ***********************************

--- a/docs/how-to/troubleshooting.rst
+++ b/docs/how-to/troubleshooting.rst
@@ -27,6 +27,38 @@ Build will read your ``pyproject.toml`` and install all required dependencies.
     $ pip install setuptools your-build-backend
     $ python -m build --no-isolation
 
+************************************************
+ "Missing dependencies" with ``--no-isolation``
+************************************************
+
+**Symptom**: A ``--no-isolation`` build stops with:
+
+::
+
+    ERROR Missing dependencies (checked against /usr/local/bin/python3.9):
+        anndata>=0.7.4
+            wanted: >=0.7.4
+            found: not installed
+
+**Cause**: build checks the declared requirements against the interpreter named in the header (the one running build),
+not against a virtual environment or your system package manager. Read each entry as:
+
+- ``found: not installed`` - the package is invisible to *that* interpreter's metadata. If you believe it is installed
+  (for example via a Linux distribution or FreeBSD port), it was installed for a different Python, so build cannot see
+  it. Install it for the interpreter in the header, or run that interpreter's ``python -m build``.
+- ``found: <version>`` - the package is installed but its version does not satisfy ``wanted``. Upgrade or downgrade it
+  to match.
+
+**Solution 1**: Install or fix the offending dependency for the interpreter shown in the header.
+
+**Solution 2**: If you manage build dependencies externally (distribution packaging), skip the check entirely:
+
+.. code-block:: console
+
+    $ python -m build --no-isolation --skip-dependency-check
+
+See :doc:`basic-usage` for more on ``--skip-dependency-check``.
+
 *******************************
  Build hangs or appears frozen
 *******************************

--- a/docs/how-to/troubleshooting.rst
+++ b/docs/how-to/troubleshooting.rst
@@ -27,15 +27,15 @@ Build will read your ``pyproject.toml`` and install all required dependencies.
     $ pip install setuptools your-build-backend
     $ python -m build --no-isolation
 
-************************************************
- "Missing dependencies" with ``--no-isolation``
-************************************************
+**********************************************
+ "Unmet dependencies" with ``--no-isolation``
+**********************************************
 
 **Symptom**: A ``--no-isolation`` build stops with:
 
 ::
 
-    ERROR Missing dependencies (checked against /usr/local/bin/python3.9):
+    ERROR Unmet dependencies (checked against /usr/local/bin/python3.9):
         anndata>=0.7.4
             wanted: >=0.7.4
             found: not installed

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -31,6 +31,28 @@ By default build will build the package in an isolated environment, but this beh
 specified in your ``pyproject.toml``, runs the build, and then cleans up the environment. This ensures reproducible
 builds regardless of what packages are installed in your development environment.
 
+******************
+ Dependency Check
+******************
+
+With ``--no-isolation``, build does not install anything; it checks that the build dependencies are already present in
+the interpreter running build. When a requirement is unmet it exits with a ``Missing dependencies`` error that names the
+interpreter checked and, for each requirement, the version specifier that was ``wanted`` and the version that was
+``found`` (``not installed`` when absent):
+
+.. code-block:: text
+
+    ERROR Missing dependencies (checked against /usr/local/bin/python3.9):
+        anndata>=0.7.4
+            wanted: >=0.7.4
+            found: not installed
+        matplotlib>=3.4 -> kiwisolver>=1.0.1
+            wanted: >=1.0.1
+            found: 1.0.0
+
+Transitive requirements are shown as a ``parent -> child`` chain; the ``wanted``/``found`` lines describe the unmet
+leaf. Pass ``--skip-dependency-check`` to skip this check (see :doc:`../how-to/basic-usage`).
+
 ************************
  Alternative CLI Script
 ************************

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -36,13 +36,13 @@ builds regardless of what packages are installed in your development environment
 ******************
 
 With ``--no-isolation``, build does not install anything; it checks that the build dependencies are already present in
-the interpreter running build. When a requirement is unmet it exits with a ``Missing dependencies`` error that names the
+the interpreter running build. When a requirement is unmet it exits with an ``Unmet dependencies`` error that names the
 interpreter checked and, for each requirement, the version specifier that was ``wanted`` and the version that was
 ``found`` (``not installed`` when absent):
 
 .. code-block:: text
 
-    ERROR Missing dependencies (checked against /usr/local/bin/python3.9):
+    ERROR Unmet dependencies (checked against /usr/local/bin/python3.9):
         anndata>=0.7.4
             wanted: >=0.7.4
             found: not installed

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -165,6 +165,16 @@ against its contents, which catches missing files in the sdist:
 
 The wheel lands next to the sdist. Pass ``--outdir`` to write somewhere else.
 
+****************************
+ Building without isolation
+****************************
+
+If you install the build dependencies yourself and build with ``--no-isolation``, build first checks that every declared
+dependency is present in the interpreter you are running. When something is missing it stops with a ``Missing
+dependencies`` error that names the interpreter it checked and, for each requirement, the version it ``wanted`` against
+the version it ``found`` - so you can tell "not installed" apart from "installed, but the wrong version". See
+:doc:`../how-to/troubleshooting` for how to read it.
+
 ************
  Next steps
 ************

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -57,6 +57,7 @@ import build.env as _env
 from build import ProjectBuilder, _ctx
 from build._compat.tarfile import TarFile, safe_extractall
 from build._exceptions import BuildBackendException, BuildException, FailedProcessError
+from build._util import format_unmet_dependencies
 from build.env import DefaultIsolatedEnv
 
 
@@ -163,10 +164,6 @@ def _error(msg: str, code: int = 1) -> NoReturn:  # pragma: no cover
     raise SystemExit(code)
 
 
-def _format_dep_chain(dep_chain: tuple[str, ...]) -> str:
-    return ' -> '.join(dep.partition(';')[0].strip() for dep in dep_chain)
-
-
 @contextlib.contextmanager
 def _bootstrap_build_env(
     isolation: bool,
@@ -203,12 +200,9 @@ def _bootstrap_build_env(
             make_builder = partial(make_builder, runner=runner)
         builder = make_builder()
 
-        if not skip_dependency_check:
-            missing = builder.check_dependencies(distribution, config_settings)
-            if missing:
-                dependencies = ''.join('\n\t' + _format_dep_chain(deps) for deps in missing)
-                _cprint()
-                _error(f'Missing dependencies:{dependencies}')
+        if not skip_dependency_check and (missing := builder.check_dependencies(distribution, config_settings)):
+            _cprint()
+            _error(format_unmet_dependencies(missing))
 
         yield builder
 

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -8,6 +8,7 @@ __lazy_modules__ = [
     'build._compat',
     'build._compat.tarfile',
     'build._exceptions',
+    'build._util',
     'build.env',
     'functools',
     'json',

--- a/src/build/_util.py
+++ b/src/build/_util.py
@@ -74,7 +74,7 @@ def check_dependency(
 
 def format_unmet_dependencies(unmet: AbstractSet[tuple[str, ...]]) -> str:
     body = ''.join(_format_missing_dependency(chain) for chain in sorted(unmet))
-    return f'Missing dependencies (checked against {sys.executable}):{body}'
+    return f'Unmet dependencies (checked against {sys.executable}):{body}'
 
 
 def _format_missing_dependency(dep_chain: tuple[str, ...]) -> str:

--- a/src/build/_util.py
+++ b/src/build/_util.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
 import re
+import sys
+
+import packaging.requirements
+
+from ._compat import importlib
 
 
 TYPE_CHECKING = False
@@ -27,10 +32,6 @@ def check_dependency(
     :param parent_extras: Extras (eg. "test" in myproject[test])
     :yields: Unmet dependencies
     """
-    import packaging.requirements
-
-    from ._compat import importlib
-
     req = packaging.requirements.Requirement(req_string)
     normalised_req_string = str(req)
 
@@ -62,6 +63,25 @@ def check_dependency(
             for other_req_string in dist.requires:
                 # yields transitive dependencies that are not satisfied.
                 yield from check_dependency(other_req_string, (*ancestral_req_strings, normalised_req_string), req.extras)
+
+
+def format_unmet_dependencies(unmet: AbstractSet[tuple[str, ...]]) -> str:
+    body = ''.join(_format_missing_dependency(chain) for chain in sorted(unmet))
+    return f'Missing dependencies (checked against {sys.executable}):{body}'
+
+
+def _format_missing_dependency(dep_chain: tuple[str, ...]) -> str:
+    requirement = packaging.requirements.Requirement(dep_chain[-1])
+    try:
+        found = importlib.metadata.distribution(requirement.name).version
+    except importlib.metadata.PackageNotFoundError:
+        found = 'not installed'
+    wanted = str(requirement.specifier) if requirement.specifier else 'any'
+    return f'\n\t{_format_dep_chain(dep_chain)}\n\t\twanted: {wanted}\n\t\tfound: {found}'
+
+
+def _format_dep_chain(dep_chain: tuple[str, ...]) -> str:
+    return ' -> '.join(dep.partition(';')[0].strip() for dep in dep_chain)
 
 
 def parse_wheel_filename(filename: str) -> re.Match[str] | None:

--- a/src/build/_util.py
+++ b/src/build/_util.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+
+__lazy_modules__ = [
+    f'{__spec__.parent}._compat',
+    'packaging',
+    'packaging.requirements',
+]
+
 import re
 import sys
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -23,6 +23,8 @@ import pytest_mock
 import build
 import build.__main__
 
+from build._compat import importlib as _importlib
+
 
 pytestmark = pytest.mark.contextvars
 
@@ -411,24 +413,47 @@ def test_build_package_via_sdist_passes_config_settings_to_build(mocker: pytest_
     build.__main__.shutil.rmtree.assert_called_once_with('temp-sdist-dir', ignore_errors=True)  # type: ignore[attr-defined]
 
 
-@pytest.mark.parametrize(
-    ('missing_deps', 'output'),
-    [
-        ([('foo',)], '\n\tfoo'),
-        ([('foo',), ('bar', 'baz', 'qux')], '\n\tfoo\n\tbar -> baz -> qux'),
-    ],
-)
-def test_build_no_isolation_with_check_deps(
-    mocker: pytest_mock.MockerFixture, package_test_flit: str, missing_deps: list[tuple[str, ...]], output: str
-) -> None:
+def test_build_no_isolation_check_deps_not_installed(mocker: pytest_mock.MockerFixture, package_test_flit: str) -> None:
     error = mocker.patch('build.__main__._error')
     build_cmd = mocker.patch('build.ProjectBuilder.build', return_value='something')
-    mocker.patch('build.ProjectBuilder.check_dependencies', return_value=missing_deps)
+    mocker.patch('build.ProjectBuilder.check_dependencies', return_value=[('foo>=1.0',)])
+    mocker.patch('build._compat.importlib.metadata.distribution', side_effect=_importlib.metadata.PackageNotFoundError)
 
     build.__main__.build_package(package_test_flit, '.', ['sdist'], isolation=False)
 
     build_cmd.assert_called_with('sdist', '.', None)
-    error.assert_called_with('Missing dependencies:' + output)
+    error.assert_called_once_with(
+        f'Missing dependencies (checked against {sys.executable}):\n\tfoo>=1.0\n\t\twanted: >=1.0\n\t\tfound: not installed'
+    )
+
+
+def test_build_no_isolation_check_deps_version_mismatch(mocker: pytest_mock.MockerFixture, package_test_flit: str) -> None:
+    error = mocker.patch('build.__main__._error')
+    mocker.patch('build.ProjectBuilder.build', return_value='something')
+    mocker.patch('build.ProjectBuilder.check_dependencies', return_value=[('bar>=2.0',)])
+    mocker.patch('build._compat.importlib.metadata.distribution', return_value=mocker.MagicMock(version='1.0.0'))
+
+    build.__main__.build_package(package_test_flit, '.', ['sdist'], isolation=False)
+
+    error.assert_called_once_with(
+        f'Missing dependencies (checked against {sys.executable}):\n\tbar>=2.0\n\t\twanted: >=2.0\n\t\tfound: 1.0.0'
+    )
+
+
+def test_build_no_isolation_check_deps_chain_without_specifier(
+    mocker: pytest_mock.MockerFixture, package_test_flit: str
+) -> None:
+    error = mocker.patch('build.__main__._error')
+    mocker.patch('build.ProjectBuilder.build', return_value='something')
+    mocker.patch('build.ProjectBuilder.check_dependencies', return_value=[('matplotlib>=2.2', 'kiwisolver')])
+    mocker.patch('build._compat.importlib.metadata.distribution', side_effect=_importlib.metadata.PackageNotFoundError)
+
+    build.__main__.build_package(package_test_flit, '.', ['sdist'], isolation=False)
+
+    error.assert_called_once_with(
+        f'Missing dependencies (checked against {sys.executable}):'
+        '\n\tmatplotlib>=2.2 -> kiwisolver\n\t\twanted: any\n\t\tfound: not installed'
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -423,7 +423,7 @@ def test_build_no_isolation_check_deps_not_installed(mocker: pytest_mock.MockerF
 
     build_cmd.assert_called_with('sdist', '.', None)
     error.assert_called_once_with(
-        f'Missing dependencies (checked against {sys.executable}):\n\tfoo>=1.0\n\t\twanted: >=1.0\n\t\tfound: not installed'
+        f'Unmet dependencies (checked against {sys.executable}):\n\tfoo>=1.0\n\t\twanted: >=1.0\n\t\tfound: not installed'
     )
 
 
@@ -436,7 +436,7 @@ def test_build_no_isolation_check_deps_version_mismatch(mocker: pytest_mock.Mock
     build.__main__.build_package(package_test_flit, '.', ['sdist'], isolation=False)
 
     error.assert_called_once_with(
-        f'Missing dependencies (checked against {sys.executable}):\n\tbar>=2.0\n\t\twanted: >=2.0\n\t\tfound: 1.0.0'
+        f'Unmet dependencies (checked against {sys.executable}):\n\tbar>=2.0\n\t\twanted: >=2.0\n\t\tfound: 1.0.0'
     )
 
 
@@ -451,7 +451,7 @@ def test_build_no_isolation_check_deps_chain_without_specifier(
     build.__main__.build_package(package_test_flit, '.', ['sdist'], isolation=False)
 
     error.assert_called_once_with(
-        f'Missing dependencies (checked against {sys.executable}):'
+        f'Unmet dependencies (checked against {sys.executable}):'
         '\n\tmatplotlib>=2.2 -> kiwisolver\n\t\twanted: any\n\t\tfound: not installed'
     )
 


### PR DESCRIPTION
Packagers and offline builders who run `python -m build --no-isolation` rely on the dependency check to tell them what is missing before a build wastes their time. Today that check lists requirement names and nothing else, so a dependency that is installed at the wrong version, or installed for a different Python than the one running build, still gets reported as simply "missing." In issue #504 a FreeBSD packager stepped through build with a debugger only to discover the package was present the whole time, invisible to the interpreter build was using.

To get past this today people reach for `--skip-dependency-check` and hope nothing is genuinely absent, run `pip list` by hand against each name in the error, or guess which interpreter build actually inspected. None of those answer the real question: what does build see, and why is it not enough?

This change makes the error answer that question. 📦 For every unmet requirement it shows the version that was wanted next to the version that was found (or that the package is not installed), and it names the interpreter the check ran against. A wrong-version dependency now reads as `found: 1.0.0` against `wanted: >=2.0`, and a dependency installed for another Python reads as `found: not installed` beside an interpreter path the user recognizes. ✨ What used to need a debugger is now visible at a glance.

Closes #504.

## Workarounds people use today

How people diagnose a present-but-unrecognised dependency until this lands:

- [#504 (comment)](https://github.com/pypa/build/issues/504#issuecomment-2383365311) — step through `build` under `pdb` to discover a dependency was installed but at the wrong version.
- [#504 (comment)](https://github.com/pypa/build/issues/504#issuecomment-3994378332) — fall back to `--skip-dependency-check`, then `pip list` by hand and `-vvv` for more detail.
- [#504 (comment)](https://github.com/pypa/build/issues/504#issuecomment-4524877911) — manually reason about which interpreter the check actually ran against versus the caller's environment.
- [pip#9794](https://github.com/pypa/pip/issues/9794) — the companion request on the pip side to validate build dependencies under `--no-build-isolation`.


### Seen in the wild on GitHub

Packagers reach for `--skip-dependency-check` to get past the opaque error, accepting they must vet the deps themselves:

- [zeromq/pyzmq cross-compile Dockerfile (L98)](https://github.com/zeromq/pyzmq/blob/73f49bb18588e09dee4e76abb5a4a1beeb418fb4/docs/source/howto/cross.Dockerfile#L98) — `cross-python -m build --no-isolation --skip-dependency-check --wheel`, the wrong-interpreter case where the check would inspect the host Python, not the cross one.
- [HaikuPorts `build` recipe (L90)](https://github.com/haikuports/haikuports/blob/a68cac38b2e05c29b0629826963735b94f198b99/dev-python/build/build-1.5.0.recipe#L90) — `$python -m build --no-isolation --skip-dependency-check` across several interpreters in a loop.
- [FreedomBox `Makefile` (L74)](https://github.com/freedombox/FreedomBox/blob/a7584b465dadd1909abc0ac1039927b1ddf44d6c/Makefile#L74) — `python -m build --no-isolation --skip-dependency-check --wheel` to bypass the check rather than decode it.
