### PR TITLE
chore: add check-dist

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,3 +71,9 @@ repos:
         files: ^docs/changelog/(?!([0-9]+\.(feature|bugfix|doc|removal|misc)\.rst|template\.jinja2|README\.rst)$).*
         entry: files in changelog must be valid (N.type.rst)
         language: fail
+  - repo: https://github.com/henryiii/check-sdist
+    rev: 8d786ae74939ac1d9b12681bc43f72a0980283dd # frozen: v1.4.0
+    hooks:
+      - id: check-sdist
+        args: [--inject-junk]
+        additional_dependencies: [] # list your build deps here

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,4 +76,4 @@ repos:
     hooks:
       - id: check-sdist
         args: [--inject-junk]
-        additional_dependencies: [] # list your build deps here
+        additional_dependencies: [flit-core]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,14 @@ dev = [
 
 [tool.flit.sdist]
 include = ["tests/", ".gitignore", "CHANGELOG.rst", "docs/", ".dockerignore", "tox.toml"]
-exclude = ["**/__pycache__", "docs/_build", "**/*.egg-info", "tests/packages/*/build", "docs/changelog/template.jinja2"]
+exclude = [
+  "**/__pycache__",
+  "docs/_build",
+  "**/*.egg-info",
+  "tests/packages/*/build",
+  "docs/changelog/template.jinja2",
+  "tasks/*",
+]
 
 [tool.uv]
 exclude-newer = "7 days"


### PR DESCRIPTION
## Description

Adding check-dist. It reads the ignore list for common tools like flit, so adding the new tasks folder there makes it happy.
