### PR TITLE
test: fix has_virtualenv fixture for pytest 9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,8 +143,7 @@ exclude = [
 
 [tool.uv]
 exclude-newer = "7 days"
-# Our docs dependencies do not support 3.9, so remove it from the uv solve
-environments = ["python_version >= '3.10'"]
+exclude-newer-package = { pytest = "2026-06-13" }
 
 
 [tool.coverage]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,10 +115,14 @@ def _clear_keyring_cache() -> Generator[None, None, None]:
     build.env._has_keyring_cli.cache_clear()
 
 
-@pytest.fixture(autouse=True, params=[False])
+@pytest.fixture(autouse=True)
 def has_virtualenv(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
-    if request.param is not None:
-        monkeypatch.setattr(build.env._PipBackend, '_has_virtualenv', request.param)
+    # In pytest 9.1+, a fixture cannot be both autouse with params and parametrized
+    # indirectly by a test. Default to False, and allow tests to override via
+    # ``@pytest.mark.parametrize('has_virtualenv', ..., indirect=True)``.
+    param = getattr(request, 'param', False)
+    if param is not None:
+        monkeypatch.setattr(build.env._PipBackend, '_has_virtualenv', param)
 
 
 @pytest.fixture(scope='session', autouse=True)


### PR DESCRIPTION
Pytest 9.1, which came out yesterday, added new warning that break test suites that have warnings as errors (10 will break them, period). I ran into this in packaging (https://github.com/pypa/packaging/pull/1260). That's a different new warning, you can't use a generator for parametrization anymore (they get exhausted, so certain ways of running them can end up getting no parameters). It also broke several downstream packages that are being tested there, including us. We won't see breakage in our suite for 7 days, but it does break if you override locally. This is a fix.

Used Kimi 2.7 code for the investigation, an open model.

:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

pytest 9.1 now flags a fixture that is both `autouse` with `params` and parametrized indirectly by a test as a duplicate parametrization. This caused collection of `tests/test_env.py::test_venv_creation` to fail with:

```
duplicate parametrization of 'has_virtualenv'
```

Update the `has_virtualenv` fixture to remain autouse and default to `False`, while allowing tests to override it through `@pytest.mark.parametrize('has_virtualenv', ..., indirect=True)`. This preserves the existing behavior and makes the test suite compatible with pytest 9.1.

`AGENTS.md` was also updated to describe the override pattern.

Assisted-by: OpenCode:Kimi-K2.7-code