### PR TITLE
chore: default --installer to pip in argparse

### DIFF
--- a/docs/changelog/1117.misc.rst
+++ b/docs/changelog/1117.misc.rst
@@ -1,0 +1,1 @@
+The ``--installer`` CLI option now has an explicit ``pip`` default instead of relying on ``None``.

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -86,7 +86,7 @@ if TYPE_CHECKING:
         metadata: bool
         config_settings: list[str] | None
         config_json: str | None
-        installer: _env.Installer | None
+        installer: _env.Installer
         no_isolation: bool
         dependency_constraints_txt: str | None
         skip_dependency_check: bool
@@ -647,6 +647,7 @@ def main_parser() -> argparse.ArgumentParser:
     env_exclusive_group.add_argument(
         '--installer',
         choices=_env.INSTALLERS,
+        default='pip',
         help='Python package installer to use (defaults to pip)',
     )
     env_exclusive_group.add_argument(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -57,7 +57,7 @@ class BuildKwargs(TypedDict):
     isolation: bool
     skip_dependency_check: bool
     dependency_constraints_txt: str | None
-    installer: str | None
+    installer: str
     env_dir: str | None
 
 
@@ -68,7 +68,7 @@ def make_kwargs(
     isolation: bool = True,
     skip_dependency_check: bool = False,
     dependency_constraints_txt: str | None = None,
-    installer: str | None = None,
+    installer: str = 'pip',
     env_dir: str | None = None,
 ) -> BuildKwargs:
     return {
@@ -1235,7 +1235,7 @@ def test_main_sdist_input_passes_kwargs(sdist: pathlib.Path, mocker: pytest_mock
     assert kwargs['isolation'] is False
     assert kwargs['skip_dependency_check'] is True
     assert kwargs['config_settings'] == {'flag': 'value'}
-    assert kwargs['installer'] is None
+    assert kwargs['installer'] == 'pip'
 
 
 def test_main_sdist_input_end_to_end(tmp_path: pathlib.Path, package_test_setuptools: str) -> None:


### PR DESCRIPTION
Maybe it was this way because we were thinking to add a smart default that would use either? That never happened, so this seem fine and simpler to check.

:robot: _AI text below_ :robot:

## Summary
- `--installer` had no `default`, so `args.installer` was `None` at runtime even though it's typed as `_env.Installer` (`Literal['pip', 'uv']`) everywhere downstream. It only worked because callers just checked `== 'uv'`.
- Set `default='pip'` on the argparse option (matching the existing help text "defaults to pip") and tighten the `_Args` stub annotation from `_env.Installer | None` to `_env.Installer`.
- Updated `tests/test_main.py` assertions/defaults that previously expected `installer` to be `None`.

Part of the code review in #1116.
