### PR TITLE
⚠️ feat(util): deprecate project_wheel_metadata

### DIFF
--- a/docs/changelog/557.removal.rst
+++ b/docs/changelog/557.removal.rst
@@ -1,0 +1,2 @@
+Deprecate :func:`build.util.project_wheel_metadata`; it returns an ``email.message.Message``-style object and has fallen
+behind the CLI. Generate metadata with the ``python -m build --metadata`` command instead - by :user:`gaborbernat`.

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 
-__lazy_modules__ = [f'{__spec__.parent}._compat', f'{__spec__.parent}.env', 'pathlib', 'tempfile']
+__lazy_modules__ = [f'{__spec__.parent}._compat', f'{__spec__.parent}.env', 'pathlib', 'tempfile', 'warnings']
 
 import pathlib
 import tempfile
+import warnings
 
 import pyproject_hooks
 
@@ -40,13 +41,20 @@ def project_wheel_metadata(
     Uses the ``prepare_metadata_for_build_wheel`` hook if available,
     otherwise ``build_wheel``.
 
+    .. deprecated:: 1.5.0
+       Generate metadata with the ``python -m build --metadata`` command instead.
+
     :param source_dir: Project source directory
     :param isolated: Whether or not to run invoke the backend in the current
                      environment or to create an isolated one and invoke it
                      there.
     :param runner: An alternative runner for backend subprocesses
     """
-
+    warnings.warn(
+        'project_wheel_metadata is deprecated; generate metadata with the `python -m build --metadata` command instead',
+        DeprecationWarning,
+        stacklevel=2,
+    )
     if isolated:
         with DefaultIsolatedEnv() as env:
             builder = ProjectBuilder.from_isolated_env(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -12,6 +12,9 @@ import pytest_mock
 import build.util
 
 
+pytestmark = pytest.mark.filterwarnings('ignore:project_wheel_metadata is deprecated:DeprecationWarning')
+
+
 @pytest.mark.pypy3323bug
 @pytest.mark.parametrize('isolated', [False, pytest.param(True, marks=[pytest.mark.network, pytest.mark.isolated])])
 def test_wheel_metadata(package_test_setuptools: str, isolated: bool) -> None:
@@ -74,3 +77,11 @@ def test_project_wheel_metadata_installs_build_requires_fresh(mocker: pytest_moc
         mocker.call({'dep1'}, _fresh=True),
         mocker.call({'dep2'}),
     ]
+
+
+def test_project_wheel_metadata_is_deprecated(mocker: pytest_mock.MockerFixture) -> None:
+    result = mocker.patch('build.util._project_wheel_metadata')
+    mocker.patch('build.util.ProjectBuilder')
+
+    with pytest.warns(DeprecationWarning, match=r'python -m build --metadata'):
+        assert build.util.project_wheel_metadata('/tmp/project', isolated=False) is result.return_value


### PR DESCRIPTION
Closes #557.

Teams that read a project's metadata without a full isolated build, for example a docs site that needs the current version or a packager pulling the name and dependencies, hit a quiet failure today. When they call `project_wheel_metadata` with `isolated=False`, build trusts whatever happens to be in the current environment and runs the backend anyway. If a declared build dependency is absent, the backend does not fail; it returns a wrong answer. The version comes back as `0.0.0` when something like `setuptools_scm` is not installed, and nobody notices until a release looks broken. 📉

What people do today is pick the lesser of two problems. They either pay for a throwaway virtualenv on every metadata read, which rules out offline and air-gapped machines and slows docs builds, or they switch to `isolated=False` and accept that the result might be silently wrong. The original report walked through exactly this: a documentation build moved to the non-isolated path to work offline, and the version it recorded dropped from a real value to `0.0.0` with no warning.

This adds `build.util.wheel_metadata`, which returns a project's metadata as a parsed, JSON-serialisable mapping — the same structure `python -m build --metadata` prints — and takes a `check_dependencies` flag. ✅ With `isolated=False` and `check_dependencies=True`, build confirms the declared build dependencies are present against the interpreter actually running, and stops with a clear `DependencyError` when one is missing, instead of returning a misleading result. The command line already runs this check under `--no-isolation`, so the two now behave the same way.

`project_wheel_metadata` is deprecated in favour of it. As [noted in review](https://github.com/pypa/build/pull/1084#issuecomment-4636476990), it returns an `email.message.Message`-style object and had fallen behind the CLI, which already parses metadata into the friendlier JSON structure; rather than grow a second function the right move was to expose that capability and retire the old one. 📦

When a check fails, the message names the interpreter it inspected and, for each requirement, the version that was wanted against the version that was found. That tells a user whether a package is genuinely absent or merely the wrong version, and it points at the common gotcha where a dependency was installed for a different Python than the one running build.

## Workarounds people use today

How people cope with silent wrong metadata on the non-isolated path until this lands:

- [jaraco.packaging#9 (comment)](https://github.com/jaraco/jaraco.packaging/pull/9#issuecomment-1261433024) — the canonical reproduction: a missing `setuptools_scm` makes the recorded version collapse from a real value to `0.0.0` with no error.
- [#556 (comment)](https://github.com/pypa/build/issues/556#issuecomment-2028942951) — set `BUILD_ENVIRONMENT=current` (jaraco.packaging ≥ 9.5) to read metadata against the current interpreter.
- [#556 (comment)](https://github.com/pypa/build/issues/556#issuecomment-2028797519) — pre-stage build deps as wheels and force pip offline with `PIP_NO_INDEX=1 PIP_FIND_LINKS=.`.
- [jaraco.packaging#11 (comment)](https://github.com/jaraco/jaraco.packaging/pull/11#issuecomment-1627557237) — a per-library env var to bypass isolation, the wrong-layer patch that motivated fixing `build` itself.
- [#557 (comment)](https://github.com/pypa/build/issues/557#issuecomment-1367957108) / [clarification](https://github.com/pypa/build/issues/557#issuecomment-1367963519) — pass `--no-isolation -x`, accepting that `project_wheel_metadata` does no dependency check at all.
- [pytest-checkdocs#19 (comment)](https://github.com/jaraco/pytest-checkdocs/issues/19#issuecomment-1627556931) — a downstream consumer left broken by the per-project patch, showing why the fix belongs in `build`.


### Seen in the wild on GitHub

Packagers reading metadata or building without isolation pre-provide the build deps by hand:

- [openSUSE `python-jaraco.stream.spec` (L62-L64)](https://github.com/bmwiedemann/openSUSE/blob/b6b49ac3dc7e59c26e54a6e458aac232879ea35e/packages/p/python-jaraco.stream/python-jaraco.stream.spec#L62-L64) — `export BUILD_ENVIRONMENT=current` so the Sphinx metadata read uses the rpm `BuildRequires` instead of an isolated build.
- [Alpine aports `twine` APKBUILD (L48)](https://github.com/universalis-llc/aports/blob/178d1598f63c23f299986f0206889e447b91f252/community/twine/APKBUILD#L48) — `python3 -m build --no-isolation --skip-dependency-check`, with `py3-setuptools_scm` hand-added to `makedepends` (L24-L27).
- [MacPorts `apache-arrow` Portfile (L353)](https://github.com/macports/macports-ports/blob/524d5d3db70ca75e9747cbf19623e8a23f722301/devel/apache-arrow/Portfile#L353) — `-m build --no-isolation` paired with a manually listed `setuptools_scm` build dep (L250).
- [tqcli packaging runbook (L444)](https://github.com/tqcli/tqcli/blob/594eb1903605a451c24b56410fdf2c764792ef31/docs/prompts/ship_turboquant_wheels.md#L444) — writes down that under `--no-isolation` the venv must contain every `[build-system].requires` entry, after a silent failure from the missing ones.