### PR TITLE
fix: use LF instead of os.linesep when writing pip/uv requirements files

### DIFF
--- a/docs/changelog/1120.bugfix.rst
+++ b/docs/changelog/1120.bugfix.rst
@@ -1,0 +1,2 @@
+Write pip/uv requirements and constraints files with ``\n`` instead of ``os.linesep``, avoiding doubled ``\r\r\n`` line
+endings on Windows - by :user:`henryiii`

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -414,7 +414,7 @@ class _PipBackend(_EnvBackend):
             with tempfile.NamedTemporaryFile(
                 'w', prefix='build-requirements-', suffix='.txt', delete=False, encoding='utf-8'
             ) as requirement_file:
-                requirement_file.write(os.linesep.join(requirements))
+                requirement_file.write('\n'.join(requirements))
             exit_stack.callback(functools.partial(os.unlink, requirement_file.name))
 
             cmd += ['-r', os.path.abspath(requirement_file.name)]
@@ -423,7 +423,7 @@ class _PipBackend(_EnvBackend):
                 with tempfile.NamedTemporaryFile(
                     'w', prefix='build-constraints-', suffix='.txt', delete=False, encoding='utf-8'
                 ) as constraint_file:
-                    constraint_file.write(os.linesep.join(constraints))
+                    constraint_file.write('\n'.join(constraints))
                 exit_stack.callback(functools.partial(os.unlink, constraint_file.name))
 
                 cmd += ['-c', os.path.abspath(constraint_file.name)]
@@ -476,7 +476,7 @@ class _UvBackend(_EnvBackend):
                 with tempfile.NamedTemporaryFile(
                     'w', prefix='build-constraints-', suffix='.txt', delete=False, encoding='utf-8'
                 ) as constraint_file:
-                    constraint_file.write(os.linesep.join(constraints))
+                    constraint_file.write('\n'.join(constraints))
                 exit_stack.callback(functools.partial(os.unlink, constraint_file.name))
 
                 cmd += ['-c', os.path.abspath(constraint_file.name)]

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -322,6 +322,50 @@ def test_uv_impl_install_cmd_well_formed(  # pragma: no cover -- uv tests are sk
 
 
 @pytest.mark.usefixtures('local_pip')
+def test_default_impl_install_files_have_lf_line_endings(mocker: pytest_mock.MockerFixture) -> None:
+    # The requirements/constraints files are opened in text mode, which translates every
+    # '\n' written to os.linesep. Joining with os.linesep first (instead of '\n') would
+    # double-translate on Windows, turning '\r\n' into '\r\r\n'. Read back as bytes, before
+    # the files are deleted by the install_dependencies() ExitStack, to catch that.
+    written: dict[str, bytes] = {}
+
+    def fake_run_subprocess(cmd: list[str], **_kwargs: object) -> None:
+        args = iter(cmd)
+        for arg in args:
+            if arg == '-r':
+                written['requirements'] = Path(next(args)).read_bytes()
+            elif arg == '-c':
+                written['constraints'] = Path(next(args)).read_bytes()
+
+    with build.env.DefaultIsolatedEnv() as env:
+        mocker.patch('build.env.run_subprocess', side_effect=fake_run_subprocess)
+        env.install(['some', 'requirements'], ['a-constraint'])
+
+    assert written['requirements'] == b'some\nrequirements'
+    assert written['constraints'] == b'a-constraint'
+
+
+@pytest.mark.skipif(IS_PYPY, reason='uv cannot find PyPy executable')
+@pytest.mark.skipif(MISSING_UV, reason='uv executable not found')
+def test_uv_impl_install_files_have_lf_line_endings(  # pragma: no cover -- uv tests are skipped on PyPy, covered on CPython
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    written: dict[str, bytes] = {}
+
+    def fake_run_subprocess(cmd: list[str], **_kwargs: object) -> None:
+        args = iter(cmd)
+        for arg in args:
+            if arg == '-c':
+                written['constraints'] = Path(next(args)).read_bytes()
+
+    with build.env.DefaultIsolatedEnv(installer='uv') as env:
+        mocker.patch('build.env.run_subprocess', side_effect=fake_run_subprocess)
+        env.install(['some', 'requirements'], ['a-constraint'])
+
+    assert written['constraints'] == b'a-constraint'
+
+
+@pytest.mark.usefixtures('local_pip')
 @pytest.mark.parametrize(
     ('installer', 'env_backend_display_name', 'has_virtualenv'),
     [

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -322,11 +322,12 @@ def test_uv_impl_install_cmd_well_formed(  # pragma: no cover -- uv tests are sk
 
 
 @pytest.mark.usefixtures('local_pip')
-def test_default_impl_install_files_have_lf_line_endings(mocker: pytest_mock.MockerFixture) -> None:
+def test_default_impl_install_files_line_endings_not_doubled(mocker: pytest_mock.MockerFixture) -> None:
     # The requirements/constraints files are opened in text mode, which translates every
-    # '\n' written to os.linesep. Joining with os.linesep first (instead of '\n') would
-    # double-translate on Windows, turning '\r\n' into '\r\r\n'. Read back as bytes, before
-    # the files are deleted by the install_dependencies() ExitStack, to catch that.
+    # '\n' written to os.linesep -- '\r\n' on disk is correct on Windows. Joining with
+    # os.linesep first (instead of '\n') would double-translate there, turning '\r\n' into
+    # '\r\r\n'. Read back as bytes, before the files are deleted by the
+    # install_dependencies() ExitStack, to catch that.
     written: dict[str, bytes] = {}
 
     def fake_run_subprocess(cmd: list[str], **_kwargs: object) -> None:
@@ -339,15 +340,17 @@ def test_default_impl_install_files_have_lf_line_endings(mocker: pytest_mock.Moc
 
     with build.env.DefaultIsolatedEnv() as env:
         mocker.patch('build.env.run_subprocess', side_effect=fake_run_subprocess)
-        env.install(['some', 'requirements'], ['a-constraint'])
+        env.install(['some', 'requirements'], ['a-constraint', 'b-constraint'])
 
-    assert written['requirements'] == b'some\nrequirements'
-    assert written['constraints'] == b'a-constraint'
+    assert b'\r\r' not in written['requirements']
+    assert written['requirements'].splitlines() == [b'some', b'requirements']
+    assert b'\r\r' not in written['constraints']
+    assert written['constraints'].splitlines() == [b'a-constraint', b'b-constraint']
 
 
 @pytest.mark.skipif(IS_PYPY, reason='uv cannot find PyPy executable')
 @pytest.mark.skipif(MISSING_UV, reason='uv executable not found')
-def test_uv_impl_install_files_have_lf_line_endings(  # pragma: no cover -- uv tests are skipped on PyPy, covered on CPython
+def test_uv_impl_install_files_line_endings_not_doubled(  # pragma: no cover -- skipped on PyPy, covered on CPython
     mocker: pytest_mock.MockerFixture,
 ) -> None:
     written: dict[str, bytes] = {}
@@ -360,9 +363,10 @@ def test_uv_impl_install_files_have_lf_line_endings(  # pragma: no cover -- uv t
 
     with build.env.DefaultIsolatedEnv(installer='uv') as env:
         mocker.patch('build.env.run_subprocess', side_effect=fake_run_subprocess)
-        env.install(['some', 'requirements'], ['a-constraint'])
+        env.install(['some', 'requirements'], ['a-constraint', 'b-constraint'])
 
-    assert written['constraints'] == b'a-constraint'
+    assert b'\r\r' not in written['constraints']
+    assert written['constraints'].splitlines() == [b'a-constraint', b'b-constraint']
 
 
 @pytest.mark.usefixtures('local_pip')


### PR DESCRIPTION
I'm not on Windows, but this seems correct. You aren't supposed to use linesep in text mode.

:robot: _AI text below_ :robot:

## Summary

- `src/build/env.py` writes the pip requirements file, the pip constraints file, and the uv constraints file via `tempfile.NamedTemporaryFile('w', ...)` (text mode, default `newline=None`) and `os.linesep.join(...)`.
- Text mode already translates every `\n` written to `os.linesep` on output. On Windows, `os.linesep` is `'\r\n'`, so joining with it first inserts literal `\r\n` between lines, and the text-mode translation then turns each of *those* `\n` into `\r\n` as well, producing `\r\r\n` line endings.
- pip and uv happen to tolerate this today because they strip line whitespace when parsing requirements/constraints files, so no user-visible breakage — but it's incorrect and fragile.
- Fix: join with `'\n'` in all three places and let the text-mode file object perform the OS-appropriate newline translation on write.

Part of the code review in #1116.