### PR TITLE
🐛 fix(ci): rerun integration tests on transient network errors

### DIFF
--- a/.github/workflows/reusable-pytest.yml
+++ b/.github/workflows/reusable-pytest.yml
@@ -7,7 +7,7 @@ jobs:
     name: Run tests
     runs-on: ${{ matrix.os }}-latest
     env:
-      PYTEST_ADDOPTS: "--run-integration --showlocals -vv --durations=10 --reruns 5 --only-rerun subprocess.CalledProcessError"
+      PYTEST_ADDOPTS: "--run-integration --showlocals -vv --durations=10 --reruns 5 --only-rerun CalledProcessError --only-rerun RemoteDisconnected --only-rerun HTTPError"
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The integration tests build real projects from PyPI, so a dropped connection fails the job: [run 31651088211](https://github.com/pypa/build/actions/runs/31651088211) lost a dateutil case to `http.client.RemoteDisconnected` while the other 328 tests passed. Module-qualified `--only-rerun` patterns cannot fix that. Since [pytest-rerunfailures 15.1](https://github.com/pytest-dev/pytest-rerunfailures/blob/16.4/CHANGES.rst) the filter matches against [`f"{excinfo.type.__name__}: {excinfo.value}"`](https://github.com/pytest-dev/pytest-rerunfailures/blob/16.4/src/pytest_rerunfailures.py#L463), a string that starts with the bare class name, so a pattern spelled `http.client.RemoteDisconnected` cannot match ([run 31651907354](https://github.com/pypa/build/actions/runs/31651907354) failed on that exception with zero reruns) and the existing `subprocess.CalledProcessError` pattern has been dead since that release too. Filtering on the bare names `CalledProcessError`, `RemoteDisconnected` and `HTTPError` matches the current target and, as unanchored regexes, the module-qualified `reprcrash` message that releases before 15.1 matched against.
