### PR TITLE
🐛 fix(ci): bump build-and-inspect-python-package to v3.0.1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
   create-release:
     name: Create GitHub Release
     needs: [dist]


### PR DESCRIPTION
The "Build distribution" check fails on every PR since August 10, for example in [run 31618820590](https://github.com/pypa/build/actions/runs/31618820590), [31589143829](https://github.com/pypa/build/actions/runs/31589143829), and [31574411778](https://github.com/pypa/build/actions/runs/31574411778). flit-core 4.0 now writes `Metadata-Version: 2.5` ([PEP 794](https://peps.python.org/pep-0794/)), and the twine 6.2.0 bundled in build-and-inspect-python-package v2.18.0 rejects it with `InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version`. The bundled packaging 26.2 does know 2.5, but twine 6.2.0 [overwrites `packaging.metadata._VALID_METADATA_VERSIONS`](https://github.com/pypa/twine/blob/6.2.0/twine/package.py#L31-L41) with a hardcoded list that stops at 2.4, so the check fails regardless.

Twine 7.0.0 [dropped that override](https://github.com/pypa/twine/issues/1317), and [build-and-inspect-python-package v3.0.0](https://github.com/hynek/build-and-inspect-python-package/releases/tag/v3.0.0) bundles it, with the changelog naming metadata 2.5 and PEP 794 support as the reason. This bumps the pin to [v3.0.1](https://github.com/hynek/build-and-inspect-python-package/releases/tag/v3.0.1), the latest release. Note that starting with v3 the action no longer force-pushes major version tags, so future bumps keep coming through the pinned commit hash as before.

Verified locally: `uv build` on this branch produces a wheel with `Metadata-Version: 2.5`, `twine check --strict` with twine 6.2.0 plus packaging 26.2 (the v2.18.0 pins) reproduces the error, and twine 7.0.0 with the same packaging passes for both the sdist and the wheel.
