### PR TITLE
fix: minor robustness fixes from code review

### DIFF
--- a/docs/changelog/1121.bugfix.rst
+++ b/docs/changelog/1121.bugfix.rst
@@ -1,0 +1,3 @@
+Batch of small robustness fixes: correct macOS release parsing for the minimum pip version, avoid sharing the mutable
+default build-system table between builders, keep the original error when isolated-environment setup fails early, and
+raise ``BuildException`` for an invalid wheel - by :user:`henryiii`

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -108,10 +108,10 @@ def _read_pyproject_toml(path: StrPath) -> Mapping[str, TOMLValue]:
     except FileNotFoundError:
         return {}
     except PermissionError as e:  # pragma: win32 no cover
-        msg = f"{e.strerror}: '{e.filename}' "
+        msg = f"{e.strerror}: '{e.filename}'"
         raise BuildException(msg) from None
     except tomllib.TOMLDecodeError as e:
-        msg = f'Failed to parse {path}: {e} '
+        msg = f'Failed to parse {path}: {e}'
         raise BuildException(msg) from None
 
 
@@ -120,7 +120,9 @@ def _parse_build_system_table(pyproject_toml: Mapping[str, TOMLValue]) -> BuildS
     # (per PEP 518), use default values
     if 'build-system' not in pyproject_toml:
         _find_typo(pyproject_toml, 'build-system')
-        return _DEFAULT_BACKEND
+        # Return a fresh copy so callers mutating the result (e.g. the ``requires``
+        # list) cannot corrupt the shared default for later builders.
+        return {**_DEFAULT_BACKEND, 'requires': list(_DEFAULT_BACKEND['requires'])}
 
     build_system = pyproject_toml['build-system']
     if not isinstance(build_system, dict):
@@ -376,7 +378,7 @@ class ProjectBuilder:
             whl = zipfile.ZipFile(wheel)
         except (OSError, zipfile.BadZipFile) as exception:
             msg = 'Invalid wheel'
-            raise ValueError(msg) from exception
+            raise BuildException(msg) from exception
 
         with whl:
             names = whl.namelist()
@@ -385,7 +387,7 @@ class ProjectBuilder:
             metadata_names = [name for name in names if name.count('/') == 1 and name.endswith('.dist-info/METADATA')]
             if len(metadata_names) != 1:
                 msg = 'Invalid wheel'
-                raise ValueError(msg)
+                raise BuildException(msg)
             distinfo = metadata_names[0].rsplit('/', 1)[0]
             member_prefix = f'{distinfo}/'
             whl.extractall(

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -131,6 +131,8 @@ class DefaultIsolatedEnv(IsolatedEnv):
                         raise BuildException(msg)
             os.makedirs(path, exist_ok=True)
 
+        # Set early so ``__exit__`` can clean up even if the calls below fail.
+        self._path = path
         try:
             # Call ``realpath`` to prevent spurious warning from being emitted
             # that the venv location has changed on Windows for the venv impl.
@@ -314,7 +316,8 @@ class _PipBackend(_EnvBackend):
     def _get_minimum_pip_version_str() -> str:
         if platform.system() == 'Darwin':
             release, _, machine = platform.mac_ver()
-            if int(release[: release.find('.')]) >= 11:
+            major = release.split('.', 1)[0]
+            if major and int(major) >= 11:
                 # macOS 11+ name scheme change requires 20.3. Intel macOS 11.0 can be
                 # told to report 10.16 for backwards compatibility; but that also fixes
                 # earlier versions of pip so this is only needed for 11+.

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -506,6 +506,49 @@ def test_get_minimum_pip_version_old_darwin(
 
 
 @pytest.mark.parametrize(
+    ('release', 'machine', 'expected'),
+    [
+        # A dot-less release must not have its last digit truncated.
+        ('15', 'arm64', '21.0.1'),
+        ('15', 'x86_64', '20.3.0'),
+        # The 10.16 backwards-compatibility report maps to the pre-11 minimum.
+        ('10.16', 'x86_64', '19.1.0'),
+        # An empty release must not raise, and falls back to the generic minimum.
+        ('', 'x86_64', '19.1.0'),
+    ],
+)
+def test_get_minimum_pip_version_darwin_release_parsing(
+    mocker: pytest_mock.MockerFixture,
+    release: str,
+    machine: str,
+    expected: str,
+) -> None:
+    mocker.patch('platform.system', return_value='Darwin')
+    mocker.patch('platform.mac_ver', return_value=(release, ('', '', ''), machine))
+    assert build.env._PipBackend._get_minimum_pip_version_str() == expected
+
+
+def test_isolated_env_enter_failure_before_path_set(
+    mocker: pytest_mock.MockerFixture,
+    tmp_path: Path,
+) -> None:
+    # If setup fails before ``self._path`` is assigned, the original exception must
+    # propagate (not an AttributeError from ``__exit__``), and the temp dir cleaned up.
+    class _DistinctError(Exception):
+        pass
+
+    env_dir = tmp_path / 'build-env'
+    env_dir.mkdir()
+    mocker.patch('build.env.tempfile.mkdtemp', return_value=str(env_dir))
+    mocker.patch('build.env.os.path.realpath', side_effect=_DistinctError('boom'))
+
+    with pytest.raises(_DistinctError, match='boom'), build.env.DefaultIsolatedEnv():
+        pass
+
+    assert not env_dir.exists()
+
+
+@pytest.mark.parametrize(
     ('version', 'has_no_wheel'),
     [
         pytest.param('20.30.0', True, id='old'),

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -542,8 +542,8 @@ def test_isolated_env_enter_failure_before_path_set(
     mocker.patch('build.env.tempfile.mkdtemp', return_value=str(env_dir))
     mocker.patch('build.env.os.path.realpath', side_effect=_DistinctError('boom'))
 
-    with pytest.raises(_DistinctError, match='boom'), build.env.DefaultIsolatedEnv():
-        pass
+    with pytest.raises(_DistinctError, match='boom'):
+        build.env.DefaultIsolatedEnv().__enter__()
 
     assert not env_dir.exists()
 

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -550,7 +550,7 @@ def test_metadata_path_legacy(tmp_dir: str, package_legacy: str) -> None:
 def test_metadata_invalid_wheel(tmp_dir: str, package_test_bad_wheel: str) -> None:
     builder = build.ProjectBuilder(package_test_bad_wheel)
 
-    with pytest.raises(ValueError, match='Invalid wheel'):
+    with pytest.raises(build.BuildException, match='Invalid wheel'):
         builder.metadata_path(tmp_dir)
 
 
@@ -575,7 +575,7 @@ def test_metadata_path_ambiguous_dist_info(
 
     hook.build_wheel.side_effect = fake_build_wheel
 
-    with pytest.raises(ValueError, match='Invalid wheel'):
+    with pytest.raises(build.BuildException, match='Invalid wheel'):
         builder.metadata_path(tmp_dir)
 
 
@@ -645,6 +645,15 @@ def test_log(mocker: pytest_mock.MockerFixture, caplog: pytest.LogCaptureFixture
 )
 def test_parse_valid_build_system_table_type(pyproject_toml: Mapping[str, TOMLValue], parse_output: BuildSystemTable) -> None:
     assert build._builder._parse_build_system_table(pyproject_toml) == parse_output
+
+
+def test_parse_default_build_system_table_not_shared() -> None:
+    # A caller mutating the returned default table must not affect later callers.
+    first = build._builder._parse_build_system_table({})
+    first['requires'].append('mutated')
+
+    second = build._builder._parse_build_system_table({})
+    assert second['requires'] == ['setuptools >= 40.8.0']
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I need to edit this a bit, leaving it in draft until I do.

:robot: _AI text below_ :robot:

A batch of minor robustness fixes found during code review.

Part of the code review in #1116.

1. **`env._get_minimum_pip_version_str`**: parse the macOS release with `split(".", 1)[0]` instead of slicing at `find(".")`. The old code truncated the last digit of a dot-less release (e.g. `"15"` became `"1"`) and raised `ValueError` on an empty release. An empty release now falls back to the generic minimum.
2. **`_builder._parse_build_system_table`**: return a fresh copy of the default build-system table (including a fresh `requires` list) so a caller mutating the result cannot corrupt the shared module-level default for every later builder in the process.
3. **`env.DefaultIsolatedEnv.__enter__`**: assign `self._path` before calling `os.path.realpath`, so a failure there no longer masks the original exception with an `AttributeError` from `__exit__` and no longer leaks the `mkdtemp` directory.
4. **`_builder.metadata_path`**: raise `BuildException` (not a bare `ValueError`) for an invalid wheel, so the CLI renders it nicely like every other failure in this package.
5. **`_builder._read_pyproject_toml`**: remove stray trailing spaces from two error messages.

Regression tests were added for items 1-4 (test-first, confirmed failing before the fixes).