### PR TITLE
🐛 fix(cli): drain verbose subprocess output without a worker thread

### DIFF
--- a/docs/changelog/1098.bugfix.rst
+++ b/docs/changelog/1098.bugfix.rst
@@ -1,0 +1,1 @@
+Verbose subprocess logging no longer relies on a worker thread, and errors raised while logging are no longer silently discarded.

--- a/docs/changelog/1098.bugfix.rst
+++ b/docs/changelog/1098.bugfix.rst
@@ -1,1 +1,2 @@
-Verbose subprocess logging no longer relies on a worker thread, and errors raised while logging are no longer silently discarded.
+Verbose subprocess logging no longer relies on a worker thread, and errors raised while logging are no longer silently
+discarded.

--- a/src/build/_ctx.py
+++ b/src/build/_ctx.py
@@ -49,25 +49,16 @@ def run_subprocess(cmd: Sequence[StrPath], cwd: str | None = None, env: Mapping[
     verbosity = VERBOSITY.get()
 
     if verbosity > 0:
-        import concurrent.futures
-
         log = LOGGER.get()
 
-        with (
-            concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor,
-            subprocess.Popen(  # noqa: S603
-                cmd, cwd=cwd, encoding='utf-8', env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-            ) as process,
-        ):
+        with subprocess.Popen(  # noqa: S603
+            cmd, cwd=cwd, encoding='utf-8', env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        ) as process:
             log(subprocess.list2cmdline(cmd), kind=('subprocess', 'cmd'))
 
-            @executor.submit
-            def log_stream() -> None:
-                assert process.stdout
-                for line in process.stdout:
-                    log(line, kind=('subprocess', 'stdout'))
-
-            concurrent.futures.wait([log_stream])
+            assert process.stdout
+            for line in process.stdout:
+                log(line, kind=('subprocess', 'stdout'))
 
             code = process.wait()
             if code:  # pragma: no cover


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Remove the unnecessary `ThreadPoolExecutor` from the verbose subprocess logging path in `run_subprocess`. Since stderr is already merged into stdout via `stderr=STDOUT`, there is only one stream to drain — the thread provides no concurrency. Worse, `concurrent.futures.wait()` silently swallows any exception raised inside the submitted callable, so logging errors are hidden. Draining stdout inline is simpler and correctly propagates errors.

Refs #1097