### PR TITLE
tests: mark test_main_sdist_input_end_to_end with pytest.mark.network

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1322,6 +1322,7 @@ def test_main_sdist_input_passes_kwargs(sdist: pathlib.Path, mocker: pytest_mock
     assert kwargs['installer'] == 'pip'
 
 
+@pytest.mark.network
 def test_main_sdist_input_end_to_end(tmp_path: pathlib.Path, package_test_setuptools: str) -> None:
     sdist_dir = tmp_path / 'dist'
     sdist_dir.mkdir()


### PR DESCRIPTION
## Description

`test_main_sdist_input_end_to_end` tries to install `setuptools` from PyPI, and that does not work in offline environments.

## Changelog

Micro change; I believe a changelog entry is not necessary.

## Checklist

- [ ] Tests pass locally (`tox`)
- [x] Code follows project style (`tox -e fix`)
- [x] Type checks pass (`tox -e type`)
- [ ] Documentation builds (`tox -e docs`)
