### PR TITLE
feat: add wheel_metadata helper

### DIFF
--- a/docs/changelog/1131.feature.rst
+++ b/docs/changelog/1131.feature.rst
@@ -1,1 +1,2 @@
-Add :func:`build.util.wheel_metadata` as a supported in-process metadata API with dependency checks for non-isolated builds - by :user:`deepakganesh78`
+Add :func:`build.util.wheel_metadata` as a supported in-process metadata API with dependency checks for non-isolated
+builds - by :user:`deepakganesh78`

--- a/docs/changelog/1131.feature.rst
+++ b/docs/changelog/1131.feature.rst
@@ -1,0 +1,1 @@
+Add :func:`build.util.wheel_metadata` as a supported in-process metadata API with dependency checks for non-isolated builds - by :user:`deepakganesh78`

--- a/docs/changelog/557.deprecation.rst
+++ b/docs/changelog/557.deprecation.rst
@@ -1,1 +1,1 @@
-Deprecate :func:`build.util.project_wheel_metadata`; use ``python -m build --metadata`` instead - by :user:`gaborbernat`
+Deprecate :func:`build.util.project_wheel_metadata`; prefer :func:`build.util.wheel_metadata` - by :user:`gaborbernat`

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -3,7 +3,15 @@
 from __future__ import annotations
 
 
-__lazy_modules__ = [f'{__spec__.parent}._compat', f'{__spec__.parent}.env', 'pathlib', 'tempfile', 'warnings']
+__lazy_modules__ = [
+    f'{__spec__.parent}._compat',
+    f'{__spec__.parent}._exceptions',
+    f'{__spec__.parent}._util',
+    f'{__spec__.parent}.env',
+    'pathlib',
+    'tempfile',
+    'warnings',
+]
 
 import pathlib
 import tempfile
@@ -13,6 +21,8 @@ import pyproject_hooks
 
 from . import ProjectBuilder
 from ._compat import importlib
+from ._exceptions import BuildException
+from ._util import format_unmet_dependencies
 from .env import DefaultIsolatedEnv
 
 
@@ -29,6 +39,47 @@ def _project_wheel_metadata(builder: ProjectBuilder) -> importlib.metadata.Packa
         return metadata
 
 
+def wheel_metadata(
+    source_dir: StrPath,
+    isolated: bool = True,
+    *,
+    check_dependencies: bool = True,
+    runner: SubprocessRunner = pyproject_hooks.quiet_subprocess_runner,
+) -> importlib.metadata.PackageMetadata:
+    """
+    Return the wheel metadata for a project.
+
+    Uses the ``prepare_metadata_for_build_wheel`` hook if available,
+    otherwise ``build_wheel``.
+
+    :param source_dir: Project source directory
+    :param isolated: Whether or not to run invoke the backend in the current
+                     environment or to create an isolated one and invoke it
+                     there.
+    :param check_dependencies: Whether to verify that build dependencies are
+                               available in non-isolated mode.
+    :param runner: An alternative runner for backend subprocesses
+    """
+    if isolated:
+        with DefaultIsolatedEnv() as env:
+            builder = ProjectBuilder.from_isolated_env(
+                env,
+                source_dir,
+                runner=runner,
+            )
+            env.install(builder.build_system_requires, _fresh=True)
+            env.install(builder.get_requires_for_build('wheel'))
+            return _project_wheel_metadata(builder)
+
+    builder = ProjectBuilder(
+        source_dir,
+        runner=runner,
+    )
+    if check_dependencies and (missing := builder.check_dependencies('wheel')):
+        raise BuildException(format_unmet_dependencies(missing))
+    return _project_wheel_metadata(builder)
+
+
 def project_wheel_metadata(
     source_dir: StrPath,
     isolated: bool = True,
@@ -41,8 +92,8 @@ def project_wheel_metadata(
     Uses the ``prepare_metadata_for_build_wheel`` hook if available,
     otherwise ``build_wheel``.
 
-    .. deprecated:: 1.5.0
-       Generate metadata with the ``python -m build --metadata`` command instead.
+    .. deprecated:: 1.6.0
+       Use :func:`wheel_metadata` instead.
 
     :param source_dir: Project source directory
     :param isolated: Whether or not to run invoke the backend in the current
@@ -51,28 +102,19 @@ def project_wheel_metadata(
     :param runner: An alternative runner for backend subprocesses
     """
     warnings.warn(
-        'project_wheel_metadata is deprecated; generate metadata with the `python -m build --metadata` command instead',
+        'project_wheel_metadata is deprecated; use build.util.wheel_metadata instead',
         DeprecationWarning,
         stacklevel=2,
     )
-    if isolated:
-        with DefaultIsolatedEnv() as env:
-            builder = ProjectBuilder.from_isolated_env(
-                env,
-                source_dir,
-                runner=runner,
-            )
-            env.install(builder.build_system_requires, _fresh=True)
-            env.install(builder.get_requires_for_build('wheel'))
-            return _project_wheel_metadata(builder)
-    else:
-        builder = ProjectBuilder(
-            source_dir,
-            runner=runner,
-        )
-        return _project_wheel_metadata(builder)
+    return wheel_metadata(
+        source_dir,
+        isolated=isolated,
+        check_dependencies=False,
+        runner=runner,
+    )
 
 
 __all__ = [
     'project_wheel_metadata',
+    'wheel_metadata',
 ]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.filterwarnings('ignore:project_wheel_metadata is deprec
 @pytest.mark.pypy3323bug
 @pytest.mark.parametrize('isolated', [False, pytest.param(True, marks=[pytest.mark.network, pytest.mark.isolated])])
 def test_wheel_metadata(package_test_setuptools: str, isolated: bool) -> None:
-    metadata = build.util.project_wheel_metadata(package_test_setuptools, isolated)
+    metadata = build.util.wheel_metadata(package_test_setuptools, isolated)
 
     # Setuptools < v69.0.3 (https://github.com/pypa/setuptools/pull/4159) normalized this to dashes
     assert metadata['name'].replace('-', '_') == 'test_setuptools'
@@ -32,7 +32,7 @@ def test_wheel_metadata_isolation(package_test_flit: str) -> None:
     if importlib.util.find_spec('flit_core'):
         pytest.xfail('flit_core is available -- we want it missing!')  # pragma: no cover
 
-    metadata = build.util.project_wheel_metadata(package_test_flit)
+    metadata = build.util.wheel_metadata(package_test_flit)
 
     assert metadata['name'] == 'test_flit'
     assert metadata['version'] == '1.0.0'
@@ -42,13 +42,13 @@ def test_wheel_metadata_isolation(package_test_flit: str) -> None:
         build.BuildBackendException,
         match=re.escape("Backend 'flit_core.buildapi' is not available."),
     ):
-        build.util.project_wheel_metadata(package_test_flit, isolated=False)
+        build.util.wheel_metadata(package_test_flit, isolated=False)
 
 
 @pytest.mark.network
 @pytest.mark.pypy3323bug
 def test_with_get_requires(package_test_metadata: str) -> None:
-    metadata = build.util.project_wheel_metadata(package_test_metadata)
+    metadata = build.util.wheel_metadata(package_test_metadata)
 
     # Setuptools < v69.0.3 (https://github.com/pypa/setuptools/pull/4159) normalized this to dashes
     assert metadata['name'].replace('-', '_') == 'test_metadata'
@@ -57,7 +57,7 @@ def test_with_get_requires(package_test_metadata: str) -> None:
     assert isinstance(metadata.json, dict)
 
 
-def test_project_wheel_metadata_installs_build_requires_fresh(mocker: pytest_mock.MockerFixture) -> None:
+def test_wheel_metadata_installs_build_requires_fresh(mocker: pytest_mock.MockerFixture) -> None:
     env = mocker.MagicMock()
     env_cm = mocker.MagicMock()
     env_cm.__enter__.return_value = env
@@ -71,7 +71,7 @@ def test_project_wheel_metadata_installs_build_requires_fresh(mocker: pytest_moc
     metadata = unittest.mock.sentinel.metadata
     mocker.patch('build.util._project_wheel_metadata', return_value=metadata)
 
-    assert build.util.project_wheel_metadata('/tmp/project') is metadata
+    assert build.util.wheel_metadata('/tmp/project') is metadata
 
     assert env.install.call_args_list == [
         mocker.call({'dep1'}, _fresh=True),
@@ -79,9 +79,35 @@ def test_project_wheel_metadata_installs_build_requires_fresh(mocker: pytest_moc
     ]
 
 
-def test_project_wheel_metadata_is_deprecated(mocker: pytest_mock.MockerFixture) -> None:
+def test_wheel_metadata_checks_dependencies_by_default(mocker: pytest_mock.MockerFixture) -> None:
+    builder = mocker.MagicMock()
+    builder.check_dependencies.return_value = {('demo>=1',)}
+    mocker.patch('build.util.ProjectBuilder', return_value=builder)
+    format_message = mocker.patch('build.util.format_unmet_dependencies', return_value='deps missing')
     result = mocker.patch('build.util._project_wheel_metadata')
-    mocker.patch('build.util.ProjectBuilder')
 
-    with pytest.warns(DeprecationWarning, match=r'python -m build --metadata'):
+    with pytest.raises(build.BuildException, match='deps missing'):
+        build.util.wheel_metadata('/tmp/project', isolated=False)
+
+    builder.check_dependencies.assert_called_once_with('wheel')
+    format_message.assert_called_once_with({('demo>=1',)})
+    result.assert_not_called()
+
+
+def test_wheel_metadata_can_skip_dependency_checks(mocker: pytest_mock.MockerFixture) -> None:
+    builder = mocker.MagicMock()
+    builder.check_dependencies.return_value = {('demo>=1',)}
+    mocker.patch('build.util.ProjectBuilder', return_value=builder)
+    mocker.patch('build.util.format_unmet_dependencies')
+    result = mocker.patch('build.util._project_wheel_metadata')
+
+    assert build.util.wheel_metadata('/tmp/project', isolated=False, check_dependencies=False) is result.return_value
+    builder.check_dependencies.assert_not_called()
+
+
+def test_project_wheel_metadata_is_deprecated(mocker: pytest_mock.MockerFixture) -> None:
+    result = mocker.patch('build.util.wheel_metadata')
+
+    with pytest.warns(DeprecationWarning, match=r'build\.util\.wheel_metadata'):
         assert build.util.project_wheel_metadata('/tmp/project', isolated=False) is result.return_value
+    result.assert_called_once_with('/tmp/project', isolated=False, check_dependencies=False, runner=unittest.mock.ANY)


### PR DESCRIPTION
## Summary

- add the promised public `wheel_metadata` helper with optional dependency validation
- retain the deprecated wrapper behavior without introducing dependency checks
- update tests, deprecation guidance, and changelog fragments

## Validation

- `tox -e type,path,3.13`
- `proselint`
- Sphinx documentation build
- `towncrier --draft`
- `pre-commit run check-sdist --all-files`

Closes #1131