### PR TITLE
Ignore invalid distributions when checking dependencies

### DIFF
--- a/docs/changelog/1145.bugfix.rst
+++ b/docs/changelog/1145.bugfix.rst
@@ -1,0 +1,1 @@
+Ignore invalid distributions when checking dependencies - by :user:`rossburton`

--- a/src/build/_util.py
+++ b/src/build/_util.py
@@ -67,6 +67,12 @@ def _check_dependency(
         yield (*ancestral_req_strings, normalised_req_string)
         return
 
+    if not dist.name:
+        # If the distribution doesn't have a name it has no metadata, so it's not actually
+        # a valid distribution. Ignore it.
+        yield (*ancestral_req_strings, normalised_req_string)
+        return
+
     if req.specifier and not req.specifier.contains(dist.version, prereleases=True):
         # the installed version is incompatible.
         yield (*ancestral_req_strings, normalised_req_string)


### PR DESCRIPTION
## Description

If there's an empty directory foo-1.2.dist-info/ on the search path then importlib will return that as a distribution called "foo".

However it has no code and no metadata, so doesn't exist in any real way. Check that the found distribution is in some way valid by verifying that it has a name set.

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

- [x] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing `` Add custom backend support - by :user:`yourname`  ``

## Checklist

- [ ] Tests pass locally (`tox`)
- [ ] Code follows project style (`tox -e fix`)
- [ ] Type checks pass (`tox -e type`)
- [ ] Documentation builds (`tox -e docs`)
