### PR TITLE
Let yamlfmt format the workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,5 +1,4 @@
 name: CD
-
 on:
   workflow_dispatch:
   pull_request:
@@ -12,13 +11,10 @@ on:
   release:
     types:
       - published
-
 concurrency:
   group: cd-${{ github.ref }}
   cancel-in-progress: true
-
 permissions: {}
-
 jobs:
   dist:
     name: Build distribution
@@ -29,9 +25,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-
       - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
-
   create-release:
     name: Create GitHub Release
     needs: [dist]
@@ -44,13 +38,11 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-
       - name: Create GitHub Release
         run: gh release create "$RELEASE_TAG" --generate-notes
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.ref_name }}
-
   publish:
     name: Publish to PyPI
     needs: [dist]
@@ -62,16 +54,13 @@ jobs:
     permissions:
       id-token: write # to sign attestation
       attestations: write # to create attestation
-
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: Packages
           path: dist
-
       - name: Generate artifact attestation for sdist and wheel
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: "dist/build-*"
-
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -12,13 +12,10 @@ on:
           - minor
           - patch
         default: auto
-
 concurrency:
   group: pre-release-${{ github.ref }}
   cancel-in-progress: true
-
 permissions: {}
-
 jobs:
   pre-release:
     name: Pre-release

--- a/.github/workflows/reusable-change-detection.yml
+++ b/.github/workflows/reusable-change-detection.yml
@@ -8,9 +8,7 @@ on:
       run-tests:
         description: Whether or not run the tests
         value: ${{ jobs.change-detection.outputs.run-tests || false }}
-
 permissions: {}
-
 jobs:
   change-detection:
     name: Identify source changes
@@ -38,8 +36,7 @@ jobs:
             .github/workflows/reusable-pytest.yml
       - name: Set a flag for running the tests
         if: >-
-          github.event_name != 'pull_request'
-          || steps.changed-testable-files.outputs.added_modified_renamed != ''
+          github.event_name != 'pull_request' || steps.changed-testable-files.outputs.added_modified_renamed != ''
         id: tests-changes
         run: >-
           echo "run-tests=true" >> "${GITHUB_OUTPUT}"
@@ -56,8 +53,7 @@ jobs:
             .github/workflows/reusable-docs.yml
       - name: Set a flag for building the docs
         if: >-
-          github.event_name != 'pull_request'
-          || steps.changed-docs-files.outputs.added_modified_renamed != ''
+          github.event_name != 'pull_request' || steps.changed-docs-files.outputs.added_modified_renamed != ''
         id: docs-changes
         run: >-
           echo "run-docs=true" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -1,9 +1,7 @@
 name: check
 on:
   workflow_call:
-
 permissions: {}
-
 jobs:
   docs:
     name: Build docs
@@ -15,17 +13,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-
       - name: Setup Python 3.12
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
-
       - name: Install tox
         run: python -m pip install tox
-
       - name: Setup run environment
         run: tox -vv --notest -e docs
-
       - name: Run check for docs
         run: tox -e docs --skip-pkg-install

--- a/.github/workflows/reusable-pytest.yml
+++ b/.github/workflows/reusable-pytest.yml
@@ -1,9 +1,7 @@
 name: pytest
 on:
   workflow_call:
-
 permissions: {}
-
 jobs:
   pytest:
     name: Run tests
@@ -29,35 +27,22 @@ jobs:
         tox-target:
           - "tox"
           - "min"
-
-    continue-on-error: >- # jobs not required in branch protection
-      ${{
-        (
-          startsWith(matrix.py, 'pypy')
-          && matrix.os == 'windows'
-        )
-        && true
-        || false
-      }}
-
+    # jobs not required in branch protection
+    continue-on-error: ${{ (startsWith(matrix.py, 'pypy') && matrix.os == 'windows') && true || false }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
-
       - name: Setup uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-
       - name: Install tox (uv)
         run: uv tool install tox --with tox-uv
-
       - name: Setup python for test ${{ matrix.py }}
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.py }}
           allow-prereleases: true
-
       - name: Run test suite via tox
         if: matrix.tox-target == 'tox'
         shell: bash
@@ -68,7 +53,6 @@ jobs:
           tox -e $BASE --skip-pkg-install
         env:
           PYTHON_VERSION_RAW: ${{ matrix.py }}
-
       - name: Run minimum version test
         if: matrix.tox-target == 'min'
         shell: bash
@@ -79,15 +63,12 @@ jobs:
         env:
           PYTHON_VERSION_RAW: ${{ matrix.py }}
           TOX_TARGET: ${{ matrix.tox-target }}
-
       - name: Run path test
         if: matrix.tox-target == 'tox' && matrix.py == '3.10'
         run: tox -e path
-
       - name: Combine coverage files
         if: always()
         run: tox -e coverage
-
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: always()
         env:

--- a/.github/workflows/reusable-type.yml
+++ b/.github/workflows/reusable-type.yml
@@ -1,9 +1,7 @@
 name: type
 on:
   workflow_call:
-
 permissions: {}
-
 jobs:
   type:
     name: Type check
@@ -15,17 +13,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-
       - name: Setup Python 3.10
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.10"
-
       - name: Install tox
         run: python -m pip install tox
-
       - name: Setup run environment
         run: tox -vv --notest -e type
-
       - name: Run check for type
         run: tox -e type --skip-pkg-install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,63 +9,39 @@ on:
   schedule:
     - cron: "0 8 * * 1"
   workflow_dispatch:
-
 concurrency:
   group: test-${{ github.ref }}
   cancel-in-progress: true
-
 permissions: {}
-
 jobs:
   change-detection:
     uses: ./.github/workflows/reusable-change-detection.yml
-
   check-docs:
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-docs)
     uses: ./.github/workflows/reusable-docs.yml
-
   pytest:
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-tests)
     uses: ./.github/workflows/reusable-pytest.yml
-
   type:
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-tests)
     uses: ./.github/workflows/reusable-type.yml
-
   # https://github.com/marketplace/actions/alls-green#why
   required-checks-pass: # This job does nothing and is only used for the branch protection
     name: Required checks pass
     if: always()
-
     needs:
       - change-detection # transitive
       - check-docs
       - pytest
       - type
-
     runs-on: ubuntu-latest
-
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           allowed-skips: >-
-            ${{
-              !fromJSON(needs.change-detection.outputs.run-docs)
-              && '
-              check-docs,
-              '
-              || ''
-            }}
-            ${{
-              !fromJSON(needs.change-detection.outputs.run-tests)
-              && '
-              pytest,
-              type,
-              '
-              || ''
-            }}
+            ${{ !fromJSON(needs.change-detection.outputs.run-docs) && 'check-docs,' || '' }} ${{ !fromJSON(needs.change-detection.outputs.run-tests) && 'pytest,type,' || '' }}
           jobs: ${{ toJSON(needs) }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,6 @@ repos:
     rev: "v0.21.0"
     hooks:
       - id: yamlfmt
-        exclude: ^\.github/workflows/ # folded ${{ }} expressions break yamlfmt
   - repo: local
     hooks:
       - id: mdformat


### PR DESCRIPTION
Follow-up to the prettier→mdformat migration (#1133), which excluded `.github/workflows` from yamlfmt because yamlfmt is non-convergent on folded `>-` scalars wrapping multi-line `${{ }}` expressions. This rewrites the two offending scalars (`continue-on-error`, `allowed-skips`) into forms yamlfmt handles — semantically identical — and drops the exclude so yamlfmt formats every workflow.