### PR TITLE
fix: decide color support per output stream, not solely from stdout

### DIFF
--- a/docs/changelog/1123.bugfix.rst
+++ b/docs/changelog/1123.bugfix.rst
@@ -1,0 +1,2 @@
+Decide color support independently for stdout and stderr instead of only checking ``stdout.isatty()``, so redirecting
+one stream no longer disables or leaks ANSI colors on the other - by :user:`henryiii`

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -108,23 +108,25 @@ _NO_COLORS = dict.fromkeys(_COLORS, '')
 
 
 _DEFAULT_STYLES = {'stdout': _COLORS, 'stderr': _COLORS}
-_styles: contextvars.ContextVar[dict[str, dict[str, str]]] = contextvars.ContextVar('_styles', default=_DEFAULT_STYLES)
+_styles = contextvars.ContextVar('_styles', default=_DEFAULT_STYLES)
 
 
 def _init_colors() -> None:
-    if 'NO_COLOR' in os.environ:
-        if 'FORCE_COLOR' in os.environ:
+    match os.environ:
+        case {'NO_COLOR': _, 'FORCE_COLOR': _}:
             warnings.warn('Both NO_COLOR and FORCE_COLOR environment variables are set, disabling color', stacklevel=2)
-        _styles.set({'stdout': _NO_COLORS, 'stderr': _NO_COLORS})
-    elif 'FORCE_COLOR' in os.environ:
-        _styles.set({'stdout': _COLORS, 'stderr': _COLORS})
-    else:
-        _styles.set(
-            {
-                'stdout': _COLORS if sys.stdout.isatty() else _NO_COLORS,
-                'stderr': _COLORS if sys.stderr.isatty() else _NO_COLORS,
-            }
-        )
+            _styles.set({'stdout': _NO_COLORS, 'stderr': _NO_COLORS})
+        case {'NO_COLOR': _}:
+            _styles.set({'stdout': _NO_COLORS, 'stderr': _NO_COLORS})
+        case {'FORCE_COLOR': _}:
+            _styles.set({'stdout': _COLORS, 'stderr': _COLORS})
+        case _:
+            _styles.set(
+                {
+                    'stdout': _COLORS if sys.stdout.isatty() else _NO_COLORS,
+                    'stderr': _COLORS if sys.stderr.isatty() else _NO_COLORS,
+                }
+            )
 
 
 def _cprint(fmt: str = '', msg: str = '', file: TextIO | None = None) -> None:

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -107,20 +107,30 @@ _COLORS = {
 _NO_COLORS = dict.fromkeys(_COLORS, '')
 
 
-_styles = contextvars.ContextVar('_styles', default=_COLORS)
+_DEFAULT_STYLES = {'stdout': _COLORS, 'stderr': _COLORS}
+_styles: contextvars.ContextVar[dict[str, dict[str, str]]] = contextvars.ContextVar('_styles', default=_DEFAULT_STYLES)
 
 
 def _init_colors() -> None:
     if 'NO_COLOR' in os.environ:
         if 'FORCE_COLOR' in os.environ:
             warnings.warn('Both NO_COLOR and FORCE_COLOR environment variables are set, disabling color', stacklevel=2)
-    elif 'FORCE_COLOR' in os.environ or sys.stdout.isatty():
-        return
-    _styles.set(_NO_COLORS)
+        _styles.set({'stdout': _NO_COLORS, 'stderr': _NO_COLORS})
+    elif 'FORCE_COLOR' in os.environ:
+        _styles.set({'stdout': _COLORS, 'stderr': _COLORS})
+    else:
+        _styles.set(
+            {
+                'stdout': _COLORS if sys.stdout.isatty() else _NO_COLORS,
+                'stderr': _COLORS if sys.stderr.isatty() else _NO_COLORS,
+            }
+        )
 
 
 def _cprint(fmt: str = '', msg: str = '', file: TextIO | None = None) -> None:
-    print(fmt.format(msg, **_styles.get()), file=file, flush=True)
+    stream = file or sys.stdout
+    key = 'stderr' if stream is sys.stderr else 'stdout'
+    print(fmt.format(msg, **_styles.get()[key]), file=file, flush=True)
 
 
 def _showwarning(
@@ -747,7 +757,7 @@ def main(cli_args: Sequence[str], prog: str | None = None) -> None:
             _write_report(args.report, outdir, built)
         if _ctx.verbosity >= -1 and built:
             artifact_list = _natural_language_list(
-                ['{underline}{}{reset}{bold}{green}'.format(artifact, **_styles.get()) for artifact in built]
+                ['{underline}{}{reset}{bold}{green}'.format(artifact, **_styles.get()['stdout']) for artifact in built]
             )
             _cprint('{bold}{green}Successfully built {}{reset}', artifact_list)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -642,30 +642,38 @@ def test_logging_output_env_subprocess_error(
 
 
 @pytest.mark.parametrize(
-    ('tty', 'env', 'colors'),
+    ('stdout_tty', 'stderr_tty', 'env', 'stdout_colors', 'stderr_colors'),
     [
-        (False, {}, build.__main__._NO_COLORS),
-        (True, {}, build.__main__._COLORS),
-        (False, {'NO_COLOR': ''}, build.__main__._NO_COLORS),
-        (True, {'NO_COLOR': ''}, build.__main__._NO_COLORS),
-        (False, {'FORCE_COLOR': ''}, build.__main__._COLORS),
-        (True, {'FORCE_COLOR': ''}, build.__main__._COLORS),
+        (False, False, {}, build.__main__._NO_COLORS, build.__main__._NO_COLORS),
+        (True, True, {}, build.__main__._COLORS, build.__main__._COLORS),
+        # regression: color support must be decided per-stream, not solely from stdout.
+        (False, True, {}, build.__main__._NO_COLORS, build.__main__._COLORS),
+        (True, False, {}, build.__main__._COLORS, build.__main__._NO_COLORS),
+        (False, False, {'NO_COLOR': ''}, build.__main__._NO_COLORS, build.__main__._NO_COLORS),
+        (True, True, {'NO_COLOR': ''}, build.__main__._NO_COLORS, build.__main__._NO_COLORS),
+        (False, False, {'FORCE_COLOR': ''}, build.__main__._COLORS, build.__main__._COLORS),
+        (True, True, {'FORCE_COLOR': ''}, build.__main__._COLORS, build.__main__._COLORS),
     ],
 )
 def test_colors(
     mocker: pytest_mock.MockerFixture,
     monkeypatch: pytest.MonkeyPatch,
-    tty: bool,
+    stdout_tty: bool,
+    stderr_tty: bool,
     env: dict[str, str],
-    colors: dict[str, object],
+    stdout_colors: dict[str, object],
+    stderr_colors: dict[str, object],
 ) -> None:
-    mocker.patch('sys.stdout.isatty', return_value=tty)
+    mocker.patch('sys.stdout.isatty', return_value=stdout_tty)
+    mocker.patch('sys.stderr.isatty', return_value=stderr_tty)
     for key, value in env.items():
         monkeypatch.setenv(key, value)
 
     build.__main__._init_colors()
 
-    assert build.__main__._styles.get() == colors
+    styles = build.__main__._styles.get()
+    assert styles['stdout'] == stdout_colors
+    assert styles['stderr'] == stderr_colors
 
 
 def test_colors_conflict(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -679,7 +687,31 @@ def test_colors_conflict(monkeypatch: pytest.MonkeyPatch) -> None:
         ):
             build.__main__._init_colors()
 
-        assert build.__main__._styles.get() == build.__main__._NO_COLORS
+        styles = build.__main__._styles.get()
+        assert styles['stdout'] == build.__main__._NO_COLORS
+        assert styles['stderr'] == build.__main__._NO_COLORS
+
+
+def test_cprint_selects_style_per_stream(mocker: pytest_mock.MockerFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+    """stderr output is colored independently of stdout, based on its own tty-ness."""
+    monkeypatch.delenv('NO_COLOR', raising=False)
+    monkeypatch.delenv('FORCE_COLOR', raising=False)
+
+    # stdout is not a tty (e.g. redirected to a log file), stderr is a tty.
+    mocker.patch('sys.stdout.isatty', return_value=False)
+    mocker.patch('sys.stderr.isatty', return_value=True)
+    build.__main__._init_colors()
+
+    assert build.__main__._styles.get()['stdout'] == build.__main__._NO_COLORS
+    assert build.__main__._styles.get()['stderr'] == build.__main__._COLORS
+
+    # the inverse: stdout is a tty, stderr is redirected.
+    mocker.patch('sys.stdout.isatty', return_value=True)
+    mocker.patch('sys.stderr.isatty', return_value=False)
+    build.__main__._init_colors()
+
+    assert build.__main__._styles.get()['stdout'] == build.__main__._COLORS
+    assert build.__main__._styles.get()['stderr'] == build.__main__._NO_COLORS
 
 
 def test_logging_output_venv_failure(


### PR DESCRIPTION
I did a bit of cleanup (see last commit), I think this is ready.

:robot: _AI text below_ :robot:

## Summary

Part of the code review in #1116.

- `_init_colors` decided color support solely from `sys.stdout.isatty()`, but nearly all colored output (log lines, warnings, TIP hints, tracebacks, `_error`) is written to **stderr**; only the final "Successfully built ..." message goes to stdout. This meant `python -m build > log` needlessly disabled colors on a tty stderr, and `python -m build 2> log` wrote raw ANSI escapes into the log while stdout was a tty.
- `_styles` now holds a `{'stdout': ..., 'stderr': ...}` mapping instead of a single style set, and `_cprint(fmt, msg, file)` picks the style set for its target stream (`file or sys.stdout`).
- `NO_COLOR` still disables color on both streams (keeping the existing warning when both `NO_COLOR` and `FORCE_COLOR` are set), and `FORCE_COLOR` still enables color on both streams. Otherwise each stream gets color independently based on its own `.isatty()`.
- Updated the direct `_styles.get()` use in `main()`'s success message to use the stdout styles.

## Test plan

- [x] Added a regression test (`test_colors`, extended; `test_cprint_selects_style_per_stream`, new) covering stdout-tty/stderr-non-tty and the inverse, confirmed it fails on the old single-stream logic and passes after the fix.
- [x] `uv run --group test pytest` (285 passed)
- [x] `uv run --group mypy mypy` (clean)
- [x] `prek -a --quiet` (clean)