### PR TITLE
docs: shorten changelog entries to concise highlights

### DIFF
--- a/docs/changelog/1058.misc.rst
+++ b/docs/changelog/1058.misc.rst
@@ -1,2 +1,1 @@
-Add test coverage for ``config_settings``, ``dependency_constraints_txt``, and ``installer`` arguments in
-:func:`build_package` and :func:`build_package_via_sdist` - by :user:`terminalchai`
+Add test coverage for ``config_settings``, ``dependency_constraints_txt``, and ``installer`` arguments - by :user:`terminalchai`

--- a/docs/changelog/1058.misc.rst
+++ b/docs/changelog/1058.misc.rst
@@ -1,1 +1,2 @@
-Add test coverage for ``config_settings``, ``dependency_constraints_txt``, and ``installer`` arguments - by :user:`terminalchai`
+Add test coverage for ``config_settings``, ``dependency_constraints_txt``, and ``installer`` arguments - by
+:user:`terminalchai`

--- a/docs/changelog/1059.misc.rst
+++ b/docs/changelog/1059.misc.rst
@@ -1,1 +1,0 @@
-Drop Python 3.9 branches from ``version_info`` checks - by :user:`henryiii`

--- a/docs/changelog/1059.misc.rst
+++ b/docs/changelog/1059.misc.rst
@@ -1,0 +1,1 @@
+Drop Python 3.9 branches from ``version_info`` checks - by :user:`henryiii`

--- a/docs/changelog/1060.misc.rst
+++ b/docs/changelog/1060.misc.rst
@@ -1,0 +1,1 @@
+Refactor ``safe_extractall`` to use ``pathlib.Path`` - by :user:`henryiii`

--- a/docs/changelog/1060.misc.rst
+++ b/docs/changelog/1060.misc.rst
@@ -1,1 +1,1 @@
-Refactor ``safe_extractall`` to use ``pathlib.Path`` - by :user:`henryiii`
+Accept ``pathlib.Path`` in ``safe_extractall`` - by :user:`henryiii`

--- a/docs/changelog/1062.misc.rst
+++ b/docs/changelog/1062.misc.rst
@@ -1,1 +1,1 @@
-Skip ``test_uv_install_strips_pythonpath`` with missing ``uv`` - by :user:`mtelka`
+Skip ``test_uv_install_strips_pythonpath`` when ``uv`` is not installed - by :user:`mtelka`

--- a/docs/changelog/1093.misc.rst
+++ b/docs/changelog/1093.misc.rst
@@ -1,1 +1,2 @@
-Tighten type annotations across ``src`` and ``tests``, removing ``Any``/``object``/``# type: ignore`` and enabling ``disallow_any_explicit`` - by :user:`gaborbernat`
+Tighten type annotations across ``src`` and ``tests``, removing ``Any``/``object``/``# type: ignore`` and enabling
+``disallow_any_explicit`` - by :user:`gaborbernat`

--- a/docs/changelog/1093.misc.rst
+++ b/docs/changelog/1093.misc.rst
@@ -1,2 +1,1 @@
-Tighten type annotations across ``src`` and ``tests`` to remove ``Any``, ``object``, and ``# type: ignore``, and enable
-``disallow_any_explicit`` so the type gate covers both - by :user:`gaborbernat`
+Tighten type annotations across ``src`` and ``tests``, removing ``Any``/``object``/``# type: ignore`` and enabling ``disallow_any_explicit`` - by :user:`gaborbernat`

--- a/docs/changelog/1098.bugfix.rst
+++ b/docs/changelog/1098.bugfix.rst
@@ -1,2 +1,1 @@
-Verbose subprocess logging no longer relies on a worker thread, and errors raised while logging are no longer silently
-discarded.
+Drain verbose subprocess output inline instead of using a ``ThreadPoolExecutor``, which silently swallowed logging errors - by :user:`henryiii`

--- a/docs/changelog/1098.bugfix.rst
+++ b/docs/changelog/1098.bugfix.rst
@@ -1,1 +1,2 @@
-Drain verbose subprocess output inline instead of using a ``ThreadPoolExecutor``, which silently swallowed logging errors - by :user:`henryiii`
+Drain verbose subprocess output inline instead of using a ``ThreadPoolExecutor``, which silently swallowed logging
+errors - by :user:`henryiii`

--- a/docs/changelog/1099.misc.rst
+++ b/docs/changelog/1099.misc.rst
@@ -1,1 +1,2 @@
-Minor cleanups in builder and CLI: simplify TOML reading, deduplicate color init, and avoid shadowing the ``build`` module - by :user:`henryiii`
+Minor cleanups in builder and CLI: simplify TOML reading, deduplicate color init, and avoid shadowing the ``build``
+module - by :user:`henryiii`

--- a/docs/changelog/1099.misc.rst
+++ b/docs/changelog/1099.misc.rst
@@ -1,2 +1,1 @@
-Minor internal cleanups: use ``tomllib.load`` directly, remove a redundant ``_styles.set`` call, deduplicate an
-``os.path.isfile`` call, and rename a local variable to avoid shadowing the ``build`` module.
+Minor cleanups in builder and CLI: simplify TOML reading, deduplicate color init, and avoid shadowing the ``build`` module - by :user:`henryiii`

--- a/docs/changelog/1100.bugfix.rst
+++ b/docs/changelog/1100.bugfix.rst
@@ -1,3 +1,1 @@
-Raise a friendly :class:`build.BuildException` when ``--env-dir`` points at an existing regular file instead of letting
-:func:`os.makedirs` surface a raw :exc:`FileExistsError`; also replace the mutable default ``[]`` in
-:meth:`DefaultIsolatedEnv.install`'s ``constraints`` parameter with an immutable tuple ``()``.
+Reject a file passed as ``--env-dir`` with a clear error instead of a raw ``FileExistsError`` - by :user:`henryiii`

--- a/docs/changelog/198.feature.rst
+++ b/docs/changelog/198.feature.rst
@@ -1,1 +1,2 @@
-Add ``--report`` to write a machine-readable JSON report of built artifacts; ``--metadata`` now also accepts ``.whl`` files - by :user:`gaborbernat`
+Add ``--report=PATH`` to write a machine-readable JSON report of built artifacts; ``--metadata`` now also accepts
+``.whl`` files - by :user:`gaborbernat`

--- a/docs/changelog/198.feature.rst
+++ b/docs/changelog/198.feature.rst
@@ -1,4 +1,1 @@
-Add ``--report PATH`` to write a machine-readable JSON report of the built artifacts (name, path, kind, size and SHA-256
-hash), so scripts and CI can refer to the produced files without globbing. ``--metadata`` now also accepts a ``.whl`` as
-its source argument and reads the wheel's ``METADATA`` directly, so a path taken from the report can be inspected
-without rebuilding - by :user:`gaborbernat`
+Add ``--report`` to write a machine-readable JSON report of built artifacts; ``--metadata`` now also accepts ``.whl`` files - by :user:`gaborbernat`

--- a/docs/changelog/311.feature.rst
+++ b/docs/changelog/311.feature.rst
@@ -1,1 +1,2 @@
-The ``srcdir`` argument now accepts ``.tar.gz`` source distributions, extracting and building from them - by :user:`gaborbernat`
+The ``srcdir`` argument now accepts ``.tar.gz`` source distributions, extracting and building from them - by
+:user:`gaborbernat`

--- a/docs/changelog/311.feature.rst
+++ b/docs/changelog/311.feature.rst
@@ -1,5 +1,1 @@
-The positional ``srcdir`` argument now accepts a ``.tar.gz`` source distribution. ``python -m build pkg-1.0.tar.gz``
-checks the filename and ``PKG-INFO``, validates every archive member to reject path traversal, escaping
-symlinks/hardlinks and device files, extracts into a temporary directory, and runs a wheel build against the extracted
-source. ``--metadata`` works the same way. ``--sdist`` errors, since the archive already is an sdist - by
-:user:`gaborbernat`.
+The ``srcdir`` argument now accepts ``.tar.gz`` source distributions, extracting and building from them - by :user:`gaborbernat`

--- a/docs/changelog/504.feature.rst
+++ b/docs/changelog/504.feature.rst
@@ -1,4 +1,1 @@
-The ``Unmet dependencies`` error reported by ``--no-isolation`` builds now lists, for each unmet requirement, the
-version specifier that was ``wanted`` and the version that was ``found`` (or that the package is not installed), and
-names the interpreter the check ran against. This makes it clear whether a dependency is absent or merely the wrong
-version, and which environment was inspected - by :user:`gaborbernat`.
+The "Unmet dependencies" error from ``--no-isolation`` builds now shows the wanted version, found version, and interpreter - by :user:`gaborbernat`

--- a/docs/changelog/504.feature.rst
+++ b/docs/changelog/504.feature.rst
@@ -1,1 +1,2 @@
-The "Unmet dependencies" error from ``--no-isolation`` builds now shows the wanted version, found version, and interpreter - by :user:`gaborbernat`
+The "Unmet dependencies" error from ``--no-isolation`` builds now shows the wanted version, found version, and
+interpreter - by :user:`gaborbernat`

--- a/docs/changelog/557.removal.rst
+++ b/docs/changelog/557.removal.rst
@@ -1,2 +1,1 @@
-Deprecate :func:`build.util.project_wheel_metadata`; it returns an ``email.message.Message``-style object and has fallen
-behind the CLI. Generate metadata with the ``python -m build --metadata`` command instead - by :user:`gaborbernat`.
+Deprecate :func:`build.util.project_wheel_metadata`; use ``python -m build --metadata`` instead - by :user:`gaborbernat`

--- a/docs/changelog/614.feature.rst
+++ b/docs/changelog/614.feature.rst
@@ -1,5 +1,1 @@
-Add ``--sdist-extract-dir PATH`` to extract the intermediate sdist into a chosen, persistent directory instead of a
-random temporary one. Reuse the same path across rebuilds and compiler caches such as ``ccache`` and ``sccache`` see a
-stable source path, so unchanged C/C++ files hit the cache. Build creates the directory if missing, clears its stale
-contents before each extraction, and keeps it after the build. The flag covers the default via-sdist build and building
-a wheel from a ``.tar.gz`` - by :user:`gaborbernat`.
+Add ``--sdist-extract-dir`` to extract the intermediate sdist into a persistent directory, enabling compiler cache reuse across rebuilds - by :user:`gaborbernat`

--- a/docs/changelog/614.feature.rst
+++ b/docs/changelog/614.feature.rst
@@ -1,1 +1,2 @@
-Add ``--sdist-extract-dir`` to extract the intermediate sdist into a persistent directory, enabling compiler cache reuse across rebuilds - by :user:`gaborbernat`
+Add ``--sdist-extract-dir`` to extract the intermediate sdist into a persistent directory, enabling compiler cache reuse
+across rebuilds - by :user:`gaborbernat`

--- a/docs/changelog/640.removal.rst
+++ b/docs/changelog/640.removal.rst
@@ -1,1 +1,2 @@
-Warn on config settings without a value (e.g. ``-C--my-flag``); use ``-C--my-flag=`` instead for compatibility with pip - by :user:`gaborbernat`
+Warn on config settings without a value (e.g. ``-C--my-flag``); use ``-C--my-flag=`` instead for compatibility with pip
+- by :user:`gaborbernat`

--- a/docs/changelog/640.removal.rst
+++ b/docs/changelog/640.removal.rst
@@ -1,2 +1,1 @@
-build now warns when you pass a config setting without a value (e.g. ``-C--my-flag``), since pip rejects that form.
-Write ``-C--my-flag=`` instead; it means the same thing and works in both tools - by :user:`gaborbernat`.
+Warn on config settings without a value (e.g. ``-C--my-flag``); use ``-C--my-flag=`` instead for compatibility with pip - by :user:`gaborbernat`

--- a/docs/changelog/655.feature.rst
+++ b/docs/changelog/655.feature.rst
@@ -1,4 +1,1 @@
-Add ``--env-dir PATH`` to put the isolated build environment at a fixed location instead of a temporary directory.
-``DefaultIsolatedEnv`` takes the same ``path`` argument. build creates the location if it is missing, refuses a
-non-empty location, removes it after a successful build, and keeps it after a failure so you can inspect it. A fixed
-path lets compilation caches such as ccache and sccache reuse results across builds - by :user:`gaborbernat`.
+Add ``--env-dir`` to place the isolated build environment at a fixed path, enabling compiler cache reuse across builds - by :user:`gaborbernat`

--- a/docs/changelog/655.feature.rst
+++ b/docs/changelog/655.feature.rst
@@ -1,1 +1,2 @@
-Add ``--env-dir`` to place the isolated build environment at a fixed path, enabling compiler cache reuse across builds - by :user:`gaborbernat`
+Add ``--env-dir`` to place the isolated build environment at a fixed path, enabling compiler cache reuse across builds -
+by :user:`gaborbernat`

--- a/docs/changelog/959.feature.rst
+++ b/docs/changelog/959.feature.rst
@@ -1,1 +1,2 @@
-Print a summary of resolved dependency versions (``name==version``) after installing them in isolated builds - by :user:`gaborbernat`
+Print a summary of resolved dependency versions (``name==version``) after installing them in isolated builds - by
+:user:`gaborbernat`

--- a/docs/changelog/959.feature.rst
+++ b/docs/changelog/959.feature.rst
@@ -1,3 +1,1 @@
-After installing the build dependencies in an isolated build, print a concise summary of each resolved version as
-``name==version`` so the exact backend version is on hand for bug reports without scraping the installer's ``-vv``
-output (:issue:`959`) - by :user:`gaborbernat`.
+Print a summary of resolved dependency versions (``name==version``) after installing them in isolated builds - by :user:`gaborbernat`

--- a/docs/changelog/966.feature.rst
+++ b/docs/changelog/966.feature.rst
@@ -1,4 +1,1 @@
-When a build backend fails, build now prints a tip pointing at ``--env-dir`` and ``--sdist-extract-dir`` (to keep the
-build environment and extracted sources for inspection) and links to a new "Debug a failed build" how-to that explains
-how to stream backend output and where backends such as meson-python write their own logs. When those locations are
-already pinned, the tip reports where they were kept - reported by :user:`dimpase`, implemented by :user:`gaborbernat`.
+On build failure, print a tip pointing to ``--env-dir`` and ``--sdist-extract-dir`` for debugging and link to the "Debug a failed build" how-to - reported by :user:`dimpase`, implemented by :user:`gaborbernat`

--- a/docs/changelog/966.feature.rst
+++ b/docs/changelog/966.feature.rst
@@ -1,1 +1,2 @@
-On build failure, print a tip pointing to ``--env-dir`` and ``--sdist-extract-dir`` for debugging and link to the "Debug a failed build" how-to - reported by :user:`dimpase`, implemented by :user:`gaborbernat`
+On build failure, print a tip pointing to ``--env-dir`` and ``--sdist-extract-dir`` for debugging and link to the "Debug
+a failed build" how-to - reported by :user:`dimpase`, implemented by :user:`gaborbernat`


### PR DESCRIPTION
The current changelog entries are really long and overly detailed (and read very much like Claude output). I've started by rewriting all of them with GLM 5.1, and I touched them up a bit by hand and also checked for missing ones.

Happy to take maintainer edits.

:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

## Summary

Rewrite all changelog entries in `docs/changelog/` to be brief, scannable 1-2 line highlights instead of verbose multi-paragraph descriptions. Key change and author credit are preserved; implementation details are trimmed.

Assisted-by: OpenCode:glm-5.1 (Open Source harness and model)