### PR TITLE
fix: derive dist-info directory from wheel contents, not filename

### DIFF
--- a/docs/changelog/1119.bugfix.rst
+++ b/docs/changelog/1119.bugfix.rst
@@ -1,1 +1,2 @@
-Fix ``metadata_path``'s build-backend fallback returning a nonexistent dist-info path for wheels with a build tag - by :user:`henryiii`
+Fix ``metadata_path``'s build-backend fallback returning a nonexistent dist-info path for wheels with a build tag - by
+:user:`henryiii`

--- a/docs/changelog/1119.bugfix.rst
+++ b/docs/changelog/1119.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``metadata_path``'s build-backend fallback returning a nonexistent dist-info path for wheels with a build tag - by :user:`henryiii`

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -35,7 +35,7 @@ from ._exceptions import (
     BuildSystemTableValidationError,
     TypoWarning,
 )
-from ._util import check_dependency, parse_wheel_filename
+from ._util import check_dependency
 
 
 TYPE_CHECKING = False
@@ -372,16 +372,25 @@ class ProjectBuilder:
 
         # fallback to build_wheel hook
         wheel = self.build('wheel', output_directory)
-        match = parse_wheel_filename(os.path.basename(wheel))
-        if not match:
+        try:
+            with zipfile.ZipFile(wheel) as w:
+                names = w.namelist()
+        except (OSError, zipfile.BadZipFile) as exception:
+            msg = 'Invalid wheel'
+            raise ValueError(msg) from exception
+
+        # The dist-info directory name cannot be reliably derived from the wheel filename (e.g. a build
+        # tag makes the filename ambiguous), so find it by inspecting the wheel's contents instead.
+        metadata_names = [name for name in names if name.count('/') == 1 and name.endswith('.dist-info/METADATA')]
+        if len(metadata_names) != 1:
             msg = 'Invalid wheel'
             raise ValueError(msg)
-        distinfo = f'{match["distribution"]}-{match["version"]}.dist-info'
+        distinfo = metadata_names[0].rsplit('/', 1)[0]
         member_prefix = f'{distinfo}/'
         with zipfile.ZipFile(wheel) as w:
             w.extractall(
                 output_directory,
-                (member for member in w.namelist() if member.startswith(member_prefix)),
+                (member for member in names if member.startswith(member_prefix)),
             )
         return os.path.join(output_directory, distinfo)
 

--- a/src/build/_util.py
+++ b/src/build/_util.py
@@ -7,7 +7,6 @@ __lazy_modules__ = [
     'packaging.requirements',
 ]
 
-import re
 import sys
 
 import packaging.requirements
@@ -20,13 +19,6 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from collections.abc import Set as AbstractSet
-
-
-_WHEEL_FILENAME_REGEX = re.compile(
-    r'(?P<distribution>.+)-(?P<version>.+)'
-    r'(-(?P<build_tag>.+))?-(?P<python_tag>.+)'
-    r'-(?P<abi_tag>.+)-(?P<platform_tag>.+)\.whl'
-)
 
 
 def check_dependency(
@@ -89,7 +81,3 @@ def _format_missing_dependency(dep_chain: tuple[str, ...]) -> str:
 
 def _format_dep_chain(dep_chain: tuple[str, ...]) -> str:
     return ' -> '.join(dep.partition(';')[0].strip() for dep in dep_chain)
-
-
-def parse_wheel_filename(filename: str) -> re.Match[str] | None:
-    return _WHEEL_FILENAME_REGEX.match(filename)

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -554,6 +554,31 @@ def test_metadata_invalid_wheel(tmp_dir: str, package_test_bad_wheel: str) -> No
         builder.metadata_path(tmp_dir)
 
 
+@pytest.mark.parametrize('distinfo_dirs', [[], ['foo-1.0.dist-info', 'bar-2.0.dist-info']], ids=['zero', 'two'])
+def test_metadata_path_ambiguous_dist_info(
+    mocker: pytest_mock.MockerFixture, tmp_dir: str, package_test_flit: str, distinfo_dirs: list[str]
+) -> None:
+    # A wheel must contain exactly one dist-info directory; anything else is rejected.
+    hook = mocker.patch('pyproject_hooks.BuildBackendHookCaller', autospec=True).return_value
+
+    builder = build.ProjectBuilder(package_test_flit)
+    hook.prepare_metadata_for_build_wheel.side_effect = pyproject_hooks.HookMissing('prepare_metadata_for_build_wheel')
+
+    wheel_name = 'foo-1.0-py3-none-any.whl'
+
+    def fake_build_wheel(outdir: str, config_settings: Mapping[str, str] | None = None) -> str:  # noqa: ARG001
+        with zipfile.ZipFile(os.path.join(outdir, wheel_name), 'w') as zf:
+            zf.writestr('foo/__init__.py', '')
+            for distinfo_dir in distinfo_dirs:
+                zf.writestr(f'{distinfo_dir}/METADATA', 'Metadata-Version: 2.1\n')
+        return wheel_name
+
+    hook.build_wheel.side_effect = fake_build_wheel
+
+    with pytest.raises(ValueError, match='Invalid wheel'):
+        builder.metadata_path(tmp_dir)
+
+
 def test_metadata_path_no_prepare_build_tag(mocker: pytest_mock.MockerFixture, tmp_dir: str, package_test_flit: str) -> None:
     # Regression test for a wheel filename with a build tag (e.g. ``foo-1.0-1-py3-none-any.whl``):
     # the dist-info directory name must be read from the wheel's contents, not guessed from the

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -9,6 +9,7 @@ import pathlib
 import sys
 import textwrap
 import typing
+import zipfile
 
 from collections.abc import Callable
 from typing import TYPE_CHECKING, NoReturn
@@ -551,6 +552,32 @@ def test_metadata_invalid_wheel(tmp_dir: str, package_test_bad_wheel: str) -> No
 
     with pytest.raises(ValueError, match='Invalid wheel'):
         builder.metadata_path(tmp_dir)
+
+
+def test_metadata_path_no_prepare_build_tag(mocker: pytest_mock.MockerFixture, tmp_dir: str, package_test_flit: str) -> None:
+    # Regression test for a wheel filename with a build tag (e.g. ``foo-1.0-1-py3-none-any.whl``):
+    # the dist-info directory name must be read from the wheel's contents, not guessed from the
+    # (ambiguous) filename, since ``-1`` could be parsed as either the build tag or part of the version.
+    hook = mocker.patch('pyproject_hooks.BuildBackendHookCaller', autospec=True).return_value
+
+    builder = build.ProjectBuilder(package_test_flit)
+    hook.prepare_metadata_for_build_wheel.side_effect = pyproject_hooks.HookMissing('prepare_metadata_for_build_wheel')
+
+    wheel_name = 'foo-1.0-1-py3-none-any.whl'
+
+    def fake_build_wheel(outdir: str, config_settings: Mapping[str, str] | None = None) -> str:  # noqa: ARG001
+        with zipfile.ZipFile(os.path.join(outdir, wheel_name), 'w') as zf:
+            zf.writestr('foo-1.0.dist-info/METADATA', 'Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n')
+            zf.writestr('foo/__init__.py', '')
+        return wheel_name
+
+    hook.build_wheel.side_effect = fake_build_wheel
+
+    metadata_dir = builder.metadata_path(tmp_dir)
+
+    assert os.path.basename(metadata_dir) == 'foo-1.0.dist-info'
+    assert os.path.isdir(metadata_dir)
+    assert os.path.isfile(os.path.join(metadata_dir, 'METADATA'))
 
 
 def test_log(mocker: pytest_mock.MockerFixture, caplog: pytest.LogCaptureFixture, package_test_flit: str) -> None:


### PR DESCRIPTION
I think fixing the regex is also an option. But this seems fine and it looks like we already do it elsewhere.

:robot: _AI text below_ :robot:

## Summary
- `ProjectBuilder.metadata_path`'s fallback path (used when a backend lacks `prepare_metadata_for_build_wheel`) derived the wheel's dist-info directory name by parsing the wheel *filename* with a hand-rolled regex. That regex's greedy groups misparse build-tagged filenames — e.g. `foo-1.0-1-py3-none-any.whl` was read as distribution=`foo-1.0`, version=`1`, silently dropping the build tag — producing a dist-info name that doesn't exist in the wheel, so metadata extraction found nothing and returned a path that doesn't exist.
- Fixed by inspecting the built wheel's contents to find the single `*.dist-info/METADATA` entry instead of guessing from the filename, mirroring the existing approach in `_wheel_metadata` (`__main__.py`).
- Removed `_util.py`'s now-unused `parse_wheel_filename` / `_WHEEL_FILENAME_REGEX` (no remaining callers in `src/` or `tests/`).

Part of the code review in #1116.
