### PR TITLE
🐛 fix(env): reject a file as --env-dir and drop a mutable default

### DIFF
--- a/docs/changelog/1100.bugfix.rst
+++ b/docs/changelog/1100.bugfix.rst
@@ -1,0 +1,1 @@
+Raise a friendly :class:`build.BuildException` when ``--env-dir`` points at an existing regular file instead of letting :func:`os.makedirs` surface a raw :exc:`FileExistsError`; also replace the mutable default ``[]`` in :meth:`DefaultIsolatedEnv.install`'s ``constraints`` parameter with an immutable tuple ``()``.

--- a/docs/changelog/1100.bugfix.rst
+++ b/docs/changelog/1100.bugfix.rst
@@ -1,1 +1,3 @@
-Raise a friendly :class:`build.BuildException` when ``--env-dir`` points at an existing regular file instead of letting :func:`os.makedirs` surface a raw :exc:`FileExistsError`; also replace the mutable default ``[]`` in :meth:`DefaultIsolatedEnv.install`'s ``constraints`` parameter with an immutable tuple ``()``.
+Raise a friendly :class:`build.BuildException` when ``--env-dir`` points at an existing regular file instead of letting
+:func:`os.makedirs` surface a raw :exc:`FileExistsError`; also replace the mutable default ``[]`` in
+:meth:`DefaultIsolatedEnv.install`'s ``constraints`` parameter with an immutable tuple ``()``.

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -121,6 +121,9 @@ class DefaultIsolatedEnv(IsolatedEnv):
             path = tempfile.mkdtemp(prefix='build-env-')
         else:
             path = self._requested_path
+            if os.path.exists(path) and not os.path.isdir(path):
+                msg = f'Build environment location is not a directory: {path}'
+                raise BuildException(msg)
             if os.path.isdir(path):
                 with os.scandir(path) as entries:
                     if next(entries, None) is not None:
@@ -203,7 +206,7 @@ class DefaultIsolatedEnv(IsolatedEnv):
     def install(
         self,
         requirements: Collection[str],
-        constraints: Collection[str] = [],
+        constraints: Collection[str] = (),
         *,
         _fresh: bool = False,  # Used internally by CLI to support preset PYTHONPATH
     ) -> None:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -696,6 +696,19 @@ def test_env_dir_rejects_non_empty_location(tmp_path: pathlib.Path) -> None:
     assert tmp_path.joinpath('sentinel').exists()
 
 
+def test_env_dir_rejects_file_at_location(tmp_path: pathlib.Path) -> None:
+    file_path = tmp_path / 'env-file'
+    file_path.touch()
+
+    with (
+        pytest.raises(build.BuildException, match='Build environment location is not a directory'),
+        build.env.DefaultIsolatedEnv(path=str(file_path)),
+    ):
+        raise AssertionError
+
+    assert file_path.is_file()
+
+
 @pytest.mark.usefixtures('mock_env_create')
 def test_env_dir_accepts_existing_empty_location(tmp_path: pathlib.Path) -> None:
     with build.env.DefaultIsolatedEnv(path=str(tmp_path)) as env:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Two small robustness fixes in `DefaultIsolatedEnv`:

- **File-at-path check**: when `--env-dir` points at an existing regular file, `os.makedirs(..., exist_ok=True)` previously raised a raw `FileExistsError`. Now a `BuildException` with a clear message (`Build environment location is not a directory: <path>`) is raised before reaching `os.makedirs`. A sibling test is added alongside the existing `test_env_dir_rejects_non_empty_location` test.
- **Mutable default argument**: `DefaultIsolatedEnv.install`'s `constraints` parameter had a mutable default `[]` (ruff B006). Changed to an empty tuple `()`.

Refs #1097