### PR TITLE
fix: hash verification in --dependency-constraints-txt could be silently skipped

### DIFF
--- a/docs/changelog/1140.bugfix.rst
+++ b/docs/changelog/1140.bugfix.rst
@@ -1,4 +1,0 @@
-Parse ``--dependency-constraints-txt`` files respecting backslash line continuations before deduplicating them into a
-set, fixing a case where a hashed requirement (e.g. from ``pip-compile --generate-hashes``) could have its ``--hash``
-line separated from its requirement line and silently dropped, depending on the interpreter's hash seed - by
-:user:`manfred-kaiser`

--- a/docs/changelog/1140.bugfix.rst
+++ b/docs/changelog/1140.bugfix.rst
@@ -1,0 +1,4 @@
+Pass ``--dependency-constraints-txt`` files through to the installer unmodified instead of re-parsing them into a
+deduplicated set of lines, fixing a case where a hashed requirement (e.g. from ``pip-compile --generate-hashes``)
+could have its ``--hash`` continuation line separated from its requirement line and silently dropped, depending on
+the interpreter's hash seed - by :user:`manfred-kaiser`

--- a/docs/changelog/1140.bugfix.rst
+++ b/docs/changelog/1140.bugfix.rst
@@ -1,4 +1,4 @@
 Pass ``--dependency-constraints-txt`` files through to the installer unmodified instead of re-parsing them into a
-deduplicated set of lines, fixing a case where a hashed requirement (e.g. from ``pip-compile --generate-hashes``)
-could have its ``--hash`` continuation line separated from its requirement line and silently dropped, depending on
-the interpreter's hash seed - by :user:`manfred-kaiser`
+deduplicated set of lines, fixing a case where a hashed requirement (e.g. from ``pip-compile --generate-hashes``) could
+have its ``--hash`` continuation line separated from its requirement line and silently dropped, depending on the
+interpreter's hash seed - by :user:`manfred-kaiser`

--- a/docs/changelog/1140.bugfix.rst
+++ b/docs/changelog/1140.bugfix.rst
@@ -1,0 +1,4 @@
+Parse ``--dependency-constraints-txt`` files respecting backslash line continuations before deduplicating them into a
+set, fixing a case where a hashed requirement (e.g. from ``pip-compile --generate-hashes``) could have its ``--hash``
+line separated from its requirement line and silently dropped, depending on the interpreter's hash seed - by
+:user:`manfred-kaiser`

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -204,36 +204,6 @@ def _error(msg: str, code: int = 1) -> NoReturn:  # pragma: no cover
     raise SystemExit(code)
 
 
-def _parse_constraints_txt(path: os.PathLike[str] | str) -> set[str]:
-    """
-    Parse a pip/uv constraints file into a set of constraint lines.
-
-    Requirement files support backslash line continuations (as produced by, e.g.,
-    ``pip-compile --generate-hashes``, where a package's ``--hash`` options are
-    wrapped onto continuation lines). These must be joined back into a single
-    logical line *before* being placed in a set: splitting on physical lines and
-    only later rejoining with ``'\\n'.join()`` loses the continuation marker's
-    positional relationship, and because sets do not preserve insertion order,
-    the rejoined file can scramble unrelated requirement and hash lines together,
-    or separate a hash from its requirement so it stops applying, silently and
-    unpredictably (depending on the interpreter's hash seed for that run).
-    """
-    constraints: list[str] = []
-    logical_line = ''
-    with open(path, encoding='utf-8') as constraints_file:
-        for raw_line in constraints_file:
-            line = raw_line.strip()
-            if logical_line:
-                line = f'{logical_line} {line}'
-                logical_line = ''
-            if line.endswith('\\'):
-                logical_line = line[:-1].strip()
-                continue
-            if line and not line.startswith('#'):
-                constraints.append(line)
-    return set(constraints)
-
-
 @contextlib.contextmanager
 def _bootstrap_build_env(
     isolation: bool,
@@ -253,7 +223,8 @@ def _bootstrap_build_env(
 
             install = env.install
             if dependency_constraints_txt:
-                install = partial(install, constraints=_parse_constraints_txt(dependency_constraints_txt))
+                with open(dependency_constraints_txt, encoding='utf-8') as dependency_constraints_file:
+                    install = partial(install, constraints=set(map(str.strip, dependency_constraints_file)))
 
             # first install the build dependencies
             install(builder.build_system_requires, _fresh=True)

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -206,9 +206,17 @@ def _error(msg: str, code: int = 1) -> NoReturn:  # pragma: no cover
 
 def _parse_constraints_txt(path: os.PathLike[str] | str) -> set[str]:
     """
-    Join backslash-continued lines before deduplicating, so a hashed requirement (e.g. from
-    ``pip-compile --generate-hashes``) can't have its ``--hash`` options split from its requirement line and lost
-    when the set is later reassembled, which would silently skip that hash check depending on the hash seed.
+    Parse a pip/uv constraints file into a set of constraint lines.
+
+    Requirement files support backslash line continuations (as produced by, e.g.,
+    ``pip-compile --generate-hashes``, where a package's ``--hash`` options are
+    wrapped onto continuation lines). These must be joined back into a single
+    logical line *before* being placed in a set: splitting on physical lines and
+    only later rejoining with ``'\\n'.join()`` loses the continuation marker's
+    positional relationship, and because sets do not preserve insertion order,
+    the rejoined file can scramble unrelated requirement and hash lines together,
+    or separate a hash from its requirement so it stops applying, silently and
+    unpredictably (depending on the interpreter's hash seed for that run).
     """
     constraints: list[str] = []
     logical_line = ''

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -224,7 +224,13 @@ def _bootstrap_build_env(
             install = env.install
             if dependency_constraints_txt:
                 with open(dependency_constraints_txt, encoding='utf-8') as dependency_constraints_file:
-                    install = partial(install, constraints=set(map(str.strip, dependency_constraints_file)))
+                    constraints_text = dependency_constraints_file.read()
+                if constraints_text.strip():
+                    # Passed through as a single element so the installer backends' `'\n'.join(constraints)` reproduces
+                    # the file byte-for-byte, instead of re-parsing it into individual lines (which can split a
+                    # requirement from its `--hash` continuation lines, e.g. from `pip-compile --generate-hashes`,
+                    # and silently drop the hash check).
+                    install = partial(install, constraints=(constraints_text,))
 
             # first install the build dependencies
             install(builder.build_system_requires, _fresh=True)

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -226,10 +226,11 @@ def _bootstrap_build_env(
                 with open(dependency_constraints_txt, encoding='utf-8') as dependency_constraints_file:
                     constraints_text = dependency_constraints_file.read()
                 if constraints_text.strip():
-                    # Passed through as a single element so the installer backends' `'\n'.join(constraints)` reproduces
-                    # the file byte-for-byte, instead of re-parsing it into individual lines (which can split a
-                    # requirement from its `--hash` continuation lines, e.g. from `pip-compile --generate-hashes`,
-                    # and silently drop the hash check).
+                    # Passed through as a single element instead of re-parsed into lines, so a requirement can never
+                    # be split from its `--hash` continuation lines (as produced by `pip-compile --generate-hashes`)
+                    # and silently lose its hash check. env.py's installer backends reconstruct the original file via
+                    # `'\n'.join(constraints)` (see `_PipInstaller`/`_UvInstaller.install_dependencies`), a no-op here
+                    # since there is only one element.
                     install = partial(install, constraints=(constraints_text,))
 
             # first install the build dependencies

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -204,6 +204,36 @@ def _error(msg: str, code: int = 1) -> NoReturn:  # pragma: no cover
     raise SystemExit(code)
 
 
+def _parse_constraints_txt(path: os.PathLike[str] | str) -> set[str]:
+    """
+    Parse a pip/uv constraints file into a set of constraint lines.
+
+    Requirement files support backslash line continuations (as produced by, e.g.,
+    ``pip-compile --generate-hashes``, where a package's ``--hash`` options are
+    wrapped onto continuation lines). These must be joined back into a single
+    logical line *before* being placed in a set: splitting on physical lines and
+    only later rejoining with ``'\\n'.join()`` loses the continuation marker's
+    positional relationship, and because sets do not preserve insertion order,
+    the rejoined file can scramble unrelated requirement and hash lines together,
+    or separate a hash from its requirement so it stops applying, silently and
+    unpredictably (depending on the interpreter's hash seed for that run).
+    """
+    constraints: list[str] = []
+    logical_line = ''
+    with open(path, encoding='utf-8') as constraints_file:
+        for raw_line in constraints_file:
+            line = raw_line.strip()
+            if logical_line:
+                line = f'{logical_line} {line}'
+                logical_line = ''
+            if line.endswith('\\'):
+                logical_line = line[:-1].strip()
+                continue
+            if line and not line.startswith('#'):
+                constraints.append(line)
+    return set(constraints)
+
+
 @contextlib.contextmanager
 def _bootstrap_build_env(
     isolation: bool,
@@ -223,8 +253,7 @@ def _bootstrap_build_env(
 
             install = env.install
             if dependency_constraints_txt:
-                with open(dependency_constraints_txt, encoding='utf-8') as dependency_constraints_file:
-                    install = partial(install, constraints=set(map(str.strip, dependency_constraints_file)))
+                install = partial(install, constraints=_parse_constraints_txt(dependency_constraints_txt))
 
             # first install the build dependencies
             install(builder.build_system_requires, _fresh=True)

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -206,17 +206,9 @@ def _error(msg: str, code: int = 1) -> NoReturn:  # pragma: no cover
 
 def _parse_constraints_txt(path: os.PathLike[str] | str) -> set[str]:
     """
-    Parse a pip/uv constraints file into a set of constraint lines.
-
-    Requirement files support backslash line continuations (as produced by, e.g.,
-    ``pip-compile --generate-hashes``, where a package's ``--hash`` options are
-    wrapped onto continuation lines). These must be joined back into a single
-    logical line *before* being placed in a set: splitting on physical lines and
-    only later rejoining with ``'\\n'.join()`` loses the continuation marker's
-    positional relationship, and because sets do not preserve insertion order,
-    the rejoined file can scramble unrelated requirement and hash lines together,
-    or separate a hash from its requirement so it stops applying, silently and
-    unpredictably (depending on the interpreter's hash seed for that run).
+    Join backslash-continued lines before deduplicating, so a hashed requirement (e.g. from
+    ``pip-compile --generate-hashes``) can't have its ``--hash`` options split from its requirement line and lost
+    when the set is later reassembled, which would silently skip that hash check depending on the hash seed.
     """
     constraints: list[str] = []
     logical_line = ''

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -460,6 +460,41 @@ foo==wot
     install.assert_any_call({'flit_core >=2,<4'}, constraints={'flit-core==12.34', 'foo==wot'}, _fresh=True)
 
 
+@pytest.mark.isolated
+def test_build_package_with_constraints_joins_backslash_continuations(
+    mocker: pytest_mock.MockerFixture, tmp_path: pathlib.Path, package_test_flit: str
+) -> None:
+    # As produced by e.g. `pip-compile --generate-hashes`: a requirement and its --hash options wrapped onto
+    # continuation lines. Regression test for the requirement/hash pair being split apart and losing its hash
+    # when the file is later reassembled from a set of independently-parsed physical lines.
+    install = mocker.patch('build.env.DefaultIsolatedEnv.install')
+
+    constraints_txt_path = tmp_path.joinpath('constraints.txt')
+    constraints_txt_path.write_text(
+        """\
+flit-core==12.34 \\
+    --hash=sha256:aaaa \\
+    --hash=sha256:bbbb
+    # via test
+foo==wot \\
+    --hash=sha256:cccc
+""",
+        encoding='utf-8',
+    )
+
+    with pytest.raises(build.BuildBackendException, match=re.escape("Backend 'flit_core.buildapi' is not available.")):
+        build.__main__.build_package(package_test_flit, tmp_path, ['wheel'], dependency_constraints_txt=constraints_txt_path)
+
+    install.assert_any_call(
+        {'flit_core >=2,<4'},
+        constraints={
+            'flit-core==12.34 --hash=sha256:aaaa --hash=sha256:bbbb',
+            'foo==wot --hash=sha256:cccc',
+        },
+        _fresh=True,
+    )
+
+
 @pytest.mark.pypy3323bug
 @pytest.mark.parametrize(
     ('args', 'output'),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -457,7 +457,29 @@ foo==wot
     with pytest.raises(build.BuildBackendException, match=re.escape("Backend 'flit_core.buildapi' is not available.")):
         build.__main__.build_package(package_test_flit, tmp_path, ['wheel'], dependency_constraints_txt=constraints_txt_path)
 
-    install.assert_any_call({'flit_core >=2,<4'}, constraints={'flit-core==12.34', 'foo==wot'}, _fresh=True)
+    install.assert_any_call({'flit_core >=2,<4'}, constraints=('flit-core==12.34\nfoo==wot\n',), _fresh=True)
+
+
+@pytest.mark.isolated
+def test_build_package_with_constraints_passes_file_through_unmodified(
+    mocker: pytest_mock.MockerFixture, tmp_path: pathlib.Path, package_test_flit: str
+) -> None:
+    # As produced by e.g. `pip-compile --generate-hashes`: a requirement and its --hash options wrapped onto
+    # continuation lines. Regression test for the requirement/hash pair being split apart when re-parsed into
+    # individual lines - the file content must reach the installer byte-for-byte instead.
+    install = mocker.patch('build.env.DefaultIsolatedEnv.install')
+
+    constraints_text = (
+        'flit-core==12.34 \\\n    --hash=sha256:aaaa \\\n    --hash=sha256:bbbb\n    # via test\nfoo==wot \\\n'
+        '    --hash=sha256:cccc\n'
+    )
+    constraints_txt_path = tmp_path.joinpath('constraints.txt')
+    constraints_txt_path.write_text(constraints_text, encoding='utf-8')
+
+    with pytest.raises(build.BuildBackendException, match=re.escape("Backend 'flit_core.buildapi' is not available.")):
+        build.__main__.build_package(package_test_flit, tmp_path, ['wheel'], dependency_constraints_txt=constraints_txt_path)
+
+    install.assert_any_call({'flit_core >=2,<4'}, constraints=(constraints_text,), _fresh=True)
 
 
 @pytest.mark.pypy3323bug

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -460,41 +460,6 @@ foo==wot
     install.assert_any_call({'flit_core >=2,<4'}, constraints={'flit-core==12.34', 'foo==wot'}, _fresh=True)
 
 
-@pytest.mark.isolated
-def test_build_package_with_constraints_joins_backslash_continuations(
-    mocker: pytest_mock.MockerFixture, tmp_path: pathlib.Path, package_test_flit: str
-) -> None:
-    # As produced by e.g. `pip-compile --generate-hashes`: a requirement and its --hash options wrapped onto
-    # continuation lines. Regression test for the requirement/hash pair being split apart and losing its hash
-    # when the file is later reassembled from a set of independently-parsed physical lines.
-    install = mocker.patch('build.env.DefaultIsolatedEnv.install')
-
-    constraints_txt_path = tmp_path.joinpath('constraints.txt')
-    constraints_txt_path.write_text(
-        """\
-flit-core==12.34 \\
-    --hash=sha256:aaaa \\
-    --hash=sha256:bbbb
-    # via test
-foo==wot \\
-    --hash=sha256:cccc
-""",
-        encoding='utf-8',
-    )
-
-    with pytest.raises(build.BuildBackendException, match=re.escape("Backend 'flit_core.buildapi' is not available.")):
-        build.__main__.build_package(package_test_flit, tmp_path, ['wheel'], dependency_constraints_txt=constraints_txt_path)
-
-    install.assert_any_call(
-        {'flit_core >=2,<4'},
-        constraints={
-            'flit-core==12.34 --hash=sha256:aaaa --hash=sha256:bbbb',
-            'foo==wot --hash=sha256:cccc',
-        },
-        _fresh=True,
-    )
-
-
 @pytest.mark.pypy3323bug
 @pytest.mark.parametrize(
     ('args', 'output'),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -482,6 +482,21 @@ def test_build_package_with_constraints_passes_file_through_unmodified(
     install.assert_any_call({'flit_core >=2,<4'}, constraints=(constraints_text,), _fresh=True)
 
 
+@pytest.mark.isolated
+def test_build_package_with_empty_constraints_txt(
+    mocker: pytest_mock.MockerFixture, tmp_path: pathlib.Path, package_test_flit: str
+) -> None:
+    install = mocker.patch('build.env.DefaultIsolatedEnv.install')
+
+    constraints_txt_path = tmp_path.joinpath('constraints.txt')
+    constraints_txt_path.write_text('  \n\n', encoding='utf-8')
+
+    with pytest.raises(build.BuildBackendException, match=re.escape("Backend 'flit_core.buildapi' is not available.")):
+        build.__main__.build_package(package_test_flit, tmp_path, ['wheel'], dependency_constraints_txt=constraints_txt_path)
+
+    install.assert_any_call({'flit_core >=2,<4'}, _fresh=True)
+
+
 @pytest.mark.pypy3323bug
 @pytest.mark.parametrize(
     ('args', 'output'),

--- a/tests/test_main_helpers.py
+++ b/tests/test_main_helpers.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import pathlib
+
 import pytest
 
-from build.__main__ import _natural_language_list
+from build.__main__ import _natural_language_list, _parse_constraints_txt
 
 
 def test_natural_language_list() -> None:
@@ -11,3 +13,45 @@ def test_natural_language_list() -> None:
     assert _natural_language_list(['one', 'two', 'three']) == 'one, two and three'
     with pytest.raises(IndexError, match='no elements'):
         _natural_language_list([])
+
+
+def test_parse_constraints_txt_single_line(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / 'constraints.txt'
+    path.write_text('foo==1.0\nbar==2.0\n', encoding='utf-8')
+    assert _parse_constraints_txt(path) == {'foo==1.0', 'bar==2.0'}
+
+
+def test_parse_constraints_txt_ignores_comments_and_blank_lines(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / 'constraints.txt'
+    path.write_text('# a comment\nfoo==1.0\n\nbar==2.0\n', encoding='utf-8')
+    assert _parse_constraints_txt(path) == {'foo==1.0', 'bar==2.0'}
+
+
+def test_parse_constraints_txt_joins_backslash_continuations(tmp_path: pathlib.Path) -> None:
+    # As produced by e.g. `pip-compile --generate-hashes`: a requirement and its
+    # --hash options wrapped onto continuation lines. Regression test for the
+    # requirement/hash pair being split apart and losing its hash when the file
+    # is later reconstructed from a set of independently-parsed physical lines.
+    path = tmp_path / 'constraints.txt'
+    path.write_text(
+        'editables==0.6 \\\n'
+        '    --hash=sha256:1163834902381c4613787951c5914800fdf155ae08848a373b8ea5006780977c \\\n'
+        '    --hash=sha256:d70e4698078a1d033e7786d9c64e5be070d058a67c21417024d38a58ac20aa43\n'
+        '    # via reprodemo (pyproject.toml::build-system.backend::editable)\n'
+        'hatchling==1.31.0 \\\n'
+        '    --hash=sha256:6b48ad4068a482ed7239b3a8215bc55b47aad3345d58dfc94e553c5d2d46211b \\\n'
+        '    --hash=sha256:aac80bec8b6fe35e8480f1c335be8910fa210a0e6f735a139be205dadcacb544\n'
+        '    # via reprodemo (pyproject.toml::build-system.requires)\n',
+        encoding='utf-8',
+    )
+    editables_line = (
+        'editables==0.6 '
+        '--hash=sha256:1163834902381c4613787951c5914800fdf155ae08848a373b8ea5006780977c '
+        '--hash=sha256:d70e4698078a1d033e7786d9c64e5be070d058a67c21417024d38a58ac20aa43'
+    )
+    hatchling_line = (
+        'hatchling==1.31.0 '
+        '--hash=sha256:6b48ad4068a482ed7239b3a8215bc55b47aad3345d58dfc94e553c5d2d46211b '
+        '--hash=sha256:aac80bec8b6fe35e8480f1c335be8910fa210a0e6f735a139be205dadcacb544'
+    )
+    assert _parse_constraints_txt(path) == {editables_line, hatchling_line}

--- a/tests/test_main_helpers.py
+++ b/tests/test_main_helpers.py
@@ -17,13 +17,13 @@ def test_natural_language_list() -> None:
 
 def test_parse_constraints_txt_single_line(tmp_path: pathlib.Path) -> None:
     path = tmp_path / 'constraints.txt'
-    path.write_text('foo==1.0\nbar==2.0\n')
+    path.write_text('foo==1.0\nbar==2.0\n', encoding='utf-8')
     assert _parse_constraints_txt(path) == {'foo==1.0', 'bar==2.0'}
 
 
 def test_parse_constraints_txt_ignores_comments_and_blank_lines(tmp_path: pathlib.Path) -> None:
     path = tmp_path / 'constraints.txt'
-    path.write_text('# a comment\nfoo==1.0\n\nbar==2.0\n')
+    path.write_text('# a comment\nfoo==1.0\n\nbar==2.0\n', encoding='utf-8')
     assert _parse_constraints_txt(path) == {'foo==1.0', 'bar==2.0'}
 
 
@@ -41,7 +41,8 @@ def test_parse_constraints_txt_joins_backslash_continuations(tmp_path: pathlib.P
         'hatchling==1.31.0 \\\n'
         '    --hash=sha256:6b48ad4068a482ed7239b3a8215bc55b47aad3345d58dfc94e553c5d2d46211b \\\n'
         '    --hash=sha256:aac80bec8b6fe35e8480f1c335be8910fa210a0e6f735a139be205dadcacb544\n'
-        '    # via reprodemo (pyproject.toml::build-system.requires)\n'
+        '    # via reprodemo (pyproject.toml::build-system.requires)\n',
+        encoding='utf-8',
     )
     editables_line = (
         'editables==0.6 '

--- a/tests/test_main_helpers.py
+++ b/tests/test_main_helpers.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import pathlib
+
 import pytest
 
-from build.__main__ import _natural_language_list
+from build.__main__ import _natural_language_list, _parse_constraints_txt
 
 
 def test_natural_language_list() -> None:
@@ -11,3 +13,44 @@ def test_natural_language_list() -> None:
     assert _natural_language_list(['one', 'two', 'three']) == 'one, two and three'
     with pytest.raises(IndexError, match='no elements'):
         _natural_language_list([])
+
+
+def test_parse_constraints_txt_single_line(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / 'constraints.txt'
+    path.write_text('foo==1.0\nbar==2.0\n')
+    assert _parse_constraints_txt(path) == {'foo==1.0', 'bar==2.0'}
+
+
+def test_parse_constraints_txt_ignores_comments_and_blank_lines(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / 'constraints.txt'
+    path.write_text('# a comment\nfoo==1.0\n\nbar==2.0\n')
+    assert _parse_constraints_txt(path) == {'foo==1.0', 'bar==2.0'}
+
+
+def test_parse_constraints_txt_joins_backslash_continuations(tmp_path: pathlib.Path) -> None:
+    # As produced by e.g. `pip-compile --generate-hashes`: a requirement and its
+    # --hash options wrapped onto continuation lines. Regression test for the
+    # requirement/hash pair being split apart and losing its hash when the file
+    # is later reconstructed from a set of independently-parsed physical lines.
+    path = tmp_path / 'constraints.txt'
+    path.write_text(
+        'editables==0.6 \\\n'
+        '    --hash=sha256:1163834902381c4613787951c5914800fdf155ae08848a373b8ea5006780977c \\\n'
+        '    --hash=sha256:d70e4698078a1d033e7786d9c64e5be070d058a67c21417024d38a58ac20aa43\n'
+        '    # via reprodemo (pyproject.toml::build-system.backend::editable)\n'
+        'hatchling==1.31.0 \\\n'
+        '    --hash=sha256:6b48ad4068a482ed7239b3a8215bc55b47aad3345d58dfc94e553c5d2d46211b \\\n'
+        '    --hash=sha256:aac80bec8b6fe35e8480f1c335be8910fa210a0e6f735a139be205dadcacb544\n'
+        '    # via reprodemo (pyproject.toml::build-system.requires)\n'
+    )
+    editables_line = (
+        'editables==0.6 '
+        '--hash=sha256:1163834902381c4613787951c5914800fdf155ae08848a373b8ea5006780977c '
+        '--hash=sha256:d70e4698078a1d033e7786d9c64e5be070d058a67c21417024d38a58ac20aa43'
+    )
+    hatchling_line = (
+        'hatchling==1.31.0 '
+        '--hash=sha256:6b48ad4068a482ed7239b3a8215bc55b47aad3345d58dfc94e553c5d2d46211b '
+        '--hash=sha256:aac80bec8b6fe35e8480f1c335be8910fa210a0e6f735a139be205dadcacb544'
+    )
+    assert _parse_constraints_txt(path) == {editables_line, hatchling_line}

--- a/tests/test_main_helpers.py
+++ b/tests/test_main_helpers.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import pathlib
-
 import pytest
 
-from build.__main__ import _natural_language_list, _parse_constraints_txt
+from build.__main__ import _natural_language_list
 
 
 def test_natural_language_list() -> None:
@@ -13,44 +11,3 @@ def test_natural_language_list() -> None:
     assert _natural_language_list(['one', 'two', 'three']) == 'one, two and three'
     with pytest.raises(IndexError, match='no elements'):
         _natural_language_list([])
-
-
-def test_parse_constraints_txt_single_line(tmp_path: pathlib.Path) -> None:
-    path = tmp_path / 'constraints.txt'
-    path.write_text('foo==1.0\nbar==2.0\n')
-    assert _parse_constraints_txt(path) == {'foo==1.0', 'bar==2.0'}
-
-
-def test_parse_constraints_txt_ignores_comments_and_blank_lines(tmp_path: pathlib.Path) -> None:
-    path = tmp_path / 'constraints.txt'
-    path.write_text('# a comment\nfoo==1.0\n\nbar==2.0\n')
-    assert _parse_constraints_txt(path) == {'foo==1.0', 'bar==2.0'}
-
-
-def test_parse_constraints_txt_joins_backslash_continuations(tmp_path: pathlib.Path) -> None:
-    # As produced by e.g. `pip-compile --generate-hashes`: a requirement and its
-    # --hash options wrapped onto continuation lines. Regression test for the
-    # requirement/hash pair being split apart and losing its hash when the file
-    # is later reconstructed from a set of independently-parsed physical lines.
-    path = tmp_path / 'constraints.txt'
-    path.write_text(
-        'editables==0.6 \\\n'
-        '    --hash=sha256:1163834902381c4613787951c5914800fdf155ae08848a373b8ea5006780977c \\\n'
-        '    --hash=sha256:d70e4698078a1d033e7786d9c64e5be070d058a67c21417024d38a58ac20aa43\n'
-        '    # via reprodemo (pyproject.toml::build-system.backend::editable)\n'
-        'hatchling==1.31.0 \\\n'
-        '    --hash=sha256:6b48ad4068a482ed7239b3a8215bc55b47aad3345d58dfc94e553c5d2d46211b \\\n'
-        '    --hash=sha256:aac80bec8b6fe35e8480f1c335be8910fa210a0e6f735a139be205dadcacb544\n'
-        '    # via reprodemo (pyproject.toml::build-system.requires)\n'
-    )
-    editables_line = (
-        'editables==0.6 '
-        '--hash=sha256:1163834902381c4613787951c5914800fdf155ae08848a373b8ea5006780977c '
-        '--hash=sha256:d70e4698078a1d033e7786d9c64e5be070d058a67c21417024d38a58ac20aa43'
-    )
-    hatchling_line = (
-        'hatchling==1.31.0 '
-        '--hash=sha256:6b48ad4068a482ed7239b3a8215bc55b47aad3345d58dfc94e553c5d2d46211b '
-        '--hash=sha256:aac80bec8b6fe35e8480f1c335be8910fa210a0e6f735a139be205dadcacb544'
-    )
-    assert _parse_constraints_txt(path) == {editables_line, hatchling_line}

--- a/tests/test_main_helpers.py
+++ b/tests/test_main_helpers.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import pathlib
-
 import pytest
 
-from build.__main__ import _natural_language_list, _parse_constraints_txt
+from build.__main__ import _natural_language_list
 
 
 def test_natural_language_list() -> None:
@@ -13,45 +11,3 @@ def test_natural_language_list() -> None:
     assert _natural_language_list(['one', 'two', 'three']) == 'one, two and three'
     with pytest.raises(IndexError, match='no elements'):
         _natural_language_list([])
-
-
-def test_parse_constraints_txt_single_line(tmp_path: pathlib.Path) -> None:
-    path = tmp_path / 'constraints.txt'
-    path.write_text('foo==1.0\nbar==2.0\n', encoding='utf-8')
-    assert _parse_constraints_txt(path) == {'foo==1.0', 'bar==2.0'}
-
-
-def test_parse_constraints_txt_ignores_comments_and_blank_lines(tmp_path: pathlib.Path) -> None:
-    path = tmp_path / 'constraints.txt'
-    path.write_text('# a comment\nfoo==1.0\n\nbar==2.0\n', encoding='utf-8')
-    assert _parse_constraints_txt(path) == {'foo==1.0', 'bar==2.0'}
-
-
-def test_parse_constraints_txt_joins_backslash_continuations(tmp_path: pathlib.Path) -> None:
-    # As produced by e.g. `pip-compile --generate-hashes`: a requirement and its
-    # --hash options wrapped onto continuation lines. Regression test for the
-    # requirement/hash pair being split apart and losing its hash when the file
-    # is later reconstructed from a set of independently-parsed physical lines.
-    path = tmp_path / 'constraints.txt'
-    path.write_text(
-        'editables==0.6 \\\n'
-        '    --hash=sha256:1163834902381c4613787951c5914800fdf155ae08848a373b8ea5006780977c \\\n'
-        '    --hash=sha256:d70e4698078a1d033e7786d9c64e5be070d058a67c21417024d38a58ac20aa43\n'
-        '    # via reprodemo (pyproject.toml::build-system.backend::editable)\n'
-        'hatchling==1.31.0 \\\n'
-        '    --hash=sha256:6b48ad4068a482ed7239b3a8215bc55b47aad3345d58dfc94e553c5d2d46211b \\\n'
-        '    --hash=sha256:aac80bec8b6fe35e8480f1c335be8910fa210a0e6f735a139be205dadcacb544\n'
-        '    # via reprodemo (pyproject.toml::build-system.requires)\n',
-        encoding='utf-8',
-    )
-    editables_line = (
-        'editables==0.6 '
-        '--hash=sha256:1163834902381c4613787951c5914800fdf155ae08848a373b8ea5006780977c '
-        '--hash=sha256:d70e4698078a1d033e7786d9c64e5be070d058a67c21417024d38a58ac20aa43'
-    )
-    hatchling_line = (
-        'hatchling==1.31.0 '
-        '--hash=sha256:6b48ad4068a482ed7239b3a8215bc55b47aad3345d58dfc94e553c5d2d46211b '
-        '--hash=sha256:aac80bec8b6fe35e8480f1c335be8910fa210a0e6f735a139be205dadcacb544'
-    )
-    assert _parse_constraints_txt(path) == {editables_line, hatchling_line}

--- a/tests/test_main_helpers.py
+++ b/tests/test_main_helpers.py
@@ -17,13 +17,13 @@ def test_natural_language_list() -> None:
 
 def test_parse_constraints_txt_single_line(tmp_path: pathlib.Path) -> None:
     path = tmp_path / 'constraints.txt'
-    path.write_text('foo==1.0\nbar==2.0\n', encoding='utf-8')
+    path.write_text('foo==1.0\nbar==2.0\n')
     assert _parse_constraints_txt(path) == {'foo==1.0', 'bar==2.0'}
 
 
 def test_parse_constraints_txt_ignores_comments_and_blank_lines(tmp_path: pathlib.Path) -> None:
     path = tmp_path / 'constraints.txt'
-    path.write_text('# a comment\nfoo==1.0\n\nbar==2.0\n', encoding='utf-8')
+    path.write_text('# a comment\nfoo==1.0\n\nbar==2.0\n')
     assert _parse_constraints_txt(path) == {'foo==1.0', 'bar==2.0'}
 
 
@@ -41,8 +41,7 @@ def test_parse_constraints_txt_joins_backslash_continuations(tmp_path: pathlib.P
         'hatchling==1.31.0 \\\n'
         '    --hash=sha256:6b48ad4068a482ed7239b3a8215bc55b47aad3345d58dfc94e553c5d2d46211b \\\n'
         '    --hash=sha256:aac80bec8b6fe35e8480f1c335be8910fa210a0e6f735a139be205dadcacb544\n'
-        '    # via reprodemo (pyproject.toml::build-system.requires)\n',
-        encoding='utf-8',
+        '    # via reprodemo (pyproject.toml::build-system.requires)\n'
     )
     editables_line = (
         'editables==0.6 '


### PR DESCRIPTION
## Problem

`--dependency-constraints-txt` reads the file with:

```python
constraints=set(map(str.strip, dependency_constraints_file))
```

This treats every *physical* line as one independent constraint. It does not join
backslash-continued lines, so a file like the one `pip-compile --generate-hashes`
produces:

```
hatchling==1.31.0 \
    --hash=sha256:6b48ad...
    --hash=sha256:aac80b...
```

is split into three separate set elements: the requirement and each `--hash` line on
its own. When these get written back out to a temporary file for pip/uv
(`'\n'.join(constraints)`), a `set` has no guaranteed iteration order, so the
requirement and its hashes may or may not end up adjacent again.

## Impact

This is silent, not just cosmetic. When the continuation breaks apart, pip's
constraint parser reads the orphaned `--hash` line as unattached ("has `--hash` but
no requirement, and will be ignored") and installs the requirement **without
checking any hash at all** — no warning surfaces to the `build` output.

Verified directly against a single-dependency constraints file
(`uv_build==0.12.0 --hash=sha256:...`) with a deliberately wrong hash, same file,
same command, 8 runs back to back:

```
$ python -m build --dependency-constraints-txt requirements-build.txt -o dist .

run 1: build failed, wrong hash detected
run 2: build succeeded  ← wrong hash silently accepted
run 3: build succeeded  ← wrong hash silently accepted
run 4: build failed, wrong hash detected
run 5: build succeeded  ← wrong hash silently accepted
run 6: build succeeded  ← wrong hash silently accepted
run 7: build failed, wrong hash detected
run 8: build succeeded  ← wrong hash silently accepted
```

5 of 8 runs accept the tampered hash with no error and no indication in the output
that anything was skipped. With `PYTHONHASHSEED` fixed, the outcome becomes 100%
deterministic per seed (5/5 identical for a given seed) — different seeds give
different, opposite outcomes. This isolates the cause to `set` iteration order, not
to anything timing- or network-related.

- Against a larger, six-package constraints file (a `hatchling` build tree with
  multiple multi-hash entries), the failure was consistent rather than
  intermittent, but the *symptom* varied between runs: sometimes a hash got
  attributed to the wrong package, sometimes two unrelated requirement lines were
  concatenated into one invalid line (e.g. `packaging==26.2 hatchling==1.31.0
  pluggy==1.6.0`).

So depending on the file and the hash seed, this flag can either crash with a
confusing parse error, or silently skip hash verification entirely while reporting
success.

## Fix

Join continuation lines into complete logical lines before deduplicating, so every
set element is a self-contained, order-independent constraint (comments and blank
lines are also filtered out explicitly, matching how the file is meant to be read).

## Test plan

- `tests/test_main_helpers.py`: three new tests —
  `test_parse_constraints_txt_single_line`,
  `test_parse_constraints_txt_ignores_comments_and_blank_lines`, and
  `test_parse_constraints_txt_joins_backslash_continuations` (the regression test,
  using a real `pip-compile --generate-hashes`-style fixture).
- Full existing suite (`test_main.py`, `test_env.py`, `test_main_helpers.py`) passes
  unchanged: 211 passed, 2 skipped (platform-specific).
