### PR TITLE
✨ feat(cli): surface debug paths when a backend build fails

### DIFF
--- a/docs/changelog/966.feature.rst
+++ b/docs/changelog/966.feature.rst
@@ -1,0 +1,4 @@
+When a build backend fails, build now prints a tip pointing at ``--env-dir`` and ``--sdist-extract-dir`` (to keep the
+build environment and extracted sources for inspection) and links to a new "Debug a failed build" how-to that explains
+how to stream backend output and where backends such as meson-python write their own logs. When those locations are
+already pinned, the tip reports where they were kept - reported by :user:`dimpase`, implemented by :user:`gaborbernat`.

--- a/docs/explanation/how-it-works.rst
+++ b/docs/explanation/how-it-works.rst
@@ -71,6 +71,11 @@ The process in detail:
 
    These hooks are defined in :PEP:`517` (the build system interface standard).
 
+   build runs each hook in a subprocess and forwards its standard output and error straight through, so a failing
+   backend's messages reach your terminal (use ``-vv`` to keep the full stream). build cannot collect log *files* the
+   backend writes inside its own working directory: :PEP:`517` exposes no way for a frontend to learn where those live,
+   so retrieving them depends on backend-specific settings. See :ref:`debug-a-failed-build` for how to keep them.
+
 4. **Build artifacts**
 
    The backend creates `distribution files

--- a/docs/explanation/how-it-works.rst
+++ b/docs/explanation/how-it-works.rst
@@ -72,9 +72,10 @@ The process in detail:
    These hooks are defined in :PEP:`517` (the build system interface standard).
 
    build runs each hook in a subprocess and forwards its standard output and error straight through, so a failing
-   backend's messages reach your terminal (use ``-vv`` to keep the full stream). build cannot collect log *files* the
-   backend writes inside its own working directory: :PEP:`517` exposes no way for a frontend to learn where those live,
-   so retrieving them depends on backend-specific settings. See :ref:`debug-a-failed-build` for how to keep them.
+   backend's messages reach your terminal regardless of verbosity (``-vv`` adds build's own diagnostics on top). build
+   cannot collect log *files* the backend writes inside its own working directory: :PEP:`517` exposes no way for a
+   frontend to learn where those live, so retrieving them depends on backend-specific settings. See
+   :ref:`debug-a-failed-build` for how to keep them.
 
 4. **Build artifacts**
 

--- a/docs/how-to/troubleshooting.rst
+++ b/docs/how-to/troubleshooting.rst
@@ -463,13 +463,12 @@ build removes that location after a successful build and keeps it after a failur
 environment in ``.build-env`` for you to examine. Setting ``TMPDIR`` (or ``TEMP`` on Windows) only moves the temporary
 directory; it does not keep the environment around.
 
-To see backend logs in real-time, use verbose output:
+build forwards the backend's output to your terminal as it happens, so compilation logs and error messages are already
+visible. Raise the verbosity to add build's own diagnostics and stream the environment setup live:
 
 .. code-block:: console
 
     $ python -m build -vv
-
-This shows all output from the build backend, including compilation logs for C extensions and detailed error messages.
 
 .. _debug-a-failed-build:
 
@@ -483,8 +482,10 @@ need.
 Stream the backend output
 =========================
 
-build forwards everything the backend writes to its standard output and error. Raise the verbosity to keep the full
-stream, including compiler invocations and backend tracebacks:
+build forwards everything the backend writes to standard output and error straight to your terminal, so compiler
+invocations and backend tracebacks already appear without any extra flag. Raise the verbosity to add build's own
+diagnostics and to stream the environment setup (installing the backend and its dependencies) live instead of only on
+failure:
 
 .. code-block:: console
 
@@ -507,15 +508,15 @@ Find the backend's own logs
 ===========================
 
 build cannot capture log *files* the backend writes inside its own working directory, because PEP 517 gives the frontend
-no way to discover them. Each backend exposes its own setting for keeping them. For ``meson-python``, point its build
-directory at a path you control:
+no way to discover them. Each backend exposes its own setting for keeping them. For ``meson-python`` and
+``scikit-build``, point its build directory at a path you control:
 
 .. code-block:: console
 
-    $ python -m build -C builddir=.meson-build
+    $ python -m build -C build-dir=.meson-build
 
-The meson log then survives at ``.meson-build/meson-logs/meson-log.txt``. Check your backend's documentation for the
-equivalent setting.
+The backend then writes its build tree and logs under ``.meson-build`` (meson-python leaves its log at
+``.meson-build/meson-logs/meson-log.txt``). Check your backend's documentation for the equivalent setting.
 
 **********************
  Still having issues?

--- a/docs/how-to/troubleshooting.rst
+++ b/docs/how-to/troubleshooting.rst
@@ -471,6 +471,52 @@ To see backend logs in real-time, use verbose output:
 
 This shows all output from the build backend, including compilation logs for C extensions and detailed error messages.
 
+.. _debug-a-failed-build:
+
+**********************
+ Debug a failed build
+**********************
+
+When a backend fails, build prints a ``TIP`` line that links back here. Work through these steps to gather what you
+need.
+
+Stream the backend output
+=========================
+
+build forwards everything the backend writes to its standard output and error. Raise the verbosity to keep the full
+stream, including compiler invocations and backend tracebacks:
+
+.. code-block:: console
+
+    $ python -m build -vv
+
+Keep the build environment and sources
+======================================
+
+A failed build deletes its temporary working directories before you can look at them. Pin both so they survive the run:
+
+.. code-block:: console
+
+    $ python -m build --env-dir .build-env --sdist-extract-dir .build-src
+
+``--env-dir`` keeps the isolated environment (the installed backend and its dependencies) on failure; see `Inspect the
+build environment`_. ``--sdist-extract-dir`` keeps the extracted sdist, which is the directory the backend actually runs
+in, so any files the backend leaves next to your sources stay put.
+
+Find the backend's own logs
+===========================
+
+build cannot capture log *files* the backend writes inside its own working directory, because PEP 517 gives the frontend
+no way to discover them. Each backend exposes its own setting for keeping them. For ``meson-python``, point its build
+directory at a path you control:
+
+.. code-block:: console
+
+    $ python -m build -C builddir=.meson-build
+
+The meson log then survives at ``.meson-build/meson-logs/meson-log.txt``. Check your backend's documentation for the
+equivalent setting.
+
 **********************
  Still having issues?
 **********************

--- a/docs/how-to/troubleshooting.rst
+++ b/docs/how-to/troubleshooting.rst
@@ -513,10 +513,9 @@ no way to discover them. Each backend exposes its own setting for keeping them. 
 
 .. code-block:: console
 
-    $ python -m build -C build-dir=.meson-build
+    $ python -m build -C build-dir=_build
 
-The backend then writes its build tree and logs under ``.meson-build`` (meson-python leaves its log at
-``.meson-build/meson-logs/meson-log.txt``). Check your backend's documentation for the equivalent setting.
+The backend then usually writes its build tree and logs under ``_build``. Check your backend's documentation for the equivalent setting.
 
 **********************
  Still having issues?

--- a/docs/how-to/troubleshooting.rst
+++ b/docs/how-to/troubleshooting.rst
@@ -515,7 +515,8 @@ no way to discover them. Each backend exposes its own setting for keeping them. 
 
     $ python -m build -C build-dir=_build
 
-The backend then usually writes its build tree and logs under ``_build``. Check your backend's documentation for the equivalent setting.
+The backend then usually writes its build tree and logs under ``_build``. Check your backend's documentation for the
+equivalent setting.
 
 **********************
  Still having issues?

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -36,6 +36,9 @@ be empty. build removes it after a successful build and keeps it after a failure
 helps compilation caches like ccache and sccache, which treat a changed build-environment path as a new file and miss
 the cache. You cannot combine ``--env-dir`` with ``--no-isolation``.
 
+When a build fails, ``--env-dir`` and ``--sdist-extract-dir`` keep the environment and the extracted sources for
+inspection; see :ref:`debug-a-failed-build`.
+
 ******************
  Dependency Check
 ******************

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -214,3 +214,4 @@ instead of parsing the output:
 - Learn about :doc:`../how-to/basic-usage` for common build workflows
 - Understand :doc:`../explanation/how-it-works` for details on the build process
 - See :doc:`../how-to/config-settings` to customize your build
+- When a build fails, follow :ref:`debug-a-failed-build` to capture backend logs and keep the working directories

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -275,14 +275,16 @@ def _build(
 
 
 @contextlib.contextmanager
-def _handle_build_error() -> Iterator[None]:
+def _handle_build_error(*, env_dir: str | None, sdist_extract_dir: StrPath | None) -> Iterator[None]:
     try:
         yield
     except (BuildException, FailedProcessError) as e:
         _error(str(e))
     except BuildBackendException as e:
+        hint = _build_failure_hint(env_dir, sdist_extract_dir)
         if isinstance(e.exception, subprocess.CalledProcessError):
             _cprint()
+            _cprint('{yellow}TIP{reset} {}', hint, file=sys.stderr)
             _error(str(e))
 
         if e.exc_info[0] is not None:
@@ -291,11 +293,26 @@ def _handle_build_error() -> Iterator[None]:
         else:  # pragma: no cover
             tb = traceback.format_exc(limit=-1)
         _cprint('\n{dim}{}{reset}\n', tb.strip('\n'))
+        _cprint('{yellow}TIP{reset} {}', hint, file=sys.stderr)
         _error(str(e))
     except Exception as e:  # pragma: no cover
         tb = traceback.format_exc().strip('\n')
         _cprint('\n{dim}{}{reset}\n', tb)
         _error(str(e))
+
+
+def _build_failure_hint(env_dir: str | None, sdist_extract_dir: StrPath | None) -> str:
+    kept = [
+        f'{label} at {os.fspath(path)}'
+        for path, label in ((env_dir, 'the build environment'), (sdist_extract_dir, 'the extracted sources'))
+        if path is not None
+    ]
+    if kept:
+        action = f'inspect {" and ".join(kept)}'
+    else:
+        action = 'pass --env-dir and --sdist-extract-dir to keep the build environment and sources'
+    docs = 'https://build.pypa.io/en/stable/how-to/troubleshooting.html#debug-a-failed-build'
+    return f'{action}, then see {docs} for help debugging a failed build'
 
 
 def _natural_language_list(elements: Sequence[str]) -> str:
@@ -719,7 +736,7 @@ def main(cli_args: Sequence[str], prog: str | None = None) -> None:
     else:
         outdir = os.path.join(args.srcdir, 'dist')
 
-    with _handle_build_error():
+    with _handle_build_error(env_dir=args.env_dir, sdist_extract_dir=args.sdist_extract_dir):
         if sdist_input:
             top_level = _validate_sdist_archive(args.srcdir)
             with _extract_sdist(args.srcdir, top_level, extract_dir=args.sdist_extract_dir) as extracted_srcdir:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -786,8 +786,40 @@ def test_handle_build_error_build_backend_exception(mocker: pytest_mock.MockerFi
     except ValueError:
         exc_info = sys.exc_info()
 
-    with pytest.raises(SystemExit), build.__main__._handle_build_error():
+    with pytest.raises(SystemExit), build.__main__._handle_build_error(env_dir=None, sdist_extract_dir=None):
         raise build.BuildBackendException(exc, exc_info=exc_info)
+
+
+def test_handle_build_error_prints_debug_tip_on_subprocess_failure(
+    mocker: pytest_mock.MockerFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mocker.patch('build.__main__._error', side_effect=SystemExit(1))
+
+    exc = subprocess.CalledProcessError(1, ['backend'])
+    with pytest.raises(SystemExit), build.__main__._handle_build_error(env_dir=None, sdist_extract_dir=None):
+        raise build.BuildBackendException(exc, 'Backend subprocess exited')
+
+    err = ANSI_STRIP.sub('', capsys.readouterr().err)
+    assert 'TIP' in err
+    assert 'pass --env-dir and --sdist-extract-dir' in err
+    assert 'troubleshooting.html#debug-a-failed-build' in err
+
+
+@pytest.mark.parametrize(
+    ('env_dir', 'sdist_extract_dir', 'expected'),
+    [
+        pytest.param(None, None, 'pass --env-dir and --sdist-extract-dir to keep', id='none-pinned'),
+        pytest.param('env', None, 'inspect the build environment at env', id='env-only'),
+        pytest.param(None, 'src', 'inspect the extracted sources at src', id='sdist-only'),
+        pytest.param('env', 'src', 'inspect the build environment at env and the extracted sources at src', id='both'),
+    ],
+)
+def test_build_failure_hint(env_dir: str | None, sdist_extract_dir: str | None, expected: str) -> None:
+    hint = build.__main__._build_failure_hint(env_dir, sdist_extract_dir)
+
+    assert expected in hint
+    assert hint.endswith('troubleshooting.html#debug-a-failed-build for help debugging a failed build')
 
 
 def test_log_unknown_kind(mocker: pytest_mock.MockerFixture) -> None:


### PR DESCRIPTION
A plain `python -m build` that hits a backend failure deletes its temporary working directories before anyone can look inside them, so the first failure leaves nothing to debug from. This is what [#966](https://github.com/pypa/build/issues/966) ran into with meson-python: the error was visible but the meson log lived in a directory that was already gone. 🔍

On any backend failure build now prints a `TIP` line. When no working directory is pinned it tells you to re-run with `--env-dir` and `--sdist-extract-dir` so the environment and the extracted sources survive the next run; when they are already pinned it reports where they were kept. The line links to a new `Debug a failed build` how-to that walks through streaming backend output with `-vv`, keeping both working directories, and reaching the backend's own log files. That last part stays the backend's job: PEP 517 gives the frontend no way to discover where a backend writes its logs, so the guide shows the meson-python `builddir` setting as the worked example rather than pretending build can capture them. ✨

The behavior change is limited to the failure path, where build now emits one extra hint before exiting; successful builds are untouched.

Stacked on #1083 (`--env-dir`) and #1085 (`--sdist-extract-dir`) — the hint reuses both flags and should merge after them. Depends on #1083 and #1085.

Closes #966
