### PR TITLE
♻️ refactor(typing): address Any-ban review follow-ups

### DIFF
--- a/docs/changelog/1110.misc.rst
+++ b/docs/changelog/1110.misc.rst
@@ -1,0 +1,2 @@
+Consolidate the ``JSONValue``/``TOMLValue`` aliases in ``build._types`` and simplify the type annotations added in
+:issue:`1093` following review - by :user:`gaborbernat`

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -70,13 +70,9 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping, Sequence
 
-    from build._types import ConfigSettings, Distribution, StrPath, SubprocessRunner
+    from build._types import ConfigSettings, Distribution, JSONValue, StrPath, SubprocessRunner
 
-    # A decoded JSON value, as produced by ``--config-json``. Uses the covariant ``Sequence``/``Mapping``
-    # so the ``str | list[str]`` settings from ``--config-setting`` are also assignable to it.
-    JSONValue = str | int | float | bool | None | Sequence['JSONValue'] | Mapping[str, 'JSONValue']
-
-    class _Args(argparse.Namespace):
+    class _CliArgs(argparse.Namespace):
         """The arguments :func:`main_parser` produces, typed for the rest of the module."""
 
         srcdir: str
@@ -709,7 +705,7 @@ def main(cli_args: Sequence[str], prog: str | None = None) -> None:
     parser = main_parser()
     if prog:
         parser.prog = prog
-    args = cast('_Args', parser.parse_args(cli_args))
+    args = cast('_CliArgs', parser.parse_args(cli_args))
 
     if args.env_dir is not None and args.no_isolation:
         parser.error('--env-dir: not allowed with --no-isolation')
@@ -799,7 +795,7 @@ def _describe_artifact(path: str, name: str) -> _ArtifactReport:
     }
 
 
-def _resolve_config_settings(args: _Args) -> Mapping[str, JSONValue]:
+def _resolve_config_settings(args: _CliArgs) -> Mapping[str, JSONValue]:
     if args.config_json:
         try:
             config_settings = json.loads(args.config_json)
@@ -813,7 +809,9 @@ def _resolve_config_settings(args: _Args) -> Mapping[str, JSONValue]:
     return {}
 
 
-def _select_build(parser: argparse.ArgumentParser, args: _Args, *, sdist_input: bool, wheel_input: bool) -> partial[list[str]]:
+def _select_build(
+    parser: argparse.ArgumentParser, args: _CliArgs, *, sdist_input: bool, wheel_input: bool
+) -> partial[list[str]]:
     if args.report is not None and args.metadata:
         parser.error('--report: not allowed with --metadata')
     if wheel_input and not args.metadata:

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -25,6 +25,8 @@ import sys
 import warnings
 import zipfile
 
+from typing import cast
+
 import pyproject_hooks
 
 from . import _ctx, env
@@ -41,31 +43,12 @@ from ._util import check_dependency, parse_wheel_filename
 TYPE_CHECKING = False
 
 if TYPE_CHECKING:
-    import datetime
-
     from collections.abc import Iterable, Iterator, Mapping, Sequence
     from typing import TypedDict
 
-    if sys.version_info < (3, 11):
-        from typing_extensions import NotRequired, Self
-    else:
-        from typing import NotRequired, Self
+    from typing_extensions import NotRequired, Self
 
-    from ._types import ConfigSettings, Distribution, StrPath, SubprocessRunner
-
-    # A value as produced by ``tomllib`` when parsing ``pyproject.toml``. Uses the covariant
-    # ``Sequence``/``Mapping`` so concrete literals (e.g. ``dict[str, list[str]]``) are assignable.
-    TOMLValue = (
-        str
-        | int
-        | float
-        | bool
-        | datetime.datetime
-        | datetime.date
-        | datetime.time
-        | Sequence['TOMLValue']
-        | Mapping[str, 'TOMLValue']
-    )
+    from ._types import ConfigSettings, Distribution, StrPath, SubprocessRunner, TOMLValue
 
     # The validated ``[build-system]`` table.
     BuildSystemTable = TypedDict(
@@ -138,7 +121,7 @@ def _parse_build_system_table(pyproject_toml: Mapping[str, TOMLValue]) -> BuildS
         raise BuildSystemTableValidationError(msg)
 
     table: BuildSystemTable = {
-        'requires': [requirement for requirement in requires if isinstance(requirement, str)],
+        'requires': cast('list[str]', requires),
         'build-backend': _DEFAULT_BACKEND['build-backend'],
     }
 
@@ -155,7 +138,7 @@ def _parse_build_system_table(pyproject_toml: Mapping[str, TOMLValue]) -> BuildS
 
     match build_system:
         case {'backend-path': list() as backend_path} if all(isinstance(i, str) for i in backend_path):
-            table['backend-path'] = [path for path in backend_path if isinstance(path, str)]
+            table['backend-path'] = cast('list[str]', backend_path)
         case {'backend-path': _}:
             msg = '`backend-path` must be an array of strings'
             raise BuildSystemTableValidationError(msg)

--- a/src/build/_types.py
+++ b/src/build/_types.py
@@ -1,16 +1,35 @@
 from __future__ import annotations
 
 import collections.abc
+import datetime
 import os
 import typing
 
 
-__all__ = ['ConfigSettings', 'Distribution', 'StrPath', 'SubprocessRunner']
+__all__ = ['ConfigSettings', 'Distribution', 'JSONValue', 'StrPath', 'SubprocessRunner', 'TOMLValue']
 
 ConfigSettings = collections.abc.Mapping[str, str | collections.abc.Sequence[str]]
 Distribution = typing.Literal['sdist', 'wheel', 'editable']
 
 StrPath = str | os.PathLike[str]
+
+# A decoded JSON value, as produced by ``json.load``/``--config-json``. Uses the covariant
+# ``Sequence``/``Mapping`` so concrete literals (e.g. ``str | list[str]``) remain assignable to it.
+JSONValue = str | int | float | bool | None | collections.abc.Sequence['JSONValue'] | collections.abc.Mapping[str, 'JSONValue']
+
+# A value as produced by ``tomllib`` when parsing ``pyproject.toml``: JSON plus the TOML date/time
+# scalars. Covariant for the same reason as ``JSONValue``.
+TOMLValue = (
+    str
+    | int
+    | float
+    | bool
+    | datetime.datetime
+    | datetime.date
+    | datetime.time
+    | collections.abc.Sequence['TOMLValue']
+    | collections.abc.Mapping[str, 'TOMLValue']
+)
 
 TYPE_CHECKING = False
 

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -52,10 +52,7 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Collection, Mapping
 
-    if sys.version_info < (3, 11):
-        from typing_extensions import Self
-    else:
-        from typing import Self
+    from typing_extensions import Self
 
 
 Installer = typing.Literal['pip', 'uv']
@@ -77,7 +74,7 @@ class IsolatedEnv(typing.Protocol):
 
 
 def _has_dependency(
-    name: str, minimum_version_str: str | None = None, /, **distargs: list[str]
+    name: str, minimum_version_str: str | None = None, /, *, path: list[str] | None = None
 ) -> importlib_metadata.Distribution | None:
     """
     Given a distribution name, see if it is present and return the distribution
@@ -88,8 +85,13 @@ def _has_dependency(
 
     from ._compat import importlib
 
+    # Pass ``path`` only when provided: ``distributions(path=None)`` suppresses the ``sys.path``
+    # default instead of falling back to it.
+    distributions = (
+        importlib.metadata.distributions(name=name) if path is None else importlib.metadata.distributions(name=name, path=path)
+    )
     try:
-        distribution = next(iter(importlib.metadata.distributions(name=name, **distargs)))
+        distribution = next(iter(distributions))
     except StopIteration:
         return None
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,7 +16,7 @@ import unittest.mock
 import venv
 import zipfile
 
-from collections.abc import Callable, Iterator, Mapping, Sequence
+from collections.abc import Callable, Iterator
 from typing import TYPE_CHECKING, Protocol, TypedDict
 
 import pytest
@@ -33,9 +33,8 @@ from build._compat import importlib as _importlib
 if TYPE_CHECKING:
     from conftest import SubTests
 
-
-class CapturedRunner(Protocol):
-    def __call__(self, cmd: Sequence[str], cwd: str | None = ..., extra_environ: Mapping[str, str] | None = ...) -> None: ...
+    from build import RunnerType
+    from build._types import JSONValue
 
 
 pytestmark = pytest.mark.contextvars
@@ -47,8 +46,6 @@ cwd = os.getcwd()
 out = os.path.join(cwd, 'dist')
 
 ANSI_STRIP = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
-
-JSONValue = str | int | list['JSONValue'] | dict[str, 'JSONValue']
 
 
 class BuildKwargs(TypedDict):
@@ -919,10 +916,10 @@ def test_build_metadata_runner_without_extra_environ(
     tmp_path: pathlib.Path,
     package_test_setuptools: str,
 ) -> None:
-    captured_runners: list[CapturedRunner] = []
+    captured_runners: list[RunnerType] = []
 
     @contextlib.contextmanager
-    def fake_bootstrap(*_args: object, runner: CapturedRunner, **_kwargs: object) -> Iterator[unittest.mock.MagicMock]:
+    def fake_bootstrap(*_args: object, runner: RunnerType, **_kwargs: object) -> Iterator[unittest.mock.MagicMock]:
         captured_runners.append(runner)
         builder = mocker.MagicMock()
         metadata_dir = tmp_path / 'metadata'

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -26,7 +26,8 @@ from build._compat import importlib as _importlib
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from build._builder import BuildSystemTable, TOMLValue
+    from build._builder import BuildSystemTable
+    from build._types import TOMLValue
 
 
 build_open_owner = 'builtins'


### PR DESCRIPTION
The type-safety work in #1093 closed a real gap: before it, a wrong argument shape or a renamed test attribute could slip through review because the checker had been told to look the other way in the awkward spots. Reviewing that change surfaced a handful of follow-ups worth settling before it becomes the baseline everyone builds on. Left alone they add quiet maintenance drag, and one of them is an annotation that overstates what the code actually accepts.

This PR clears that review feedback so the typing improvements rest on a clean footing. 🎯 The description of decoded JSON and TOML data had been copied into three files and was already drifting apart; it now lives in one place, so there is a single source of truth to keep correct. A helper that advertised it accepted far more than it ever receives now states exactly what it takes, which removes a trap for the next person who calls it. And where the code re-checked facts it had just proven, it now records that they hold instead of paying for the same validation twice.

One review suggestion was to push the JSON and TOML shape definitions upstream into Python's shared type stubs (typeshed). We looked into it and are deliberately keeping them inside `build`. 💡 The wider ecosystem has decided more than once that these parsers should stay loosely typed, because a stricter definition makes every project that reads JSON or TOML do extra work and breaks code that already exists. The JSON case was declined in python/typing#182 and again in python/typeshed#5911, with the most recent request closed in January 2026 (python/typeshed#15272); the TOML case was declined in python/typeshed#10031, whose trial run introduced errors into projects like `pytest` and `pylint`. Defining the shapes locally gives `build` the precision it wants exactly where this data is validated and consumed, without pushing that cost onto everyone downstream.

Nothing about how `build` is used changes. The public API, the command-line interface, and runtime behaviour are all untouched, so existing users and integrators see no difference. What improves is the maintenance cost and a type story that stays accurate enough to keep catching real mistakes as the project grows.