### PR TITLE
♻️ refactor(cli): minor cleanups in builder and CLI

### DIFF
--- a/docs/changelog/1099.misc.rst
+++ b/docs/changelog/1099.misc.rst
@@ -1,0 +1,1 @@
+Minor internal cleanups: use ``tomllib.load`` directly, remove a redundant ``_styles.set`` call, deduplicate an ``os.path.isfile`` call, and rename a local variable to avoid shadowing the ``build`` module.

--- a/docs/changelog/1099.misc.rst
+++ b/docs/changelog/1099.misc.rst
@@ -1,1 +1,2 @@
-Minor internal cleanups: use ``tomllib.load`` directly, remove a redundant ``_styles.set`` call, deduplicate an ``os.path.isfile`` call, and rename a local variable to avoid shadowing the ``build`` module.
+Minor internal cleanups: use ``tomllib.load`` directly, remove a redundant ``_styles.set`` call, deduplicate an
+``os.path.isfile`` call, and rename a local variable to avoid shadowing the ``build`` module.

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -114,7 +114,6 @@ def _init_colors() -> None:
     if 'NO_COLOR' in os.environ:
         if 'FORCE_COLOR' in os.environ:
             warnings.warn('Both NO_COLOR and FORCE_COLOR environment variables are set, disabling color', stacklevel=2)
-        _styles.set(_NO_COLORS)
     elif 'FORCE_COLOR' in os.environ or sys.stdout.isatty():
         return
     _styles.set(_NO_COLORS)
@@ -700,9 +699,10 @@ def main(cli_args: Sequence[str], prog: str | None = None) -> None:
 
     _setup_cli(verbosity=args.verbosity)
 
-    sdist_input = os.path.isfile(args.srcdir) and os.fspath(args.srcdir).lower().endswith('.tar.gz')
-    wheel_input = os.path.isfile(args.srcdir) and os.fspath(args.srcdir).lower().endswith('.whl')
-    build = partial(
+    is_file = os.path.isfile(args.srcdir)
+    sdist_input = is_file and os.fspath(args.srcdir).lower().endswith('.tar.gz')
+    wheel_input = is_file and os.fspath(args.srcdir).lower().endswith('.whl')
+    run_build = partial(
         _select_build(parser, args, sdist_input=sdist_input, wheel_input=wheel_input),
         config_settings=_resolve_config_settings(args),
         isolation=not args.no_isolation,
@@ -723,9 +723,9 @@ def main(cli_args: Sequence[str], prog: str | None = None) -> None:
         if sdist_input:
             top_level = _validate_sdist_archive(args.srcdir)
             with _extract_sdist(args.srcdir, top_level, extract_dir=args.sdist_extract_dir) as extracted_srcdir:
-                built = build(extracted_srcdir, outdir)
+                built = run_build(extracted_srcdir, outdir)
         else:
-            built = build(args.srcdir, outdir)
+            built = run_build(args.srcdir, outdir)
         if args.report is not None:
             _write_report(args.report, outdir, built)
         if _ctx.verbosity >= -1 and built:

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -104,7 +104,7 @@ def _validate_source_directory(source_dir: StrPath) -> None:
 def _read_pyproject_toml(path: StrPath) -> Mapping[str, TOMLValue]:
     try:
         with open(path, 'rb') as f:
-            return tomllib.loads(f.read().decode())
+            return tomllib.load(f)
     except FileNotFoundError:
         return {}
     except PermissionError as e:  # pragma: win32 no cover


### PR DESCRIPTION
:robot: _AI text below_ :robot:

- Use `tomllib.load(f)` directly on the binary file handle in `_read_pyproject_toml` instead of `tomllib.loads(f.read().decode())`
- Remove the redundant `_styles.set(_NO_COLORS)` inside the `NO_COLOR` branch of `_init_colors`; the trailing call already handles it
- Compute `os.path.isfile(args.srcdir)` once as `is_file` instead of twice in `main`
- Rename local variable `build` → `run_build` in `main` to avoid shadowing the top-level `import build` module

Refs #1097