### PR TITLE
🔧 build(type): replace mypy with pyrefly

### DIFF
--- a/docs/changelog/1136.misc.rst
+++ b/docs/changelog/1136.misc.rst
@@ -1,0 +1,1 @@
+Replace ``mypy`` with ``pyrefly`` as the type checker.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,8 +115,9 @@ typing = [
   { include-group = "test-core" },
   { include-group = "extra" },
 ]
-mypy = [
-  "mypy ~= 2.1.0",
+type = [
+  "pyrefly >= 1.1.1",
+  "gitpython >= 3.1.44",  # pyrefly checks the whole tree, including tasks/release.py
   { include-group = "typing" },
 ]
 release = [
@@ -128,7 +129,7 @@ release = [
 dev = [
   "flit-core",
   { include-group = "test" },
-  { include-group = "mypy" },
+  { include-group = "type" },
 ]
 
 [tool.flit.sdist]
@@ -190,20 +191,17 @@ filterwarnings = [
   "ignore:os.path.commonprefix:DeprecationWarning" # https://github.com/pypa/pyproject-hooks/pull/222
 ]
 
-[tool.mypy]
-files = ["src", "tests"]
-exclude = ["tests/packages"]
-python_version = "3.10"
-strict = true
-disallow_any_explicit = true
-enable_error_code = ["ignore-without-code", "truthy-bool", "redundant-expr"]
-warn_unreachable = true
+[tool.pyrefly]
+project-includes = ["src", "tests", "tasks"]
+project-excludes = ["**/tests/packages*"]
+search-path = ["src", "tests"]
+python-version = "3.10"
+preset = "strict"
+ignore-missing-imports = ["virtualenv"]  # optional dependency
 
-[[tool.mypy.overrides]]
-module = [
-  "virtualenv", # Optional dependency
-]
-ignore_missing_imports = true
+[tool.pyrefly.errors]
+# `@override` needs typing_extensions before 3.12; build takes no runtime deps for typing
+missing-override-decorator = false
 
 [tool.ruff]
 exclude = [
@@ -231,7 +229,7 @@ ignore = [
   "PLR2004", # Magic values
   "PTH",     # Too many change for now
   "Q",       # Using formatter for quotes
-  "S101",    # Assert is used by mypy and pytest
+  "S101",    # Assert is used by the type checker and pytest
   "SLF001",  # Private members are okay to access
 ]
 
@@ -260,7 +258,7 @@ ignore = [
 ]
 
 [tool.repo-review]
-ignore = ["PC140"]  # mypy in tox
+ignore = ["PC140"]  # type checker in tox
 
 
 [tool.towncrier]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ typing = [
 ]
 type = [
   "pyrefly >= 1.1.1",
+  "colorama",  # win32-only runtime dep; installed so its stubs resolve to source
   "gitpython >= 3.1.44",  # pyrefly checks the whole tree, including tasks/release.py
   { include-group = "typing" },
 ]
@@ -196,7 +197,7 @@ project-includes = ["src", "tests", "tasks"]
 project-excludes = ["**/tests/packages*"]
 search-path = ["src", "tests"]
 python-version = "3.10"
-preset = "strict"
+preset = "all"
 ignore-missing-imports = ["virtualenv"]  # optional dependency
 
 [tool.pyrefly.errors]

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -68,7 +68,7 @@ from build.env import DefaultIsolatedEnv
 TYPE_CHECKING = False
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Mapping, Sequence
+    from collections.abc import Generator, Mapping, Sequence
 
     from build._types import ConfigSettings, Distribution, StrPath, SubprocessRunner
 
@@ -215,7 +215,7 @@ def _bootstrap_build_env(
     installer: _env.Installer,
     env_dir: str | None = None,
     runner: SubprocessRunner | None = None,
-) -> Iterator[ProjectBuilder]:
+) -> Generator[ProjectBuilder]:
     runner = runner or pyproject_hooks.default_subprocess_runner
     if isolation:
         with DefaultIsolatedEnv(installer=installer, path=env_dir) as env:
@@ -281,7 +281,7 @@ def _build(
 
 
 @contextlib.contextmanager
-def _handle_build_error(*, env_dir: str | None, sdist_extract_dir: StrPath | None) -> Iterator[None]:
+def _handle_build_error(*, env_dir: str | None, sdist_extract_dir: StrPath | None) -> Generator[None]:
     try:
         yield
     except (BuildException, FailedProcessError) as e:
@@ -877,7 +877,7 @@ def _validate_sdist_archive(archive: StrPath) -> str:
 
 
 @contextlib.contextmanager
-def _extract_sdist(archive: StrPath, top_level: str, *, extract_dir: StrPath | None = None) -> Iterator[str]:
+def _extract_sdist(archive: StrPath, top_level: str, *, extract_dir: StrPath | None = None) -> Generator[str]:
     if extract_dir is None:
         tmp_dir = tempfile.mkdtemp(prefix='build-via-sdist-')
         try:

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
     import datetime
 
     from collections.abc import Iterable, Iterator, Mapping, Sequence
-    from typing import TypedDict
+    from typing import TypedDict, TypeGuard
 
     if sys.version_info < (3, 11):
         from typing_extensions import NotRequired, Self
@@ -88,6 +88,10 @@ def _find_typo(dictionary: Iterable[str], expected: str) -> None:
                 TypoWarning,
                 stacklevel=2,
             )
+
+
+def _is_str_list(value: TOMLValue) -> TypeGuard[list[str]]:
+    return isinstance(value, list) and all(isinstance(i, str) for i in value)
 
 
 def _validate_source_directory(source_dir: StrPath) -> None:
@@ -135,7 +139,7 @@ def _parse_build_system_table(pyproject_toml: Mapping[str, TOMLValue]) -> BuildS
         msg = '`requires` is a required property'
         raise BuildSystemTableValidationError(msg)
     requires = build_system['requires']
-    if not isinstance(requires, list) or not all(isinstance(i, str) for i in requires):
+    if not _is_str_list(requires):
         msg = '`requires` must be an array of strings'
         raise BuildSystemTableValidationError(msg)
 
@@ -156,7 +160,7 @@ def _parse_build_system_table(pyproject_toml: Mapping[str, TOMLValue]) -> BuildS
             _find_typo(build_system, 'build-backend')
 
     match build_system:
-        case {'backend-path': list() as backend_path} if all(isinstance(i, str) for i in backend_path):
+        case {'backend-path': backend_path} if _is_str_list(backend_path):
             table['backend-path'] = backend_path
         case {'backend-path': _}:
             msg = '`backend-path` must be an array of strings'

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -43,7 +43,7 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     import datetime
 
-    from collections.abc import Iterable, Iterator, Mapping, Sequence
+    from collections.abc import Generator, Iterable, Mapping, Sequence
     from typing import TypedDict, TypeGuard
 
     if sys.version_info < (3, 11):
@@ -422,7 +422,7 @@ class ProjectBuilder:
         return os.path.join(outdir, basename)
 
     @contextlib.contextmanager
-    def _handle_backend(self, hook: str) -> Iterator[None]:
+    def _handle_backend(self, hook: str) -> Generator[None]:
         try:
             yield
         except pyproject_hooks.BackendUnavailable as exception:

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -105,6 +105,10 @@ class DefaultIsolatedEnv(IsolatedEnv):
     Isolated environment which supports several different underlying implementations.
     """
 
+    # both are set in ``__enter__`` and only valid inside the context
+    _path: str
+    _env_backend: _EnvBackend
+
     def __init__(
         self,
         *,
@@ -139,8 +143,6 @@ class DefaultIsolatedEnv(IsolatedEnv):
             # Ref: https://bugs.python.org/issue46171
             path = os.path.realpath(path)
             self._path = path
-
-            self._env_backend: _EnvBackend
 
             # uv is opt-in only.
             if self.installer == 'uv':
@@ -435,6 +437,10 @@ class _PipBackend(_EnvBackend):
 
 
 class _UvBackend(_EnvBackend):
+    # both are set in ``create``
+    _env_path: str
+    _uv_bin: str
+
     def create(self, path: str) -> None:
         import venv
 

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 def _project_wheel_metadata(builder: ProjectBuilder) -> importlib.metadata.PackageMetadata:
     with tempfile.TemporaryDirectory() as tmpdir:
         path = pathlib.Path(builder.metadata_path(tmpdir))
-        metadata = importlib.metadata.PathDistribution(path).metadata
+        metadata = importlib.metadata.PathDistribution(path).metadata  # pyrefly: ignore[bad-argument-type]  # https://github.com/python/importlib_metadata/issues/542
         assert metadata is not None
         return metadata
 

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -92,7 +92,7 @@ def tag_release_commit(release_commit: Commit, repo: Repo, version: Version) -> 
     existing_tags = [x.name for x in repo.tags]
     if tag_name in existing_tags:
         print(f'delete existing tag {tag_name}')
-        repo.delete_tag(tag_name)
+        repo.delete_tag(repo.tags[tag_name])
     changelog_content = extract_changelog_for_version(version)
     tag_message = f'build {version}\n\n{changelog_content}'
     print(f'creating tag {tag_name}')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,7 @@ def _xfail_isolated_strict(item: pytest.Item, *, is_integration_file: bool) -> b
 
 def is_integration(item: pytest.Item) -> bool:
     # item.location is typically a (path, lineno) tuple; cast to str for typing
-    return os.path.basename(str(item.location[0])) == 'test_integration.py'
+    return os.path.basename(item.location[0]) == 'test_integration.py'
 
 
 def pytest_runtest_call(item: pytest.Item) -> None:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -44,7 +44,8 @@ def test_make_extra_environ_overrides_pythonpath() -> None:
 
 def test_installed_versions(mocker: pytest_mock.MockerFixture) -> None:
     env = build.env.DefaultIsolatedEnv()
-    env._env_backend = SimpleNamespace(purelib='/purelib')
+    # _env_backend is created lazily in __enter__, so it is absent on a fresh env
+    mocker.patch.object(env, '_env_backend', SimpleNamespace(purelib='/purelib'), create=True)
     distributions = mocker.patch(
         'build._compat.importlib.metadata.distributions',
         return_value=[

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -133,6 +133,7 @@ def test_venv_executable_missing_post_creation(
 
 
 @typing.no_type_check
+# pyrefly: ignore[unannotated-return]  # https://github.com/facebook/pyrefly/issues/3561
 def test_isolated_env_abstract() -> None:
     with pytest.raises(TypeError):
         build.env.IsolatedEnv()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -890,7 +890,7 @@ def test_log_dependency_versions(mocker: pytest_mock.MockerFixture) -> None:
 
 def test_log_dependency_versions_none(mocker: pytest_mock.MockerFixture) -> None:
     env = mocker.create_autospec(build.env.DefaultIsolatedEnv, instance=True)
-    env.installed_versions.return_value = {}
+    env.installed_versions.return_value = {}  # pyrefly: ignore[implicit-any-empty-container]
     log = mocker.patch('build.__main__._ctx.log')
 
     build.__main__._log_dependency_versions(env, set())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,7 +16,7 @@ import unittest.mock
 import venv
 import zipfile
 
-from collections.abc import Callable, Iterator, Mapping, Sequence
+from collections.abc import Callable, Generator, Mapping, Sequence
 from typing import TYPE_CHECKING, Protocol, TypedDict
 
 import pytest
@@ -890,7 +890,8 @@ def test_log_dependency_versions(mocker: pytest_mock.MockerFixture) -> None:
 
 def test_log_dependency_versions_none(mocker: pytest_mock.MockerFixture) -> None:
     env = mocker.create_autospec(build.env.DefaultIsolatedEnv, instance=True)
-    env.installed_versions.return_value = {}  # pyrefly: ignore[implicit-any-empty-container]
+    installed: dict[str, str] = {}
+    env.installed_versions.return_value = installed
     log = mocker.patch('build.__main__._ctx.log')
 
     build.__main__._log_dependency_versions(env, set())
@@ -969,7 +970,7 @@ def test_build_metadata_runner_without_extra_environ(
     captured_runners: list[CapturedRunner] = []
 
     @contextlib.contextmanager
-    def fake_bootstrap(*_args: object, runner: CapturedRunner, **_kwargs: object) -> Iterator[unittest.mock.MagicMock]:
+    def fake_bootstrap(*_args: object, runner: CapturedRunner, **_kwargs: object) -> Generator[unittest.mock.MagicMock]:
         captured_runners.append(runner)
         builder = mocker.MagicMock()
         metadata_dir = tmp_path / 'metadata'

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -295,7 +295,7 @@ def test_build_missing_backend(
     builder = build.ProjectBuilder(bad_backend_path)
 
     with pytest.raises(build.BuildBackendException):
-        builder.build(distribution, str(tmpdir))
+        builder.build(distribution, tmpdir)
 
 
 def _nothing_installed(name: str) -> NoReturn:
@@ -312,7 +312,7 @@ def test_check_dependencies(
 
     builder = build.ProjectBuilder(package_test_flit)
 
-    side_effects: list[object] = [
+    side_effects: list[list[str] | type[pyproject_hooks.BackendUnavailable]] = [
         [],
         ['something'],
         pyproject_hooks.BackendUnavailable,

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -312,7 +312,7 @@ def test_check_dependencies(
 
     builder = build.ProjectBuilder(package_test_flit)
 
-    side_effects = [
+    side_effects: list[object] = [
         [],
         ['something'],
         pyproject_hooks.BackendUnavailable,
@@ -575,7 +575,7 @@ def test_metadata_path_no_prepare(tmp_dir: str, package_test_no_prepare: str) ->
     builder = build.ProjectBuilder(package_test_no_prepare)
 
     metadata = _importlib.metadata.PathDistribution(
-        pathlib.Path(builder.metadata_path(tmp_dir)),
+        pathlib.Path(builder.metadata_path(tmp_dir)),  # pyrefly: ignore[bad-argument-type]  # https://github.com/python/importlib_metadata/issues/542
     ).metadata
     assert metadata is not None
 
@@ -587,7 +587,7 @@ def test_metadata_path_with_prepare(tmp_dir: str, package_test_setuptools: str) 
     builder = build.ProjectBuilder(package_test_setuptools)
 
     metadata = _importlib.metadata.PathDistribution(
-        pathlib.Path(builder.metadata_path(tmp_dir)),
+        pathlib.Path(builder.metadata_path(tmp_dir)),  # pyrefly: ignore[bad-argument-type]  # https://github.com/python/importlib_metadata/issues/542
     ).metadata
     assert metadata is not None
 
@@ -600,7 +600,7 @@ def test_metadata_path_legacy(tmp_dir: str, package_legacy: str) -> None:
     builder = build.ProjectBuilder(package_legacy)
 
     metadata = _importlib.metadata.PathDistribution(
-        pathlib.Path(builder.metadata_path(tmp_dir)),
+        pathlib.Path(builder.metadata_path(tmp_dir)),  # pyrefly: ignore[bad-argument-type]  # https://github.com/python/importlib_metadata/issues/542
     ).metadata
     assert metadata is not None
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -52,7 +52,7 @@ def test_with_get_requires(package_test_metadata: str) -> None:
 
     # Setuptools < v69.0.3 (https://github.com/pypa/setuptools/pull/4159) normalized this to dashes
     assert metadata['name'].replace('-', '_') == 'test_metadata'
-    assert str(metadata['version']) == '1.0.0'
+    assert metadata['version'] == '1.0.0'
     assert metadata['summary'] == 'hello!'
     assert isinstance(metadata.json, dict)
 

--- a/tox.toml
+++ b/tox.toml
@@ -51,8 +51,8 @@ dependency_groups = ["lint"]
 [env.type]
 description = "run type check on code base"
 set_env = { PYTHONWARNDEFAULTENCODING = "" }
-commands = [["mypy", { replace = "posargs", extend = true }]]
-dependency_groups = ["mypy"]
+commands = [["pyrefly", "check", { replace = "posargs", extend = true }]]
+dependency_groups = ["type"]
 
 [env.docs]
 description = "build documentations"


### PR DESCRIPTION
Replaces mypy with pyrefly. #1135 replaces mypy with ty instead, from the same starting point. The two are alternatives; pick one and close the other. @henryiii asked whether pyrefly does better than ty, so this is the comparison with the code attached.

## Why consider it

Two reasons, neither of them speed. Our current setup is slow to nobody: the type check takes 22 seconds today and 20 here.

The first is coverage. pyrefly enforces more than the mypy configuration it replaces, and more than #1135 can. Every rule is switched on, and everything it flagged was worth fixing.

The second is maturity. pyrefly is production ready as of its 1.0 and is the default type checker at Meta. On the independent conformance suite maintained by the Python typing council it scores roughly twenty points above both mypy and ty, and ty scores below mypy. Migration was mechanical: pyrefly read our mypy configuration and translated it without help, including the per-module exceptions.

## What it found

Four classes of problem mypy had been letting through.

A real defect in the release tooling, which the mypy setup never checked. #1135 finds this one too.

An unchecked assignment in the configuration parser, where a runtime validation convinced mypy of something it had not actually established. This is the interesting one: #1135 hits the same wall and has to resolve it by weakening the type, because ty cannot handle the accurate version. Weakening it loses real safety. Here the type stays accurate and the check gets stronger.

Five uses of a decorator form the standard library has deprecated. Neither mypy nor ty reports these; ty has the rule but does not apply it in this case, which is filed upstream.

Four attributes set outside their constructor, now declared properly. Nothing changes at runtime. Neither mypy nor ty has this check.

## What it costs

Two suppressions, both temporary and both tracked upstream. One is a genuine bug in a third-party package that mypy was papering over; #1135 carries the same one, and I have opened the fix upstream. The other is a pyrefly false positive already fixed upstream but landing after the current release, so it clears itself on the next version.

Nothing else. No changes to shipping code to satisfy the checker, no version pin holding CI together.

## Recommendation

This enforces more than mypy, more than #1135, and costs nothing in working code to get there. I would merge this and close #1135.
