### PR TITLE
fix(cli): fix CLI warnings being written to stdout instead of stderr

### DIFF
--- a/docs/changelog/1111.bugfix.rst
+++ b/docs/changelog/1111.bugfix.rst
@@ -1,0 +1,2 @@
+Emit CLI warnings to stderr instead of stdout, so they no longer corrupt ``--metadata`` JSON output on stdout - by
+:user:`ymyzk`

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -130,8 +130,8 @@ def _showwarning(
     lineno: int,  # noqa: ARG001
     file: TextIO | None = None,
     line: str | None = None,  # noqa: ARG001
-) -> None:  # pragma: no cover
-    _cprint('{yellow}WARNING{reset} {}', str(message), file)
+) -> None:
+    _cprint('{yellow}WARNING{reset} {}', str(message), file if file is not None else sys.stderr)
 
 
 def _make_logger() -> _ctx.Logger:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -682,6 +682,16 @@ def test_colors_conflict(monkeypatch: pytest.MonkeyPatch) -> None:
         assert build.__main__._styles.get() == build.__main__._NO_COLORS
 
 
+def test_warning_goes_to_stderr(capsys: pytest.CaptureFixture[str]) -> None:
+    build.__main__._showwarning('a warning', UserWarning, 'f.py', 1)
+
+    out, err = capsys.readouterr()
+
+    assert out == ''
+    assert 'WARNING' in err
+    assert 'a warning' in err
+
+
 def test_logging_output_venv_failure(
     monkeypatch: pytest.MonkeyPatch, package_test_flit: str, tmp_dir: str, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
## Description

CLI warning messages were written to **stdout** instead of **stderr**.

The `warnings.showwarning` hook (`_showwarning` in `src/build/__main__.py`) passed `file=None` through to `_cprint`, which forwards to `print(..., file=None)` and therefore defaults to `sys.stdout`. Every other CLI diagnostic — the `* ` step logs and the `ERROR`/`TIP` messages — goes to stderr, so warnings were inconsistent.

More importantly, this corrupted the machine-readable JSON emitted on stdout by `python -m build --metadata`: a warning line ended up interleaved with the JSON and broke downstream parsing.

Reproduction (setting both variables triggers a `UserWarning`):

```console
$ FORCE_COLOR=1 NO_COLOR=1 python -m build --metadata
```

Before, the `WARNING Both NO_COLOR and FORCE_COLOR ...` line landed on stdout, mixed into the JSON. After, it goes to stderr alongside the `* ` step logs, leaving stdout to contain only the JSON.

Changes:

- `src/build/__main__.py`: default `_showwarning`'s destination to `sys.stderr` when the `warnings` machinery passes `file=None`, while still honoring an explicitly provided stream. Removed the now-covered `# pragma: no cover`.
- `tests/test_main.py`: added a regression test asserting the hook writes to stderr and leaves stdout empty.

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

- [x] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing ``Add custom backend support - by :user:`yourname` ``

## Checklist

- [x] Tests pass locally (`tox`)
- [x] Code follows project style (`tox -e fix`)
- [x] Type checks pass (`tox -e type`)
- [x] Documentation builds (`tox -e docs`)

