### PR TITLE
🐛 fix(ci): pin coverage core to ctrace so test contexts record

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,12 +149,12 @@ exclude-newer = "7 days"
 
 [tool.coverage]
 run.plugins = ["covdefaults"]
+run.core = "ctrace"  # sysmon is 3.14+'s default but can't record dynamic contexts; PyPy falls back to pytrace
 run.source = ["build", "tests"]
 run.omit = ["tests/conftest.py", "tests/test_integration.py",]
 report.omit = ["src/build/_types.py"]
 run.disable_warnings = [
   "module-not-measured",  # Triggers in multithreaded context on build
-  "no-sysmon",
 ]
 covdefaults.subtract_omit = "*/__main__.py"
 report.exclude_also = [

--- a/tox.toml
+++ b/tox.toml
@@ -27,7 +27,6 @@ commands = [
 dependency_groups = ["test"]
 
 [env_run_base.set_env]
-COVERAGE_CORE = "sysmon"
 COVERAGE_FILE = "{toxworkdir}/.coverage.{envname}"
 PYPY3323BUG = "1"
 PYTHONWARNDEFAULTENCODING = "1"


### PR DESCRIPTION
coverage 7.15.3 turned the sysmon-cannot-record-dynamic-contexts condition into a [warning](https://github.com/nedbat/coveragepy/pull/2234) that `filterwarnings = ["error"]` makes fatal on 3.14/3.15, where sysmon is now the default core. Pinning `run.core = "ctrace"` in the coverage config keeps `--cov-context=test` recording; the config key, unlike the `COVERAGE_CORE` env var, falls back to PyTracer on PyPy.
