### PR TITLE
♻️ refactor(typing): ban explicit Any across src and tests

### DIFF
--- a/docs/changelog/1093.misc.rst
+++ b/docs/changelog/1093.misc.rst
@@ -1,0 +1,2 @@
+Tighten type annotations across ``src`` and ``tests`` to remove ``Any``, ``object``, and ``# type: ignore``, and enable
+``disallow_any_explicit`` so the type gate covers both - by :user:`gaborbernat`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,7 @@ files = ["src", "tests"]
 exclude = ["tests/packages"]
 python_version = "3.10"
 strict = true
+disallow_any_explicit = true
 enable_error_code = ["ignore-without-code", "truthy-bool", "redundant-expr"]
 warn_unreachable = true
 

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -45,7 +45,7 @@ import warnings
 from functools import partial
 from tarfile import TarError
 from tarfile import open as tar_open
-from typing import Any, NoReturn, TextIO
+from typing import NoReturn, TextIO, cast
 
 import pyproject_hooks
 
@@ -68,6 +68,25 @@ if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping, Sequence
 
     from build._types import ConfigSettings, Distribution, StrPath, SubprocessRunner
+
+    # A decoded JSON value, as produced by ``--config-json``. Uses the covariant ``Sequence``/``Mapping``
+    # so the ``str | list[str]`` settings from ``--config-setting`` are also assignable to it.
+    JSONValue = str | int | float | bool | None | Sequence['JSONValue'] | Mapping[str, 'JSONValue']
+
+    class _Args(argparse.Namespace):
+        """The arguments :func:`main_parser` produces, typed for the rest of the module."""
+
+        srcdir: str
+        verbosity: int
+        outdir: str | None
+        distributions: list[Distribution] | None
+        metadata: bool
+        config_settings: list[str] | None
+        config_json: str | None
+        installer: _env.Installer | None
+        no_isolation: bool
+        dependency_constraints_txt: str | None
+        skip_dependency_check: bool
 
 
 _COLORS = {
@@ -242,16 +261,11 @@ def _handle_build_error() -> Iterator[None]:
             _cprint()
             _error(str(e))
 
-        if e.exc_info:
-            tb_lines = traceback.format_exception(
-                e.exc_info[0],
-                e.exc_info[1],
-                e.exc_info[2],
-                limit=-1,
-            )
+        if e.exc_info[0] is not None:
+            tb_lines = traceback.format_exception(e.exc_info[0], e.exc_info[1], e.exc_info[2], limit=-1)
             tb = ''.join(tb_lines)
         else:  # pragma: no cover
-            tb = traceback.format_exc(-1)  # type: ignore[unreachable]
+            tb = traceback.format_exc(limit=-1)
         _cprint('\n{dim}{}{reset}\n', tb.strip('\n'))
         _error(str(e))
     except Exception as e:  # pragma: no cover
@@ -409,7 +423,7 @@ def main_parser() -> argparse.ArgumentParser:
             self,
             option_strings: Sequence[str],
             dest: str,
-            default: Any = None,
+            default: int | None = None,
             help: str | None = None,
         ) -> None:
             super().__init__(
@@ -423,8 +437,8 @@ def main_parser() -> argparse.ArgumentParser:
         def __call__(
             self,
             parser: argparse.ArgumentParser,  # noqa: ARG002
-            namespace: object,
-            values: str | Sequence[Any] | None,  # noqa: ARG002
+            namespace: argparse.Namespace,
+            values: str | Sequence[str] | None,  # noqa: ARG002
             option_string: str | None = None,  # noqa: ARG002
         ) -> None:
             setattr(namespace, self.dest, getattr(namespace, self.dest, 0) - 1)
@@ -564,18 +578,19 @@ def main_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _parse_config_settings(raw_config_settings: list[str]) -> dict[str, Any]:
-    config_settings = dict[str, Any]()
+def _parse_config_settings(raw_config_settings: list[str]) -> dict[str, str | list[str]]:
+    config_settings = dict[str, str | list[str]]()
 
     for arg in raw_config_settings:
         setting, _, value = arg.partition('=')
         if setting not in config_settings:
             config_settings[setting] = value
         else:
-            if not isinstance(config_settings[setting], list):
-                config_settings[setting] = [config_settings[setting]]
-
-            config_settings[setting].append(value)
+            existing = config_settings[setting]
+            if isinstance(existing, list):
+                existing.append(value)
+            else:
+                config_settings[setting] = [existing, value]
 
     return config_settings
 
@@ -590,7 +605,7 @@ def main(cli_args: Sequence[str], prog: str | None = None) -> None:
     parser = main_parser()
     if prog:
         parser.prog = prog
-    args = parser.parse_args(cli_args)
+    args = cast('_Args', parser.parse_args(cli_args))
 
     _setup_cli(verbosity=args.verbosity)
 
@@ -625,7 +640,7 @@ def main(cli_args: Sequence[str], prog: str | None = None) -> None:
             _cprint('{bold}{green}Successfully built {}{reset}', artifact_list)
 
 
-def _resolve_config_settings(args: argparse.Namespace) -> dict[str, Any]:
+def _resolve_config_settings(args: _Args) -> Mapping[str, JSONValue]:
     if args.config_json:
         try:
             config_settings = json.loads(args.config_json)
@@ -639,7 +654,7 @@ def _resolve_config_settings(args: argparse.Namespace) -> dict[str, Any]:
     return {}
 
 
-def _select_build(parser: argparse.ArgumentParser, args: argparse.Namespace, *, sdist_input: bool) -> partial[list[str]]:
+def _select_build(parser: argparse.ArgumentParser, args: _Args, *, sdist_input: bool) -> partial[list[str]]:
     if args.metadata and args.distributions:
         parser.error('--metadata: not allowed with --sdist or --wheel')
     if sdist_input and args.distributions and 'sdist' in args.distributions:
@@ -650,7 +665,8 @@ def _select_build(parser: argparse.ArgumentParser, args: argparse.Namespace, *, 
     if args.metadata:
         return partial(_build_metadata, distributions=['wheel'])
     if sdist_input:
-        return partial(build_package, distributions=args.distributions or ['wheel'])
+        distributions: list[Distribution] = args.distributions or ['wheel']
+        return partial(build_package, distributions=distributions)
     if args.distributions:
         return partial(build_package, distributions=args.distributions)
     return partial(build_package_via_sdist, distributions=['wheel'])

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -25,8 +25,6 @@ import sys
 import warnings
 import zipfile
 
-from typing import Any
-
 import pyproject_hooks
 
 from . import _ctx, env
@@ -43,23 +41,46 @@ from ._util import check_dependency, parse_wheel_filename
 TYPE_CHECKING = False
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Mapping, Sequence
+    import datetime
+
+    from collections.abc import Iterable, Iterator, Mapping, Sequence
+    from typing import TypedDict
 
     if sys.version_info < (3, 11):
-        from typing_extensions import Self
+        from typing_extensions import NotRequired, Self
     else:
-        from typing import Self
+        from typing import NotRequired, Self
 
     from ._types import ConfigSettings, Distribution, StrPath, SubprocessRunner
 
+    # A value as produced by ``tomllib`` when parsing ``pyproject.toml``. Uses the covariant
+    # ``Sequence``/``Mapping`` so concrete literals (e.g. ``dict[str, list[str]]``) are assignable.
+    TOMLValue = (
+        str
+        | int
+        | float
+        | bool
+        | datetime.datetime
+        | datetime.date
+        | datetime.time
+        | Sequence['TOMLValue']
+        | Mapping[str, 'TOMLValue']
+    )
 
-_DEFAULT_BACKEND = {
+    # The validated ``[build-system]`` table.
+    BuildSystemTable = TypedDict(
+        'BuildSystemTable',
+        {'requires': list[str], 'build-backend': str, 'backend-path': NotRequired[list[str]]},
+    )
+
+
+_DEFAULT_BACKEND: BuildSystemTable = {
     'build-backend': 'setuptools.build_meta:__legacy__',
     'requires': ['setuptools >= 40.8.0'],
 }
 
 
-def _find_typo(dictionary: Mapping[str, str], expected: str) -> None:
+def _find_typo(dictionary: Iterable[str], expected: str) -> None:
     for obj in dictionary:
         if difflib.SequenceMatcher(None, expected, obj).ratio() >= 0.8:
             warnings.warn(
@@ -80,7 +101,7 @@ def _validate_source_directory(source_dir: StrPath) -> None:
         raise BuildException(msg)
 
 
-def _read_pyproject_toml(path: StrPath) -> Mapping[str, Any]:
+def _read_pyproject_toml(path: StrPath) -> Mapping[str, TOMLValue]:
     try:
         with open(path, 'rb') as f:
             return tomllib.loads(f.read().decode())
@@ -94,51 +115,57 @@ def _read_pyproject_toml(path: StrPath) -> Mapping[str, Any]:
         raise BuildException(msg) from None
 
 
-def _parse_build_system_table(pyproject_toml: Mapping[str, Any]) -> Mapping[str, Any]:
+def _parse_build_system_table(pyproject_toml: Mapping[str, TOMLValue]) -> BuildSystemTable:
     # If pyproject.toml is missing (per PEP 517) or [build-system] is missing
     # (per PEP 518), use default values
     if 'build-system' not in pyproject_toml:
         _find_typo(pyproject_toml, 'build-system')
         return _DEFAULT_BACKEND
 
-    build_system_table = dict(pyproject_toml['build-system'])
+    build_system = pyproject_toml['build-system']
+    if not isinstance(build_system, dict):
+        msg = '`build-system` must be a table'
+        raise BuildSystemTableValidationError(msg)
 
     # If [build-system] is present, it must have a ``requires`` field (per PEP 518)
-    if 'requires' not in build_system_table:
-        _find_typo(build_system_table, 'requires')
+    if 'requires' not in build_system:
+        _find_typo(build_system, 'requires')
         msg = '`requires` is a required property'
         raise BuildSystemTableValidationError(msg)
-    if not isinstance(build_system_table['requires'], list) or not all(
-        isinstance(i, str) for i in build_system_table['requires']
-    ):
+    requires = build_system['requires']
+    if not isinstance(requires, list) or not all(isinstance(i, str) for i in requires):
         msg = '`requires` must be an array of strings'
         raise BuildSystemTableValidationError(msg)
 
-    match build_system_table:
-        case {'build-backend': str()}:
-            pass
-        case {'build-backend': _}:
+    table: BuildSystemTable = {
+        'requires': [requirement for requirement in requires if isinstance(requirement, str)],
+        'build-backend': _DEFAULT_BACKEND['build-backend'],
+    }
+
+    if 'build-backend' in build_system:
+        backend = build_system['build-backend']
+        if not isinstance(backend, str):
             msg = '`build-backend` must be a string'
             raise BuildSystemTableValidationError(msg)
-        case _:
-            _find_typo(build_system_table, 'build-backend')
-            # If ``build-backend`` is missing, inject the legacy setuptools backend
-            # but leave ``requires`` intact to emulate pip
-            build_system_table['build-backend'] = _DEFAULT_BACKEND['build-backend']
+        table['build-backend'] = backend
+    else:
+        # If ``build-backend`` is missing, inject the legacy setuptools backend
+        # but leave ``requires`` intact to emulate pip
+        _find_typo(build_system, 'build-backend')
 
-    match build_system_table:
-        case {'backend-path': list() as backend_path} if all(isinstance(i, str) for i in backend_path):
-            pass
-        case {'backend-path': _}:
+    if 'backend-path' in build_system:
+        backend_path = build_system['backend-path']
+        if not isinstance(backend_path, list) or not all(isinstance(i, str) for i in backend_path):
             msg = '`backend-path` must be an array of strings'
             raise BuildSystemTableValidationError(msg)
+        table['backend-path'] = [path for path in backend_path if isinstance(path, str)]
 
-    unknown_props = build_system_table.keys() - {'requires', 'build-backend', 'backend-path'}
+    unknown_props = build_system.keys() - {'requires', 'build-backend', 'backend-path'}
     if unknown_props:
         msg = f'Unknown properties: {", ".join(unknown_props)}'
         raise BuildSystemTableValidationError(msg)
 
-    return build_system_table
+    return table
 
 
 def _validate_backend_path(source_dir: str, backend_paths: Sequence[str]) -> None:
@@ -359,7 +386,7 @@ class ProjectBuilder:
         return os.path.join(output_directory, distinfo)
 
     def _call_backend(
-        self, hook_name: str, outdir: StrPath, config_settings: ConfigSettings | None = None, **kwargs: Any
+        self, hook_name: str, outdir: StrPath, config_settings: ConfigSettings | None = None, **kwargs: str | bool
     ) -> str:
         outdir = os.path.abspath(outdir)
 

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -142,23 +142,23 @@ def _parse_build_system_table(pyproject_toml: Mapping[str, TOMLValue]) -> BuildS
         'build-backend': _DEFAULT_BACKEND['build-backend'],
     }
 
-    if 'build-backend' in build_system:
-        backend = build_system['build-backend']
-        if not isinstance(backend, str):
+    match build_system:
+        case {'build-backend': str() as backend}:
+            table['build-backend'] = backend
+        case {'build-backend': _}:
             msg = '`build-backend` must be a string'
             raise BuildSystemTableValidationError(msg)
-        table['build-backend'] = backend
-    else:
-        # If ``build-backend`` is missing, inject the legacy setuptools backend
-        # but leave ``requires`` intact to emulate pip
-        _find_typo(build_system, 'build-backend')
+        case _:
+            # If ``build-backend`` is missing, inject the legacy setuptools backend
+            # but leave ``requires`` intact to emulate pip
+            _find_typo(build_system, 'build-backend')
 
-    if 'backend-path' in build_system:
-        backend_path = build_system['backend-path']
-        if not isinstance(backend_path, list) or not all(isinstance(i, str) for i in backend_path):
+    match build_system:
+        case {'backend-path': list() as backend_path} if all(isinstance(i, str) for i in backend_path):
+            table['backend-path'] = [path for path in backend_path if isinstance(path, str)]
+        case {'backend-path': _}:
             msg = '`backend-path` must be an array of strings'
             raise BuildSystemTableValidationError(msg)
-        table['backend-path'] = [path for path in backend_path if isinstance(path, str)]
 
     unknown_props = build_system.keys() - {'requires', 'build-backend', 'backend-path'}
     if unknown_props:

--- a/src/build/_ctx.py
+++ b/src/build/_ctx.py
@@ -83,11 +83,11 @@ def run_subprocess(cmd: Sequence[StrPath], cwd: str | None = None, env: Mapping[
 
 if TYPE_CHECKING:
     log: Logger
-    verbosity: bool
+    verbosity: int
 
 else:
 
-    def __getattr__(name: str) -> object:
+    def __getattr__(name: str) -> Logger | int:
         if name == 'log':
             return LOGGER.get()
         if name == 'verbosity':

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -71,7 +71,7 @@ class IsolatedEnv(typing.Protocol):
 
 
 def _has_dependency(
-    name: str, minimum_version_str: str | None = None, /, **distargs: object
+    name: str, minimum_version_str: str | None = None, /, **distargs: list[str]
 ) -> importlib_metadata.Distribution | None:
     """
     Given a distribution name, see if it is present and return the distribution

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,18 +12,21 @@ import stat
 import sys
 import sysconfig
 import tempfile
-import typing
 
 from collections.abc import Callable, Generator
 from functools import partial, update_wrapper
 from pathlib import Path
-from typing import Any
+from typing import Protocol
 
 import pytest
 
 import build.env
 
 from build._compat import tomllib
+
+
+class SubTests(Protocol):
+    def test(self, msg: str | None = ..., **kwargs: object) -> contextlib.AbstractContextManager[None]: ...
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -39,7 +42,7 @@ PYPY3_WIN_VENV_BAD = (
 PYPY3_WIN_M = 'https://foss.heptapod.net/pypy/pypy/-/issues/3323 and https://foss.heptapod.net/pypy/pypy/-/issues/3321'
 
 
-def pytest_collection_modifyitems(config: pytest.Config, items: list[typing.Any]) -> None:
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     skip_int = pytest.mark.skip(reason='integration tests not run (no --run-integration flag)')
     skip_other = pytest.mark.skip(reason='only integration tests are run (got --only-integration flag)')
 
@@ -56,10 +59,7 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[typing.Any]
         if (
             PYPY3_WIN_VENV_BAD
             and item.get_closest_marker('isolated')
-            and (
-                not (is_integration_file and item.originalname == 'test_build')
-                or (hasattr(item, 'callspec') and '--no-isolation' not in item.callspec.params.get('args', []))
-            )
+            and _xfail_isolated_strict(item, is_integration_file=is_integration_file)
         ):
             item.add_marker(pytest.mark.xfail(reason=PYPY3_WIN_M, strict=True))
         if is_integration_file:  # pragma: no cover
@@ -69,6 +69,15 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[typing.Any]
             item.add_marker(skip_other)
     # run integration tests after unit tests
     items.sort(key=lambda i: 1 if is_integration(i) else 0)
+
+
+def _xfail_isolated_strict(item: pytest.Item, *, is_integration_file: bool) -> bool:
+    if isinstance(item, pytest.Function) and hasattr(item, 'callspec'):
+        args = item.callspec.params.get('args', [])
+        if isinstance(args, (list, tuple)) and '--no-isolation' not in args:
+            return True
+    is_test_build = is_integration_file and isinstance(item, pytest.Function) and item.originalname == 'test_build'
+    return not is_test_build
 
 
 def is_integration(item: pytest.Item) -> bool:
@@ -135,7 +144,7 @@ def is_setuptools(package_path: Path) -> bool:
     return 'setuptools' in pp.get('build-system', {}).get('build-backend', 'setuptools')
 
 
-def generate_package_path_fixture(package_name: str) -> Callable[..., str]:
+def generate_package_path_fixture(package_name: str) -> Callable[[str, Path], str]:
     @pytest.fixture
     def fixture(packages_path: str, tmp_path: Path) -> str:
         package_path = Path(packages_path) / package_name
@@ -203,9 +212,9 @@ def pytest_report_header() -> str:
 
 
 @pytest.fixture
-def subtests(request: pytest.FixtureRequest) -> Any:
+def subtests(request: pytest.FixtureRequest) -> SubTests:
     try:
-        return request.getfixturevalue('subtests')
+        existing: SubTests = request.getfixturevalue('subtests')
     except pytest.FixtureLookupError:
 
         class Subtests:
@@ -215,3 +224,4 @@ def subtests(request: pytest.FixtureRequest) -> Any:
                 yield
 
         return Subtests()
+    return existing

--- a/tests/test_compat_tarfile.py
+++ b/tests/test_compat_tarfile.py
@@ -7,6 +7,7 @@ from io import BytesIO
 from pathlib import Path
 from tarfile import CHRTYPE, LNKTYPE, SYMTYPE, TarError, TarInfo
 from tarfile import open as tar_open
+from typing import Protocol
 
 import pytest
 
@@ -14,9 +15,12 @@ from build._compat.tarfile import _validate_safe_member, safe_extractall
 
 
 FileMember = Callable[[str, bytes], TarInfo]
-LinkMember = Callable[..., TarInfo]
 DeviceMember = Callable[[str], TarInfo]
 ArchiveBuilder = Callable[[Path, 'list[tuple[TarInfo, bytes | None]]'], None]
+
+
+class LinkMember(Protocol):
+    def __call__(self, name: str, linkname: str, *, hard: bool = ...) -> TarInfo: ...
 
 
 def test_safe_extractall_extracts_clean_archive(

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -22,6 +22,9 @@ from packaging.version import Version
 import build
 import build.env
 
+from build import _ctx
+from build._compat.importlib import metadata as importlib_metadata
+
 
 IS_PYPY = sys.implementation.name == 'pypy'
 IS_WINDOWS = sys.platform.startswith('win')
@@ -235,7 +238,7 @@ def test_default_impl_install_cmd_well_formed(
     constraints: list[str],
     fresh: bool,
 ) -> None:
-    mocker.patch.object(build.env._ctx, 'verbosity', verbosity)  # type: ignore[attr-defined]
+    mocker.patch.object(_ctx, 'verbosity', verbosity)
 
     with build.env.DefaultIsolatedEnv() as env:
         run_subprocess = mocker.patch('build.env.run_subprocess')
@@ -273,7 +276,7 @@ def test_uv_impl_install_cmd_well_formed(  # pragma: no cover -- uv tests are sk
     constraints: list[str],
     fresh: bool,
 ) -> None:
-    mocker.patch.object(build.env._ctx, 'verbosity', verbosity)  # type: ignore[attr-defined]
+    mocker.patch.object(_ctx, 'verbosity', verbosity)
 
     with build.env.DefaultIsolatedEnv(installer='uv') as env:
         run_subprocess = mocker.patch('build.env.run_subprocess')
@@ -504,7 +507,7 @@ def test_venv_creation_no_setuptools(
 ) -> None:
     original = build.env._has_dependency
 
-    def no_setuptools(name: str, min_ver: str | None = None, /, **kwargs: object) -> object:
+    def no_setuptools(name: str, min_ver: str | None = None, /, **kwargs: list[str]) -> importlib_metadata.Distribution | None:
         if name == 'setuptools':
             return None
         return original(name, min_ver, **kwargs)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -154,7 +154,7 @@ def test_isolation(tmp_dir: str, package_test_flit: str, mocker: pytest_mock.Moc
     if importlib.util.find_spec('flit_core'):
         pytest.xfail('flit_core is available -- we want it missing!')  # pragma: no cover
 
-    mocker.patch('build.__main__._error')
+    error = mocker.patch('build.__main__._error')
 
     build.__main__.main([package_test_flit, '-o', tmp_dir, '--no-isolation'])
-    build.__main__._error.assert_called_with("Backend 'flit_core.buildapi' is not available.")  # type: ignore[attr-defined]
+    error.assert_called_with("Backend 'flit_core.buildapi' is not available.")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,8 +14,8 @@ import tarfile
 import unittest.mock
 import venv
 
-from collections.abc import Callable
-from typing import Any, TypedDict
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from typing import TYPE_CHECKING, Protocol, TypedDict
 
 import pytest
 import pytest_mock
@@ -24,6 +24,14 @@ import build
 import build.__main__
 
 from build._compat import importlib as _importlib
+
+
+if TYPE_CHECKING:
+    from conftest import SubTests
+
+
+class CapturedRunner(Protocol):
+    def __call__(self, cmd: Sequence[str], cwd: str | None = ..., extra_environ: Mapping[str, str] | None = ...) -> None: ...
 
 
 pytestmark = pytest.mark.contextvars
@@ -652,7 +660,7 @@ ERROR Failed to create venv. Maybe try installing virtualenv.
 @pytest.mark.contextvars
 @pytest.mark.network
 def test_verbose_logging_output(
-    subtests: Any,
+    subtests: SubTests,
     capfd: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
     tmp_dir: str,
@@ -762,11 +770,11 @@ def test_build_metadata_runner_without_extra_environ(
     tmp_path: pathlib.Path,
     package_test_setuptools: str,
 ) -> None:
-    captured_runners: list[Any] = []
+    captured_runners: list[CapturedRunner] = []
 
     @contextlib.contextmanager
-    def fake_bootstrap(*_args: object, **kwargs: object) -> Any:
-        captured_runners.append(kwargs['runner'])
+    def fake_bootstrap(*_args: object, runner: CapturedRunner, **_kwargs: object) -> Iterator[unittest.mock.MagicMock]:
+        captured_runners.append(runner)
         builder = mocker.MagicMock()
         metadata_dir = tmp_path / 'metadata'
         metadata_dir.mkdir()
@@ -784,7 +792,10 @@ def test_build_metadata_runner_without_extra_environ(
     ctx_run.assert_called_once_with(['echo', 'test'], None, mocker.ANY)
 
 
-WriteSdist = Callable[..., None]
+class WriteSdist(Protocol):
+    def __call__(
+        self, path: pathlib.Path, top_level: str, *, with_pkg_info: bool = ..., extra: dict[str, str] | None = ...
+    ) -> None: ...
 
 
 @pytest.fixture

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -11,7 +11,7 @@ import textwrap
 import typing
 
 from collections.abc import Callable
-from typing import Any, NoReturn
+from typing import TYPE_CHECKING, NoReturn
 
 import pyproject_hooks
 import pytest
@@ -21,6 +21,12 @@ import build
 import build._builder
 
 from build._compat import importlib as _importlib
+
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from build._builder import BuildSystemTable, TOMLValue
 
 
 build_open_owner = 'builtins'
@@ -35,8 +41,8 @@ DEFAULT_BACKEND = {
 class MockDistribution(_importlib.metadata.Distribution):
     _metadata: str = ''
 
-    def locate_file(self, path: Any) -> Any:  # pragma: no cover  # noqa: ARG002
-        return ''
+    def locate_file(self, path: str | os.PathLike[str]) -> _importlib.metadata.SimplePath:  # pragma: no cover
+        raise NotImplementedError
 
     def read_text(self, filename: str) -> str:
         if filename == 'METADATA':
@@ -249,8 +255,8 @@ def _nothing_installed(name: str) -> NoReturn:
 def test_check_dependencies(
     mocker: pytest_mock.MockerFixture, package_test_flit: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    mocker.patch('pyproject_hooks.BuildBackendHookCaller.get_requires_for_build_sdist')
-    mocker.patch('pyproject_hooks.BuildBackendHookCaller.get_requires_for_build_wheel')
+    get_requires_sdist = mocker.patch('pyproject_hooks.BuildBackendHookCaller.get_requires_for_build_sdist')
+    get_requires_wheel = mocker.patch('pyproject_hooks.BuildBackendHookCaller.get_requires_for_build_wheel')
 
     monkeypatch.setattr(_importlib.metadata, 'distribution', _nothing_installed)
 
@@ -262,8 +268,8 @@ def test_check_dependencies(
         pyproject_hooks.BackendUnavailable,
     ]
 
-    builder._hook.get_requires_for_build_sdist.side_effect = copy.copy(side_effects)  # type: ignore[attr-defined]
-    builder._hook.get_requires_for_build_wheel.side_effect = copy.copy(side_effects)  # type: ignore[attr-defined]
+    get_requires_sdist.side_effect = copy.copy(side_effects)
+    get_requires_wheel.side_effect = copy.copy(side_effects)
 
     # requires = []
     assert builder.check_dependencies('sdist') == {('flit_core<4,>=2',)}
@@ -281,18 +287,18 @@ def test_check_dependencies(
 
 
 def test_build(mocker: pytest_mock.MockerFixture, package_test_flit: str, tmp_dir: str) -> None:
-    mocker.patch('pyproject_hooks.BuildBackendHookCaller', autospec=True)
+    hook = mocker.patch('pyproject_hooks.BuildBackendHookCaller', autospec=True).return_value
 
     builder = build.ProjectBuilder(package_test_flit)
 
-    builder._hook.build_sdist.side_effect = ['dist.tar.gz', Exception]  # type: ignore[attr-defined]
-    builder._hook.build_wheel.side_effect = ['dist.whl', Exception]  # type: ignore[attr-defined]
+    hook.build_sdist.side_effect = ['dist.tar.gz', Exception]
+    hook.build_wheel.side_effect = ['dist.whl', Exception]
 
     assert builder.build('sdist', tmp_dir) == os.path.join(tmp_dir, 'dist.tar.gz')
-    builder._hook.build_sdist.assert_called_with(tmp_dir, None)  # type: ignore[attr-defined]
+    hook.build_sdist.assert_called_with(tmp_dir, None)
 
     assert builder.build('wheel', tmp_dir) == os.path.join(tmp_dir, 'dist.whl')
-    builder._hook.build_wheel.assert_called_with(tmp_dir, None)  # type: ignore[attr-defined]
+    hook.build_wheel.assert_called_with(tmp_dir, None)
 
     with pytest.raises(build.BuildBackendException):
         builder.build('sdist', tmp_dir)
@@ -332,10 +338,10 @@ def test_build_system_typo(mocker: pytest_mock.MockerFixture, package_test_typo:
 
 
 def test_missing_outdir(mocker: pytest_mock.MockerFixture, tmp_dir: str, package_test_flit: str) -> None:
-    mocker.patch('pyproject_hooks.BuildBackendHookCaller', autospec=True)
+    hook = mocker.patch('pyproject_hooks.BuildBackendHookCaller', autospec=True).return_value
 
     builder = build.ProjectBuilder(package_test_flit)
-    builder._hook.build_sdist.return_value = 'dist.tar.gz'  # type: ignore[attr-defined]
+    hook.build_sdist.return_value = 'dist.tar.gz'
     out = os.path.join(tmp_dir, 'out')
 
     builder.build('sdist', out)
@@ -344,21 +350,21 @@ def test_missing_outdir(mocker: pytest_mock.MockerFixture, tmp_dir: str, package
 
 
 def test_relative_outdir(mocker: pytest_mock.MockerFixture, tmp_dir: str, package_test_flit: str) -> None:  # noqa: ARG001
-    mocker.patch('pyproject_hooks.BuildBackendHookCaller', autospec=True)
+    hook = mocker.patch('pyproject_hooks.BuildBackendHookCaller', autospec=True).return_value
 
     builder = build.ProjectBuilder(package_test_flit)
-    builder._hook.build_sdist.return_value = 'dist.tar.gz'  # type: ignore[attr-defined]
+    hook.build_sdist.return_value = 'dist.tar.gz'
 
     builder.build('sdist', '.')
 
-    builder._hook.build_sdist.assert_called_with(os.path.abspath('.'), None)  # type: ignore[attr-defined]
+    hook.build_sdist.assert_called_with(os.path.abspath('.'), None)
 
 
 def test_build_not_dir_outdir(mocker: pytest_mock.MockerFixture, tmp_dir: str, package_test_flit: str) -> None:
-    mocker.patch('pyproject_hooks.BuildBackendHookCaller', autospec=True)
+    hook = mocker.patch('pyproject_hooks.BuildBackendHookCaller', autospec=True).return_value
 
     builder = build.ProjectBuilder(package_test_flit)
-    builder._hook.build_sdist.return_value = 'dist.tar.gz'  # type: ignore[attr-defined]
+    hook.build_sdist.return_value = 'dist.tar.gz'
     out = os.path.join(tmp_dir, 'out')
 
     open(out, 'a', encoding='utf-8').close()  # create empty file
@@ -426,30 +432,30 @@ def test_build_with_dep_on_console_script(
 
 
 def test_prepare(mocker: pytest_mock.MockerFixture, tmp_dir: str, package_test_flit: str) -> None:
-    mocker.patch('pyproject_hooks.BuildBackendHookCaller', autospec=True)
+    hook = mocker.patch('pyproject_hooks.BuildBackendHookCaller', autospec=True).return_value
 
     builder = build.ProjectBuilder(package_test_flit)
-    builder._hook.prepare_metadata_for_build_wheel.return_value = 'dist-1.0.dist-info'  # type: ignore[attr-defined]
+    hook.prepare_metadata_for_build_wheel.return_value = 'dist-1.0.dist-info'
 
     assert builder.prepare('wheel', tmp_dir) == os.path.join(tmp_dir, 'dist-1.0.dist-info')
-    builder._hook.prepare_metadata_for_build_wheel.assert_called_with(tmp_dir, None, _allow_fallback=False)  # type: ignore[attr-defined]
+    hook.prepare_metadata_for_build_wheel.assert_called_with(tmp_dir, None, _allow_fallback=False)
 
 
 def test_prepare_no_hook(mocker: pytest_mock.MockerFixture, tmp_dir: str, package_test_flit: str) -> None:
-    mocker.patch('pyproject_hooks.BuildBackendHookCaller', autospec=True)
+    hook = mocker.patch('pyproject_hooks.BuildBackendHookCaller', autospec=True).return_value
 
     builder = build.ProjectBuilder(package_test_flit)
     failure = pyproject_hooks.HookMissing('prepare_metadata_for_build_wheel')
-    builder._hook.prepare_metadata_for_build_wheel.side_effect = failure  # type: ignore[attr-defined]
+    hook.prepare_metadata_for_build_wheel.side_effect = failure
 
     assert builder.prepare('wheel', tmp_dir) is None
 
 
 def test_prepare_error(mocker: pytest_mock.MockerFixture, tmp_dir: str, package_test_flit: str) -> None:
-    mocker.patch('pyproject_hooks.BuildBackendHookCaller', autospec=True)
+    hook = mocker.patch('pyproject_hooks.BuildBackendHookCaller', autospec=True).return_value
 
     builder = build.ProjectBuilder(package_test_flit)
-    builder._hook.prepare_metadata_for_build_wheel.side_effect = Exception  # type: ignore[attr-defined]
+    hook.prepare_metadata_for_build_wheel.side_effect = Exception
 
     with pytest.raises(build.BuildBackendException, match='Backend operation failed: Exception'):
         builder.prepare('wheel', tmp_dir)
@@ -490,11 +496,15 @@ def test_no_outdir_multiple(mocker: pytest_mock.MockerFixture, tmp_dir: str, pac
 
 
 def test_runner_user_specified(tmp_dir: str, package_test_flit: str) -> None:
-    def dummy_runner(cmd: typing.Sequence[str], cwd: str | None = None, extra_environ: dict[str, str] | None = None) -> None:  # noqa: ARG001
+    def dummy_runner(
+        cmd: typing.Sequence[str],  # noqa: ARG001
+        cwd: str | None = None,  # noqa: ARG001
+        extra_environ: typing.Mapping[str, str] | None = None,  # noqa: ARG001
+    ) -> None:
         msg = 'Runner was called'
         raise RuntimeError(msg)
 
-    builder = build.ProjectBuilder(package_test_flit, runner=dummy_runner)  # type: ignore[arg-type]
+    builder = build.ProjectBuilder(package_test_flit, runner=dummy_runner)
     with pytest.raises(build.BuildBackendException, match='Runner was called'):
         builder.build('wheel', tmp_dir)
 
@@ -581,13 +591,17 @@ def test_log(mocker: pytest_mock.MockerFixture, caplog: pytest.LogCaptureFixture
         ),
     ],
 )
-def test_parse_valid_build_system_table_type(pyproject_toml: dict[str, Any], parse_output: dict[str, Any]) -> None:
+def test_parse_valid_build_system_table_type(pyproject_toml: Mapping[str, TOMLValue], parse_output: BuildSystemTable) -> None:
     assert build._builder._parse_build_system_table(pyproject_toml) == parse_output
 
 
 @pytest.mark.parametrize(
     ('pyproject_toml', 'error_message'),
     [
+        (
+            {'build-system': 'not a table'},
+            '`build-system` must be a table',
+        ),
         (
             {'build-system': {}},
             '`requires` is a required property',
@@ -618,7 +632,7 @@ def test_parse_valid_build_system_table_type(pyproject_toml: dict[str, Any], par
         ),
     ],
 )
-def test_parse_invalid_build_system_table_type(pyproject_toml: dict[str, Any], error_message: str) -> None:
+def test_parse_invalid_build_system_table_type(pyproject_toml: Mapping[str, TOMLValue], error_message: str) -> None:
     with pytest.raises(build.BuildSystemTableValidationError, match=error_message):
         build._builder._parse_build_system_table(pyproject_toml)
 


### PR DESCRIPTION
`build` was already typed under mypy `strict`, yet `Any`, `object`, and `# type: ignore` still appeared wherever a precise type looked awkward to recover: the decoded `--config-json` payloads, the `build-system` table, the parsed CLI namespace, and a scattering of test mocks. 🎯 Each of those is a place where the checker silently stopped helping, so a wrong argument shape or a renamed mock attribute could pass review unnoticed.

The recursive data really is recursive, so it is modelled that way: `TOMLValue` and `JSONValue` are covariant `Sequence`/`Mapping` aliases, and the `build-system` table is a `TypedDict` with `NotRequired` for `backend-path`. The argument object that `argparse` produces gets a dedicated `Namespace` subclass, which turns every `args.*` read into a concrete type instead of an implicit `Any`. On the test side the heterogeneous callables — sdist writers, tar member factories, captured subprocess runners, and the optional `pytest-subtests` shim — become `Protocol` types, and mocked attributes are read from the typed patch handles rather than off the real module, which clears the last `# type: ignore` comments.

To keep this from regressing, `disallow_any_explicit` is enabled and mypy now runs over both `src` and `tests`. ✨ An accidental `Any` fails the type gate directly. This is internal-only: no public API, runtime behaviour, or CLI surface changes.