### PR TITLE
test: isolate color tests from NO_COLOR and FORCE_COLOR

### DIFF
--- a/docs/changelog/1128.misc.rst
+++ b/docs/changelog/1128.misc.rst
@@ -1,0 +1,1 @@
+Isolate color tests from externally set ``NO_COLOR`` and ``FORCE_COLOR`` environment variables - by :user:`Yearnzq`

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -669,6 +669,8 @@ def test_colors(
 ) -> None:
     mocker.patch('sys.stdout.isatty', return_value=stdout_tty)
     mocker.patch('sys.stderr.isatty', return_value=stderr_tty)
+    monkeypatch.delenv('NO_COLOR', raising=False)
+    monkeypatch.delenv('FORCE_COLOR', raising=False)
     for key, value in env.items():
         monkeypatch.setenv(key, value)
 


### PR DESCRIPTION
## Summary
- Clear externally set `NO_COLOR` and `FORCE_COLOR` in `test_colors` before applying the parametrized environment.
- Add a changelog fragment for the test isolation fix.

## Rationale
`test_colors` should be controlled only by its parametrized `env` input. If a developer shell already has `NO_COLOR` or `FORCE_COLOR` set, the test can observe that external state and fail for reasons unrelated to the case under test.

## Validation
- `NO_COLOR=1 FORCE_COLOR=1 python -m pytest tests/test_main.py::test_colors -q` (8 passed)