### PR TITLE
👷 ci: enforce lazy imports with flake8-lazy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,11 @@ repos:
       - id: ruff-check
         args: [--fix, --show-fixes]
       - id: ruff-format
+  - repo: https://github.com/henryiii/flake8-lazy
+    rev: 1e661c3087909adc5c1603b304848b02641facdc # frozen: v0.8.1
+    hooks:
+      - id: flake8-lazy
+        files: ^src/
   - repo: https://github.com/codespell-project/codespell
     rev: "2ccb47ff45ad361a21071a7eedda4c37e6ae8c5a" # frozen: v2.4.2
     hooks:

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 
 __lazy_modules__ = [
     'argparse',
+    'build._compat',
+    'build._compat.tarfile',
     'build._exceptions',
     'build.env',
     'functools',
     'json',
     'os',
+    'packaging',
     'packaging.utils',
     'packaging.version',
     'platform',

--- a/src/build/_compat/tarfile.py
+++ b/src/build/_compat/tarfile.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+
+__lazy_modules__ = [
+    'pathlib',
+]
+
 import sys
 import tarfile
 


### PR DESCRIPTION
build keeps its command-line startup fast by deferring heavy imports, and each module records which ones in a `__lazy_modules__` list. Nothing has been checking those lists, so they drifted out of sync with the actual imports. 🐌

This adds [`flake8-lazy`](https://github.com/henryiii/flake8-lazy) as a pre-commit hook so the lists are verified on every change. It runs only against `src/`, since deferred imports matter for the shipped package rather than the test suite. Bringing the current code back into compliance meant declaring the parent packages the hook now expects (`packaging`, `build._compat`) in `__main__` and giving the `tarfile` compat shim a `__lazy_modules__` entry for `pathlib`.

The lists are declarative, so there is no runtime behavior change; the value is catching a missing or stale declaration before it ships.