### PR TITLE
✨ feat(cli): add --sdist-extract-dir to reuse compiler caches

### DIFF
--- a/docs/changelog/614.feature.rst
+++ b/docs/changelog/614.feature.rst
@@ -1,0 +1,5 @@
+Add ``--sdist-extract-dir PATH`` to extract the intermediate sdist into a chosen, persistent directory instead of a
+random temporary one. Reuse the same path across rebuilds and compiler caches such as ``ccache`` and ``sccache`` see a
+stable source path, so unchanged C/C++ files hit the cache. Build creates the directory if missing, clears its stale
+contents before each extraction, and keeps it after the build. The flag covers the default via-sdist build and building
+a wheel from a ``.tar.gz`` - by :user:`gaborbernat`.

--- a/docs/explanation/how-it-works.rst
+++ b/docs/explanation/how-it-works.rst
@@ -99,6 +99,11 @@ By default, ``python -m build`` creates both sdist and wheel following this stra
 This "build wheel from sdist" strategy ensures your sdist is complete. If files are missing from the sdist, the wheel
 build will fail, alerting you to the problem.
 
+Step 2 defaults to a random temporary directory that build removes after the run. Build randomises the path on purpose:
+it surfaces backends that hard-code absolute paths and keeps successive builds independent. That same randomness defeats
+compiler caches keyed on the source path, so ``--sdist-extract-dir`` lets you opt into a stable, persistent location
+when cache hits matter more than isolation.
+
 If the positional argument is a ``.tar.gz`` rather than a directory, the default is **wheel-only**: build checks the
 archive, extracts it into a temporary directory, and runs the wheel build against the extracted source. There is no
 sdist step. The archive already is an sdist, and PEP 517 has no hook for turning one sdist into another, so ``--sdist``

--- a/docs/how-to/basic-usage.rst
+++ b/docs/how-to/basic-usage.rst
@@ -108,6 +108,28 @@ Or the short form:
 
     $ python -m build -o /path/to/output
 
+*******************************************
+ Speeding up rebuilds of compiled packages
+*******************************************
+
+When the default build extracts the intermediate sdist, it uses a random temporary directory. Compiler caches such as
+`ccache <https://ccache.dev/>`_ and `sccache <https://github.com/mozilla/sccache>`_ fold the absolute source path into
+their cache key, so a fresh path on every run means every C/C++ file is recompiled from scratch.
+
+Pin the extraction path with ``--sdist-extract-dir`` so the cache can recognise unchanged files across rebuilds:
+
+.. code-block:: console
+
+    $ python -m build --sdist-extract-dir build/sdist
+
+Build creates the directory if missing, clears and repopulates it each run so the contents stay fresh, and keeps it
+after the build. The path stays stable while the project version is unchanged, as it is during iteration on the
+extension sources. The same flag applies when building a wheel from a ``.tar.gz``.
+
+Build still runs in a fresh isolated environment whose path is *not* pinned, so include directories from that
+environment (Python headers, dependency headers) keep changing. Caching those compile units needs toolchain-side path
+remapping on top of this flag (e.g. ``-fdebug-prefix-map``, or sccache's ``base_dir``).
+
 ***********************
  Controlling verbosity
 ***********************

--- a/docs/reference/environment-variables.rst
+++ b/docs/reference/environment-variables.rst
@@ -246,9 +246,12 @@ build.
 **Common use cases**:
 
 - **Debugging**: Keep temp directory to inspect build logs
-- **ccache**: Place builds on a filesystem where ccache can cache compilation
 - **Disk space**: Use a different filesystem with more available space
 - **Performance**: Use faster storage (e.g., tmpfs on Linux)
+
+``TMPDIR`` only relocates the base directory; build still appends a random suffix, so the extraction path differs on
+every run. For compiler caches such as ``ccache`` or ``sccache``, which key on the source path, that random suffix is a
+guaranteed cache miss - use ``--sdist-extract-dir`` to pin the path instead.
 
 See :doc:`../how-to/troubleshooting` for debugging examples.
 

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -163,7 +163,9 @@ against its contents, which catches missing files in the sdist:
     $ python -m build dist/mypackage-0.1.0.tar.gz
     Successfully built mypackage-0.1.0-py3-none-any.whl
 
-The wheel lands next to the sdist. Pass ``--outdir`` to write somewhere else.
+The wheel lands next to the sdist. Pass ``--outdir`` to write somewhere else. If your package compiles C/C++ and you
+rebuild often, ``--sdist-extract-dir`` keeps the extracted sources at a fixed path so ``ccache``/``sccache`` can reuse
+earlier compilations; see :doc:`../how-to/basic-usage`.
 
 ****************************
  Building without isolation

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -87,6 +87,7 @@ if TYPE_CHECKING:
         no_isolation: bool
         dependency_constraints_txt: str | None
         skip_dependency_check: bool
+        sdist_extract_dir: str | None
 
 
 _COLORS = {
@@ -331,6 +332,7 @@ def build_package_via_sdist(
     skip_dependency_check: bool = False,
     dependency_constraints_txt: os.PathLike[str] | None = None,
     installer: _env.Installer = 'pip',
+    sdist_extract_dir: StrPath | None = None,
 ) -> list[str]:
     """
     Build a sdist and then the specified distributions from it.
@@ -341,6 +343,8 @@ def build_package_via_sdist(
     :param config_settings: Configuration settings to be passed to the backend
     :param isolation: Isolate the build in a separate environment
     :param skip_dependency_check: Do not perform the dependency check
+    :param sdist_extract_dir: Directory to extract the intermediate sdist into; a temporary directory is used and
+        removed afterwards when ``None``
     """
     if 'sdist' in distributions:
         msg = 'Only binary distributions are allowed but sdist was specified'
@@ -353,7 +357,7 @@ def build_package_via_sdist(
     sdist_name = os.path.basename(sdist)
     built: list[str] = []
     if distributions:
-        with _extract_sdist(sdist, sdist_name.removesuffix('.tar.gz')) as extracted_srcdir:
+        with _extract_sdist(sdist, sdist_name.removesuffix('.tar.gz'), extract_dir=sdist_extract_dir) as extracted_srcdir:
             _ctx.log(f'Building {_natural_language_list(distributions)} from sdist', kind=('step',))
             for distribution in distributions:
                 out = _build(
@@ -510,6 +514,13 @@ def main_parser() -> argparse.ArgumentParser:
         metavar='PATH',
     )
     build_group.add_argument(
+        '--sdist-extract-dir',
+        help='extract the intermediate sdist to PATH (created if missing and kept afterwards) instead of a random '
+        'temporary directory; reusing it across rebuilds gives compiler caches such as ccache/sccache a stable '
+        'source path. Only affects the default (via-sdist) build and building a wheel from an sdist',
+        metavar='PATH',
+    )
+    build_group.add_argument(
         '--sdist',
         '-s',
         dest='distributions',
@@ -629,7 +640,7 @@ def main(cli_args: Sequence[str], prog: str | None = None) -> None:
     with _handle_build_error():
         if sdist_input:
             top_level = _validate_sdist_archive(args.srcdir)
-            with _extract_sdist(args.srcdir, top_level) as extracted_srcdir:
+            with _extract_sdist(args.srcdir, top_level, extract_dir=args.sdist_extract_dir) as extracted_srcdir:
                 built = build(extracted_srcdir, outdir)
         else:
             built = build(args.srcdir, outdir)
@@ -669,7 +680,7 @@ def _select_build(parser: argparse.ArgumentParser, args: _Args, *, sdist_input: 
         return partial(build_package, distributions=distributions)
     if args.distributions:
         return partial(build_package, distributions=args.distributions)
-    return partial(build_package_via_sdist, distributions=['wheel'])
+    return partial(build_package_via_sdist, distributions=['wheel'], sdist_extract_dir=args.sdist_extract_dir)
 
 
 def _validate_sdist_archive(archive: StrPath) -> str:
@@ -705,14 +716,23 @@ def _validate_sdist_archive(archive: StrPath) -> str:
 
 
 @contextlib.contextmanager
-def _extract_sdist(archive: StrPath, top_level: str) -> Iterator[str]:
-    extract_dir = tempfile.mkdtemp(prefix='build-via-sdist-')
-    try:
+def _extract_sdist(archive: StrPath, top_level: str, *, extract_dir: StrPath | None = None) -> Iterator[str]:
+    if extract_dir is None:
+        tmp_dir = tempfile.mkdtemp(prefix='build-via-sdist-')
+        try:
+            with TarFile.open(archive) as tar:
+                safe_extractall(tar, tmp_dir)
+            yield os.path.join(tmp_dir, top_level)
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+    else:
+        root = os.fspath(extract_dir)
+        os.makedirs(root, exist_ok=True)
+        target = os.path.join(root, top_level)
+        shutil.rmtree(target, ignore_errors=True)
         with TarFile.open(archive) as tar:
-            safe_extractall(tar, extract_dir)
-        yield os.path.join(extract_dir, top_level)
-    finally:
-        shutil.rmtree(extract_dir, ignore_errors=True)
+            safe_extractall(tar, root)
+        yield target
 
 
 def entrypoint() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -156,7 +156,7 @@ def test_parse_args(
     if hook == 'build_package':
         build_package.assert_called_with(*build_args, **build_kwargs)
     elif hook == 'build_package_via_sdist':
-        build_package_via_sdist.assert_called_with(*build_args, **build_kwargs)
+        build_package_via_sdist.assert_called_with(*build_args, **build_kwargs, sdist_extract_dir=None)
     else:  # pragma: no cover
         msg = f'Unknown hook {hook}'
         raise ValueError(msg)
@@ -949,6 +949,60 @@ def test_extract_sdist_rejects_absolute_symlink(tmp_path: pathlib.Path) -> None:
     cm = build.__main__._extract_sdist(str(archive), 'demo-1.0.0')
     with pytest.raises(tarfile.TarError):
         cm.__enter__()
+
+
+def test_extract_sdist_fixed_dir_is_deterministic_and_kept(sdist: pathlib.Path, tmp_path: pathlib.Path) -> None:
+    extract_dir = tmp_path / 'extract'
+    with build.__main__._extract_sdist(str(sdist), 'demo-1.0.0', extract_dir=str(extract_dir)) as extracted:
+        assert extracted == str(extract_dir / 'demo-1.0.0')
+        assert os.path.isfile(os.path.join(extracted, 'PKG-INFO'))
+    assert (extract_dir / 'demo-1.0.0' / 'PKG-INFO').is_file()
+
+
+def test_extract_sdist_fixed_dir_clears_stale_before_extract(sdist: pathlib.Path, tmp_path: pathlib.Path) -> None:
+    extract_dir = tmp_path / 'extract'
+    stale = extract_dir / 'demo-1.0.0' / 'stale.txt'
+    stale.parent.mkdir(parents=True)
+    stale.write_text('old', encoding='utf-8')
+
+    with build.__main__._extract_sdist(str(sdist), 'demo-1.0.0', extract_dir=str(extract_dir)) as extracted:
+        assert extracted == str(extract_dir / 'demo-1.0.0')
+        assert not stale.exists()
+        assert os.path.isfile(os.path.join(extracted, 'PKG-INFO'))
+
+
+@pytest.mark.parametrize(
+    ('extra_args', 'expected'),
+    [
+        pytest.param([], None, id='default-temp-dir'),
+        pytest.param(['--sdist-extract-dir', 'extract-here'], 'extract-here', id='fixed-dir'),
+    ],
+)
+def test_main_via_sdist_forwards_extract_dir(
+    tmp_path: pathlib.Path,
+    mocker: pytest_mock.MockerFixture,
+    extra_args: list[str],
+    expected: str | None,
+) -> None:
+    via_sdist = mocker.patch('build.__main__.build_package_via_sdist', autospec=True, return_value=['something'])
+
+    build.__main__.main([str(tmp_path), *extra_args])
+
+    assert via_sdist.call_args.kwargs['sdist_extract_dir'] == expected
+
+
+def test_main_sdist_input_forwards_extract_dir(
+    sdist: pathlib.Path,
+    tmp_path: pathlib.Path,
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    extract = mocker.patch('build.__main__._extract_sdist', autospec=True)
+    extract.return_value.__enter__.return_value = str(tmp_path / 'demo-1.0.0')
+    mocker.patch('build.__main__.build_package', return_value=['demo-1.0.0-py3-none-any.whl'])
+
+    build.__main__.main([str(sdist), '--wheel', '-o', str(tmp_path), '--sdist-extract-dir', 'extract-here'])
+
+    assert extract.call_args.kwargs['extract_dir'] == 'extract-here'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Teams shipping packages with large C/C++ extensions wait minutes on every rebuild, even when they only touched one file. The default build produces an sdist, extracts it to a random temporary directory, and builds the wheel from there. Compiler caches like `ccache` and `sccache` decide what to reuse from the absolute path of each source file, so a new random path on every run looks like brand-new code and nothing is reused. Closes #614.

Right now the only way out is to drop the convenient one-shot build and run the steps by hand: build the sdist, untar it into a fixed folder, then point a wheel build at that folder, repeating it after every code change. People also reach for `TMPDIR`, but that only moves the parent folder and still adds a random suffix, so the cache keeps missing.

This adds `--sdist-extract-dir`, which lets you choose a stable folder for that intermediate sdist. 🚀 Reuse the same folder across rebuilds and the cache recognizes unchanged files, so only what you actually edited gets recompiled. The familiar `python -m build` workflow stays intact.

The random temporary directory remains the default on purpose, so everyday builds stay isolated and still catch backends that hard-code paths. The new behavior is opt-in: name a folder and build refreshes its contents on each run and keeps it for the next one. The flag also applies when building a wheel straight from a `.tar.gz`.

One thing to set expectations: the isolated build environment still lives at a random path, so packages whose compile lines embed environment include paths (Python or dependency headers) need toolchain-side path remapping on top of this to get full cache hits. Pinning that environment is tracked separately in #655.

## Workarounds people use today

These are the stopgaps people reach for in the issue thread and across the toolchain until this lands:

- [#614 (comment)](https://github.com/pypa/build/issues/614#issuecomment-1542388823) — run the steps by hand: `build -s`, untar into a fixed folder, then `build -w` against it, repeated after every edit.
- [#614 (comment)](https://github.com/pypa/build/issues/614#issuecomment-1542406647) — the requester spells out that all they need is a *deterministic* extraction path so the cache key stays stable.
- [#614 (comment)](https://github.com/pypa/build/issues/614#issuecomment-1542455745) — a maintainer's alternative: derive a predictable `$TMPDIR/...` location instead of a random one.
- [ccache `base_dir` / `CCACHE_BASEDIR`](https://ccache.dev/manual/latest.html#config_base_dir) and the [ccache discussion on same-checkout-different-location misses](https://github.com/ccache/ccache/discussions/1370) — rewrite absolute paths before hashing so a moving directory still hits.
- [sccache `SCCACHE_BASEDIR`](https://github.com/mozilla/sccache/blob/main/docs/Configuration.md) — the sccache equivalent for normalizing build paths.


### Seen in the wild on GitHub

Projects building C/C++ extensions with `python -m build` already script the pin-the-path dance by hand:

- [Arch `python-zstandard` PKGBUILD (L25-L63)](https://github.com/nisavid/arch-strix-halo-pkgs/blob/ab1fff54105f811ca00fc053a2a7b4236600bcf1/packages/python-zstandard-gfx1151/PKGBUILD#L25-L63) — extract the sdist into a fixed `$srcdir`, `export CCACHE_BASEDIR="$srcdir"`, then `python -m build --wheel --no-isolation`.
- [PEP-Repository CI `.gitlab-ci.yml` (L376)](https://github.com/PEP-Repository/core/blob/d8aa9eed4da12031337f3e7435c3b48027d20326/.gitlab-ci.yml#L376) — `export CCACHE_BASEDIR="$PWD"` before `pipx run build --wheel` (L825) so ccache hits survive build's path handling.
