### PR TITLE
🔧 build(type): replace mypy with ty

### DIFF
--- a/docs/changelog/1135.misc.rst
+++ b/docs/changelog/1135.misc.rst
@@ -1,0 +1,1 @@
+Replace ``mypy`` with ``ty`` as the type checker.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,8 +115,9 @@ typing = [
   { include-group = "test-core" },
   { include-group = "extra" },
 ]
-mypy = [
-  "mypy ~= 2.1.0",
+type = [
+  "ty>=0.0.59",
+  "gitpython >= 3.1.44",
   { include-group = "typing" },
 ]
 release = [
@@ -128,7 +129,7 @@ release = [
 dev = [
   "flit-core",
   { include-group = "test" },
-  { include-group = "mypy" },
+  { include-group = "type" },
 ]
 
 [tool.flit.sdist]
@@ -144,6 +145,8 @@ exclude = [
 
 [tool.uv]
 exclude-newer = "7 days"
+# ty releases lag the 7-day global cutoff; allow the pinned version through
+exclude-newer-package = { ty = "2026-07-13T00:00:00Z" }
 
 
 [tool.coverage]
@@ -190,20 +193,8 @@ filterwarnings = [
   "ignore:os.path.commonprefix:DeprecationWarning" # https://github.com/pypa/pyproject-hooks/pull/222
 ]
 
-[tool.mypy]
-files = ["src", "tests"]
-exclude = ["tests/packages"]
-python_version = "3.10"
-strict = true
-disallow_any_explicit = true
-enable_error_code = ["ignore-without-code", "truthy-bool", "redundant-expr"]
-warn_unreachable = true
-
-[[tool.mypy.overrides]]
-module = [
-  "virtualenv", # Optional dependency
-]
-ignore_missing_imports = true
+[tool.ty]
+environment.python-version = "3.14"
 
 [tool.ruff]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ typing = [
 ]
 type = [
   "ty>=0.0.59",
-  "gitpython >= 3.1.44",
+  "gitpython >= 3.1.44",  # ty checks the whole tree, including tasks/release.py
   { include-group = "typing" },
 ]
 release = [
@@ -194,7 +194,15 @@ filterwarnings = [
 ]
 
 [tool.ty]
-environment.python-version = "3.14"
+environment.python-version = "3.10"
+
+[tool.ty.src]
+exclude = ["tests/packages"]
+
+[tool.ty.rules]
+all = "error"
+# `@override` needs typing_extensions before 3.12; build ships no runtime deps for typing
+missing-override-decorator = "ignore"
 
 [tool.ruff]
 exclude = [
@@ -251,7 +259,7 @@ ignore = [
 ]
 
 [tool.repo-review]
-ignore = ["PC140"]  # mypy in tox
+ignore = ["PC140"]  # type checker in tox
 
 
 [tool.towncrier]

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -5,6 +5,9 @@ build - A simple, correct Python build frontend
 from __future__ import annotations
 
 
+if __spec__ is None:  # pragma: no cover
+    raise RuntimeError
+
 __lazy_modules__ = [
     f'{__spec__.parent}._builder',
     f'{__spec__.parent}._exceptions',

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -5,6 +5,8 @@ build - A simple, correct Python build frontend
 from __future__ import annotations
 
 
+# ty types module-scope `__spec__` as `ModuleSpec | None`; narrow it so `__spec__.parent`
+# resolves. https://github.com/astral-sh/ty/issues/4017
 if __spec__ is None:  # pragma: no cover
     raise RuntimeError
 

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -177,7 +177,7 @@ def _make_logger() -> _ctx.Logger:
 
 
 def _setup_cli(*, verbosity: int) -> None:
-    warnings.showwarning = _showwarning
+    warnings.showwarning = _showwarning  # ty: ignore[invalid-assignment]  # ty bug: identical signature rejected
 
     if platform.system() == 'Windows':
         try:
@@ -834,14 +834,15 @@ def _select_build(parser: argparse.ArgumentParser, args: _Args, *, sdist_input: 
             'cannot build a source distribution from a source distribution; '
             'pass --wheel to build a wheel from the sdist (see https://github.com/pypa/build/issues/311)'
         )
+    wheel_only: list[Distribution] = ['wheel']
     if args.metadata:
-        return partial(_build_metadata, distributions=['wheel'])
+        return partial(_build_metadata, distributions=wheel_only)
     if sdist_input:
         distributions: list[Distribution] = args.distributions or ['wheel']
         return partial(build_package, distributions=distributions)
     if args.distributions:
         return partial(build_package, distributions=args.distributions)
-    return partial(build_package_via_sdist, distributions=['wheel'], sdist_extract_dir=args.sdist_extract_dir)
+    return partial(build_package_via_sdist, distributions=wheel_only, sdist_extract_dir=args.sdist_extract_dir)
 
 
 def _validate_sdist_archive(archive: StrPath) -> str:

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -177,7 +177,7 @@ def _make_logger() -> _ctx.Logger:
 
 
 def _setup_cli(*, verbosity: int) -> None:
-    warnings.showwarning = _showwarning  # ty: ignore[invalid-assignment]  # ty bug: identical signature rejected
+    warnings.showwarning = _showwarning  # ty: ignore[invalid-assignment]  # https://github.com/astral-sh/ty/issues/3962
 
     if platform.system() == 'Windows':
         try:

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 
+if __spec__ is None:  # pragma: no cover
+    raise RuntimeError
+
 __lazy_modules__ = [
     'contextlib',
     'difflib',
@@ -53,8 +56,9 @@ if TYPE_CHECKING:
 
     from ._types import ConfigSettings, Distribution, StrPath, SubprocessRunner
 
-    # A value as produced by ``tomllib`` when parsing ``pyproject.toml``. Uses the covariant
-    # ``Sequence``/``Mapping`` so concrete literals (e.g. ``dict[str, list[str]]``) are assignable.
+    # A value as produced by ``tomllib`` when parsing ``pyproject.toml``. Arrays are ``list`` and
+    # tables are ``dict`` (as ``tomllib`` produces them) so ``isinstance`` narrowing yields a
+    # concrete, indexable type.
     TOMLValue = (
         str
         | int
@@ -63,8 +67,8 @@ if TYPE_CHECKING:
         | datetime.datetime
         | datetime.date
         | datetime.time
-        | Sequence['TOMLValue']
-        | Mapping[str, 'TOMLValue']
+        | list['TOMLValue']
+        | dict[str, 'TOMLValue']
     )
 
     # The validated ``[build-system]`` table.

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 
+# ty types module-scope `__spec__` as `ModuleSpec | None`; narrow it so `__spec__.parent`
+# resolves. https://github.com/astral-sh/ty/issues/4017
 if __spec__ is None:  # pragma: no cover
     raise RuntimeError
 
@@ -57,8 +59,10 @@ if TYPE_CHECKING:
     from ._types import ConfigSettings, Distribution, StrPath, SubprocessRunner
 
     # A value as produced by ``tomllib`` when parsing ``pyproject.toml``. Arrays are ``list`` and
-    # tables are ``dict`` (as ``tomllib`` produces them) so ``isinstance`` narrowing yields a
-    # concrete, indexable type.
+    # tables are ``dict`` (as ``tomllib`` produces them) rather than the covariant
+    # ``Sequence``/``Mapping``: ``isinstance`` narrowing synthesizes ``Top[Mapping[...]]``, which
+    # degrades a recursive alias to ``Divergent`` and leaves the table unindexable
+    # (https://github.com/astral-sh/ty/issues/3699).
     TOMLValue = (
         str
         | int

--- a/src/build/_ctx.py
+++ b/src/build/_ctx.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
 
+# ty types module-scope `__spec__` as `ModuleSpec | None`; narrow it so `__spec__.parent`
+# resolves. https://github.com/astral-sh/ty/issues/4017
+if __spec__ is None:  # pragma: no cover
+    raise RuntimeError
+
 __lazy_modules__ = ['subprocess']
 
 import contextvars
@@ -21,7 +26,7 @@ class Logger(typing.Protocol):  # pragma: no cover
     def __call__(self, message: str, *, kind: tuple[str, ...] | None = None) -> None: ...
 
 
-_package_name = __package__
+_package_name = __spec__.parent
 _default_logger = logging.getLogger(_package_name)
 
 

--- a/src/build/_ctx.py
+++ b/src/build/_ctx.py
@@ -21,7 +21,7 @@ class Logger(typing.Protocol):  # pragma: no cover
     def __call__(self, message: str, *, kind: tuple[str, ...] | None = None) -> None: ...
 
 
-_package_name = __spec__.parent
+_package_name = __package__
 _default_logger = logging.getLogger(_package_name)
 
 
@@ -30,7 +30,7 @@ def _log_default(message: str, *, kind: tuple[str, ...] | None = None) -> None: 
     _default_logger.log(logging.INFO, message, stacklevel=2)
 
 
-LOGGER = contextvars.ContextVar('LOGGER', default=_log_default)
+LOGGER: contextvars.ContextVar[Logger] = contextvars.ContextVar('LOGGER', default=_log_default)
 VERBOSITY = contextvars.ContextVar('VERBOSITY', default=0)
 
 

--- a/src/build/_util.py
+++ b/src/build/_util.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 
+# ty types module-scope `__spec__` as `ModuleSpec | None`; narrow it so `__spec__.parent`
+# resolves. https://github.com/astral-sh/ty/issues/4017
 if __spec__ is None:  # pragma: no cover
     raise RuntimeError
 

--- a/src/build/_util.py
+++ b/src/build/_util.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 
+if __spec__ is None:  # pragma: no cover
+    raise RuntimeError
+
 __lazy_modules__ = [
     f'{__spec__.parent}._compat',
     'packaging',

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 
+# ty types module-scope `__spec__` as `ModuleSpec | None`; narrow it so `__spec__.parent`
+# resolves. https://github.com/astral-sh/ty/issues/4017
 if __spec__ is None:  # pragma: no cover
     raise RuntimeError
 

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 
+if __spec__ is None:  # pragma: no cover
+    raise RuntimeError
+
 __lazy_modules__ = [
     'abc',
     'contextlib',

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 
+if __spec__ is None:  # pragma: no cover
+    raise RuntimeError
+
 __lazy_modules__ = [f'{__spec__.parent}._compat', f'{__spec__.parent}.env', 'pathlib', 'tempfile', 'warnings']
 
 import pathlib
@@ -24,7 +27,7 @@ if TYPE_CHECKING:
 def _project_wheel_metadata(builder: ProjectBuilder) -> importlib.metadata.PackageMetadata:
     with tempfile.TemporaryDirectory() as tmpdir:
         path = pathlib.Path(builder.metadata_path(tmpdir))
-        metadata = importlib.metadata.PathDistribution(path).metadata
+        metadata = importlib.metadata.PathDistribution(path).metadata  # ty: ignore[invalid-argument-type]  # ty SimplePath bug
         assert metadata is not None
         return metadata
 

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 
+# ty types module-scope `__spec__` as `ModuleSpec | None`; narrow it so `__spec__.parent`
+# resolves. https://github.com/astral-sh/ty/issues/4017
 if __spec__ is None:  # pragma: no cover
     raise RuntimeError
 
@@ -27,7 +29,7 @@ if TYPE_CHECKING:
 def _project_wheel_metadata(builder: ProjectBuilder) -> importlib.metadata.PackageMetadata:
     with tempfile.TemporaryDirectory() as tmpdir:
         path = pathlib.Path(builder.metadata_path(tmpdir))
-        metadata = importlib.metadata.PathDistribution(path).metadata  # ty: ignore[invalid-argument-type]  # ty SimplePath bug
+        metadata = importlib.metadata.PathDistribution(path).metadata  # ty: ignore[invalid-argument-type]  # https://github.com/python/importlib_metadata/issues/542
         assert metadata is not None
         return metadata
 

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -92,7 +92,7 @@ def tag_release_commit(release_commit: Commit, repo: Repo, version: Version) -> 
     existing_tags = [x.name for x in repo.tags]
     if tag_name in existing_tags:
         print(f'delete existing tag {tag_name}')
-        repo.delete_tag(tag_name)
+        repo.delete_tag(repo.tags[tag_name])
     changelog_content = extract_changelog_for_version(version)
     tag_message = f'build {version}\n\n{changelog_content}'
     print(f'creating tag {tag_name}')

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -44,7 +44,7 @@ def test_make_extra_environ_overrides_pythonpath() -> None:
 
 def test_installed_versions(mocker: pytest_mock.MockerFixture) -> None:
     env = build.env.DefaultIsolatedEnv()
-    env._env_backend = SimpleNamespace(purelib='/purelib')
+    mocker.patch.object(env, '_env_backend', SimpleNamespace(purelib='/purelib'), create=True)
     distributions = mocker.patch(
         'build._compat.importlib.metadata.distributions',
         return_value=[

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -575,7 +575,7 @@ def test_metadata_path_no_prepare(tmp_dir: str, package_test_no_prepare: str) ->
     builder = build.ProjectBuilder(package_test_no_prepare)
 
     metadata = _importlib.metadata.PathDistribution(
-        pathlib.Path(builder.metadata_path(tmp_dir)),  # ty: ignore[invalid-argument-type]  # ty SimplePath bug
+        pathlib.Path(builder.metadata_path(tmp_dir)),  # ty: ignore[invalid-argument-type]  # https://github.com/python/importlib_metadata/issues/542
     ).metadata
     assert metadata is not None
 
@@ -587,7 +587,7 @@ def test_metadata_path_with_prepare(tmp_dir: str, package_test_setuptools: str) 
     builder = build.ProjectBuilder(package_test_setuptools)
 
     metadata = _importlib.metadata.PathDistribution(
-        pathlib.Path(builder.metadata_path(tmp_dir)),  # ty: ignore[invalid-argument-type]  # ty SimplePath bug
+        pathlib.Path(builder.metadata_path(tmp_dir)),  # ty: ignore[invalid-argument-type]  # https://github.com/python/importlib_metadata/issues/542
     ).metadata
     assert metadata is not None
 
@@ -600,7 +600,7 @@ def test_metadata_path_legacy(tmp_dir: str, package_legacy: str) -> None:
     builder = build.ProjectBuilder(package_legacy)
 
     metadata = _importlib.metadata.PathDistribution(
-        pathlib.Path(builder.metadata_path(tmp_dir)),  # ty: ignore[invalid-argument-type]  # ty SimplePath bug
+        pathlib.Path(builder.metadata_path(tmp_dir)),  # ty: ignore[invalid-argument-type]  # https://github.com/python/importlib_metadata/issues/542
     ).metadata
     assert metadata is not None
 

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -575,7 +575,7 @@ def test_metadata_path_no_prepare(tmp_dir: str, package_test_no_prepare: str) ->
     builder = build.ProjectBuilder(package_test_no_prepare)
 
     metadata = _importlib.metadata.PathDistribution(
-        pathlib.Path(builder.metadata_path(tmp_dir)),
+        pathlib.Path(builder.metadata_path(tmp_dir)),  # ty: ignore[invalid-argument-type]  # ty SimplePath bug
     ).metadata
     assert metadata is not None
 
@@ -587,7 +587,7 @@ def test_metadata_path_with_prepare(tmp_dir: str, package_test_setuptools: str) 
     builder = build.ProjectBuilder(package_test_setuptools)
 
     metadata = _importlib.metadata.PathDistribution(
-        pathlib.Path(builder.metadata_path(tmp_dir)),
+        pathlib.Path(builder.metadata_path(tmp_dir)),  # ty: ignore[invalid-argument-type]  # ty SimplePath bug
     ).metadata
     assert metadata is not None
 
@@ -600,7 +600,7 @@ def test_metadata_path_legacy(tmp_dir: str, package_legacy: str) -> None:
     builder = build.ProjectBuilder(package_legacy)
 
     metadata = _importlib.metadata.PathDistribution(
-        pathlib.Path(builder.metadata_path(tmp_dir)),
+        pathlib.Path(builder.metadata_path(tmp_dir)),  # ty: ignore[invalid-argument-type]  # ty SimplePath bug
     ).metadata
     assert metadata is not None
 

--- a/tox.toml
+++ b/tox.toml
@@ -51,8 +51,8 @@ dependency_groups = ["lint"]
 [env.type]
 description = "run type check on code base"
 set_env = { PYTHONWARNDEFAULTENCODING = "" }
-commands = [["mypy", { replace = "posargs", extend = true }]]
-dependency_groups = ["mypy"]
+commands = [["ty", "check", "--output-format", "concise", "--error-on-warning", "."]]
+dependency_groups = ["type"]
 
 [env.docs]
 description = "build documentations"


### PR DESCRIPTION
Replaces mypy with ty. #1136 replaces mypy with pyrefly instead, from the same starting point. The two are alternatives; pick one and close the other.

## Why consider it

ty is fast and actively developed by the team behind ruff and uv, and a single vendor across our lint and type tooling has some appeal. That is the whole case. It is not a response to a problem we have: the type check takes 22 seconds today and 15 seconds here, on a job that runs alongside the full test matrix and is mostly setup. Seven seconds is not a reason to switch.

## What we gain

Checking now covers the release tooling, which the mypy setup never looked at. That immediately turned up a real defect in the release script that has been sitting there unnoticed. #1136 finds the same one, so this is an argument for widening coverage rather than for ty.

## What it costs

ty has no strict mode. This PR turns on every rule ty has, which is the strictest it can be configured, and that still enforces less than the mypy setup it replaces. Some of what we enforce today has no ty equivalent at all, including the project's deliberate ban on escape-hatch typing.

Three ty defects force changes to shipping code rather than to configuration. Two are cosmetic but permanent until fixed upstream: dead guards added to five modules, and one suppression. The third is a genuine loss of safety. A type describing parsed configuration has to be weakened for ty to handle it, and once weakened, mypy catches a real error in that area that ty cannot see. All three are filed upstream and linked from the code. pyrefly has none of them.

ty is pre-1.0 and states that its diagnostics may change between any two releases. We therefore have to pin it, and that pin is load-bearing for CI staying green. On the independent conformance suite maintained by the Python typing council, ty scores below mypy; pyrefly scores roughly twenty points above both.

## Recommendation

Even configured as strictly as it goes, this checks less than what we have and less than #1136, and it costs working code to get there. Staying on mypy is defensible. #1136 is the better trade. I would close this one.
