### PR TITLE
chore: run mypy on more parts of the code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ typing = [
   "tomli",
   "typing-extensions >= 4.0.0",
   "types-colorama",
+  "gitpython >= 3.1.44",
   { include-group = "test-core" },
   { include-group = "extra" },
 ]
@@ -192,7 +193,7 @@ filterwarnings = [
 ]
 
 [tool.mypy]
-files = ["src", "tests"]
+files = ["src", "tests", "tasks", "docs"]
 exclude = ["tests/packages"]
 python_version = "3.10"
 strict = true

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -107,7 +107,7 @@ def tag_release_commit(release_commit: Commit, repo: Repo, version: Version) -> 
     existing_tags = [x.name for x in repo.tags]
     if tag_name in existing_tags:
         print(f'delete existing tag {tag_name}')
-        repo.delete_tag(tag_name)
+        repo.delete_tag(repo.tags[tag_name])
     changelog_content = extract_changelog_for_version(version)
     tag_message = f'build {version}\n\n{changelog_content}'
     print(f'creating tag {tag_name}')


### PR DESCRIPTION
## Description

<!-- Describe what changes you made and why -->

I applied full-repo checking to mypy to match #1136 and #1135.

This removes one of the two reasons listed to switch: Full tree checking.

The other reason is "maturity", which IMO has a pretty obvious answer. ;)

If we still want to evaluate a switch, this reduces the diff.

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

No fragment needed.

- [ ] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing `` Add custom backend support - by :user:`yourname`  ``

## Checklist

- [ ] Tests pass locally (`tox`)
- [x] Code follows project style (`tox -e fix`)
- [x] Type checks pass (`tox -e type`)
- [ ] Documentation builds (`tox -e docs`)
