### PR TITLE
fix: build correct dest path in Windows symlink support probe

### DIFF
--- a/docs/changelog/1118.bugfix.rst
+++ b/docs/changelog/1118.bugfix.rst
@@ -1,0 +1,2 @@
+Fix the Windows symlink support probe always returning ``False`` due to a stale object interpolated into the destination
+path - by :user:`henryiii`

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -501,7 +501,7 @@ def _fs_supports_symlink() -> bool:
 
     # Windows may support symlinks (setting in Windows 10)
     with tempfile.NamedTemporaryFile(prefix='build-symlink-') as tmp_file:  # pragma: win32 cover
-        dest = f'{tmp_file}-b'
+        dest = f'{tmp_file.name}-b'
         try:
             os.symlink(tmp_file.name, dest)
             os.unlink(dest)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -234,6 +234,43 @@ def test_venv_symlink(
     assert supports_symlink is has_symlink
 
 
+def test_fs_supports_symlink_windows_dest_is_tmp_file_path(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """Regression test for the Windows-only branch of ``_fs_supports_symlink``.
+
+    ``dest`` must be built from ``tmp_file.name``, not from the ``NamedTemporaryFile`` object itself: interpolating the
+    object yields its repr (containing ``<`` and ``>``, which are invalid in Windows filenames), so ``os.symlink`` would
+    always fail and the function would always report symlinks as unsupported, even when Windows Developer Mode enables
+    them.
+
+    """
+    mocker.patch('os.name', 'nt')
+
+    # Avoid exercising the real tempfile module: on some platforms tempfile's own
+    # internals branch on os.name, which we're patching to 'nt' above.
+    fake_tmp_file = mocker.MagicMock()
+    fake_tmp_file.name = r'C:\Users\test\AppData\Local\Temp\build-symlink-abc123'
+    fake_tmp_file.__enter__.return_value = fake_tmp_file
+    fake_tmp_file.__exit__.return_value = False
+    mocker.patch('build.env.tempfile.NamedTemporaryFile', return_value=fake_tmp_file)
+
+    recorded_dest = {}
+
+    def fake_symlink(_src: str, dst: str) -> None:
+        recorded_dest['dst'] = dst
+
+    mocker.patch('os.symlink', side_effect=fake_symlink)
+    mocker.patch('os.unlink')
+
+    build.env._fs_supports_symlink.cache_clear()
+    supports_symlink = build.env._fs_supports_symlink()
+    build.env._fs_supports_symlink.cache_clear()
+
+    assert supports_symlink is True
+    assert recorded_dest['dst'] == f'{fake_tmp_file.name}-b'
+
+
 def test_install_short_circuits(
     mocker: pytest_mock.MockerFixture,
 ) -> None:


### PR DESCRIPTION
I'm on macOS, so couldn't run the regression test. If there's any question about this, I can revert the fix and see if the CI fails.

:robot: _AI text below_ :robot:

## Summary

`_fs_supports_symlink()` in `src/build/env.py` builds a destination path for a symlink probe on Windows with:

```python
dest = f'{tmp_file}-b'
```

This interpolates the `NamedTemporaryFile` object's `repr()` (e.g. `<_TemporaryFileWrapper file=<_io.BufferedRandom name='...'>>`) instead of its `.name` attribute. Since `<` and `>` are invalid characters in Windows filenames, `os.symlink()` always raises `OSError`, so the function always returns `False` - even on systems where Windows Developer Mode has symlinks enabled. This silently prevents symlink-based venv creation from ever being used on Windows.

Fix: use `tmp_file.name` instead of `tmp_file`.

Part of the code review in #1116.
