### PR TITLE
tests: check send CLI warnings to stderr instead of stdout

### DIFF
--- a/docs/changelog/1125.bugfix.rst
+++ b/docs/changelog/1125.bugfix.rst
@@ -1,0 +1,2 @@
+Send CLI warnings to stderr instead of stdout, so they no longer corrupt ``--metadata``'s JSON output - by
+:user:`henryiii`

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -757,6 +757,34 @@ def test_metadata_json_output(
     assert metadata['version'] == '1.0.0'
 
 
+def test_showwarning_writes_to_stderr(capsys: pytest.CaptureFixture[str]) -> None:
+    build.__main__._showwarning('some warning message', UserWarning, 'somefile.py', 1)
+
+    out, err = capsys.readouterr()
+
+    assert out == ''
+    assert 'WARNING' in err
+    assert 'some warning message' in err
+
+
+@pytest.mark.filterwarnings('always::UserWarning')
+def test_metadata_json_output_not_corrupted_by_warning(
+    capsys: pytest.CaptureFixture[str],
+    package_test_setuptools: str,
+) -> None:
+    # A warning emitted during the build (here, pip-incompatible bare --config-setting)
+    # must not land on stdout, or it would corrupt the --metadata JSON output.
+    build.__main__.main([package_test_setuptools, '--metadata', '-n', '-C--flag'])
+
+    stdout, stderr = capsys.readouterr()
+
+    metadata = json.loads(stdout)
+    assert metadata['name'] in {'test_setuptools', 'test-setuptools'}
+
+    assert 'WARNING' in stderr
+    assert "Config setting '--flag' was passed without a value" in stderr
+
+
 def test_setup_cli_windows_colorama_available(mocker: pytest_mock.MockerFixture) -> None:
     mocker.patch('platform.system', return_value='Windows')
     colorama = mocker.MagicMock()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary
- `_showwarning` forwarded the (normally `None`) `file` argument straight to `_cprint`, which defaults `print()`'s `file=` to stdout, so warnings landed on stdout while every other CLI diagnostic (`_error`, the logger, TIPs) goes to stderr.
- This corrupts machine-readable output: a `TypoWarning` or the valueless `--config-setting` warning printed in the middle of `--metadata`'s JSON breaks `json.loads` for consumers.
- Fix: default the destination to `sys.stderr` when `file` is `None`.

Part of the code review in #1116.

## Test plan
- Added `test_showwarning_writes_to_stderr`, a direct unit test confirming `_showwarning` writes to stderr and not stdout.
- Added `test_metadata_json_output_not_corrupted_by_warning`, an end-to-end regression test that reproduces the exact JSON-corruption bug (`--metadata` + a bare `--config-setting`) and confirms it no longer occurs.
- Both tests fail with the pre-fix code (the second with `json.decoder.JSONDecodeError`) and pass after the fix.
- [x] `uv run --group test pytest`
- [x] `uv run --group mypy mypy`
- [x] `prek -a --quiet`