### PR TITLE
chore: Generator is more accurate than Iterator

### DIFF
--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -68,7 +68,7 @@ from build.env import DefaultIsolatedEnv
 TYPE_CHECKING = False
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Mapping, Sequence
+    from collections.abc import Generator, Mapping, Sequence
 
     from build._types import ConfigSettings, Distribution, JSONValue, StrPath, SubprocessRunner
 
@@ -212,7 +212,7 @@ def _bootstrap_build_env(
     installer: _env.Installer,
     env_dir: str | None = None,
     runner: SubprocessRunner | None = None,
-) -> Iterator[ProjectBuilder]:
+) -> Generator[ProjectBuilder, None, None]:
     runner = runner or pyproject_hooks.default_subprocess_runner
     if isolation:
         with DefaultIsolatedEnv(installer=installer, path=env_dir) as env:
@@ -285,7 +285,7 @@ def _build(
 
 
 @contextlib.contextmanager
-def _handle_build_error(*, env_dir: str | None, sdist_extract_dir: StrPath | None) -> Iterator[None]:
+def _handle_build_error(*, env_dir: str | None, sdist_extract_dir: StrPath | None) -> Generator[None, None, None]:
     try:
         yield
     except (BuildException, FailedProcessError) as e:
@@ -883,7 +883,7 @@ def _validate_sdist_archive(archive: StrPath) -> str:
 
 
 @contextlib.contextmanager
-def _extract_sdist(archive: StrPath, top_level: str, *, extract_dir: StrPath | None = None) -> Iterator[str]:
+def _extract_sdist(archive: StrPath, top_level: str, *, extract_dir: StrPath | None = None) -> Generator[str, None, None]:
     if extract_dir is None:
         tmp_dir = tempfile.mkdtemp(prefix='build-via-sdist-')
         try:

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -212,7 +212,7 @@ def _bootstrap_build_env(
     installer: _env.Installer,
     env_dir: str | None = None,
     runner: SubprocessRunner | None = None,
-) -> Generator[ProjectBuilder, None, None]:
+) -> Generator[ProjectBuilder]:
     runner = runner or pyproject_hooks.default_subprocess_runner
     if isolation:
         with DefaultIsolatedEnv(installer=installer, path=env_dir) as env:
@@ -285,7 +285,7 @@ def _build(
 
 
 @contextlib.contextmanager
-def _handle_build_error(*, env_dir: str | None, sdist_extract_dir: StrPath | None) -> Generator[None, None, None]:
+def _handle_build_error(*, env_dir: str | None, sdist_extract_dir: StrPath | None) -> Generator[None]:
     try:
         yield
     except (BuildException, FailedProcessError) as e:
@@ -883,7 +883,7 @@ def _validate_sdist_archive(archive: StrPath) -> str:
 
 
 @contextlib.contextmanager
-def _extract_sdist(archive: StrPath, top_level: str, *, extract_dir: StrPath | None = None) -> Generator[str, None, None]:
+def _extract_sdist(archive: StrPath, top_level: str, *, extract_dir: StrPath | None = None) -> Generator[str]:
     if extract_dir is None:
         tmp_dir = tempfile.mkdtemp(prefix='build-via-sdist-')
         try:

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -405,7 +405,7 @@ class ProjectBuilder:
         return os.path.join(outdir, basename)
 
     @contextlib.contextmanager
-    def _handle_backend(self, hook: str) -> Generator[None, None, None]:
+    def _handle_backend(self, hook: str) -> Generator[None]:
         try:
             yield
         except pyproject_hooks.BackendUnavailable as exception:

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -41,7 +41,7 @@ from ._util import check_dependency
 TYPE_CHECKING = False
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator, Mapping, Sequence
+    from collections.abc import Generator, Iterable, Mapping, Sequence
     from typing import TypedDict, TypeGuard
 
     from typing_extensions import NotRequired, Self
@@ -405,7 +405,7 @@ class ProjectBuilder:
         return os.path.join(outdir, basename)
 
     @contextlib.contextmanager
-    def _handle_backend(self, hook: str) -> Iterator[None]:
+    def _handle_backend(self, hook: str) -> Generator[None, None, None]:
         try:
             yield
         except pyproject_hooks.BackendUnavailable as exception:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,7 +109,7 @@ def avoid_constraints(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _clear_keyring_cache() -> Generator[None, None, None]:
+def _clear_keyring_cache() -> Generator[None]:
     build.env._has_keyring_cli.cache_clear()
     yield
     build.env._has_keyring_cli.cache_clear()
@@ -167,7 +167,7 @@ for package_name in package_names:
 
 
 @pytest.fixture
-def test_no_permission(packages_path: str) -> Generator[str, None, None]:
+def test_no_permission(packages_path: str) -> Generator[str]:
     path = os.path.join(packages_path, 'test-no-permission')
     file = os.path.join(path, 'pyproject.toml')
     orig_stat = os.stat(file).st_mode
@@ -180,7 +180,7 @@ def test_no_permission(packages_path: str) -> Generator[str, None, None]:
 
 
 @pytest.fixture
-def tmp_dir() -> Generator[str, None, None]:
+def tmp_dir() -> Generator[str]:
     path = tempfile.mkdtemp(prefix='python-build-test-')
 
     yield path
@@ -220,7 +220,7 @@ def subtests(request: pytest.FixtureRequest) -> SubTests:
         class Subtests:
             @staticmethod
             @contextlib.contextmanager
-            def test(msg: str | None = None, **_kwargs: object) -> Generator[None, None, None]:  # noqa: ARG004
+            def test(msg: str | None = None, **_kwargs: object) -> Generator[None]:  # noqa: ARG004
                 yield
 
         return Subtests()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,7 +16,7 @@ import unittest.mock
 import venv
 import zipfile
 
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Generator
 from typing import TYPE_CHECKING, Protocol, TypedDict
 
 import pytest
@@ -1004,7 +1004,9 @@ def test_build_metadata_runner_without_extra_environ(
     captured_runners: list[SubprocessRunner] = []
 
     @contextlib.contextmanager
-    def fake_bootstrap(*_args: object, runner: SubprocessRunner, **_kwargs: object) -> Iterator[unittest.mock.MagicMock]:
+    def fake_bootstrap(
+        *_args: object, runner: SubprocessRunner, **_kwargs: object
+    ) -> Generator[unittest.mock.MagicMock, None, None]:
         captured_runners.append(runner)
         builder = mocker.MagicMock()
         metadata_dir = tmp_path / 'metadata'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1004,9 +1004,7 @@ def test_build_metadata_runner_without_extra_environ(
     captured_runners: list[SubprocessRunner] = []
 
     @contextlib.contextmanager
-    def fake_bootstrap(
-        *_args: object, runner: SubprocessRunner, **_kwargs: object
-    ) -> Generator[unittest.mock.MagicMock, None, None]:
+    def fake_bootstrap(*_args: object, runner: SubprocessRunner, **_kwargs: object) -> Generator[unittest.mock.MagicMock]:
         captured_runners.append(runner)
         builder = mocker.MagicMock()
         metadata_dir = tmp_path / 'metadata'


### PR DESCRIPTION
## Description

A function with a yield is a generator. Typeshed refuses to correctly type contextmanager, but it only works on Generator, not Iterator, in practice (it requires `.throw()`). I guess pyrefly patches this or doesn't use typeshed? Anyway, this is better (I'd love for this to be fixed some day, it's actually bit real code bases), so let's type it right here.

No AI assistence used, but based loosly on #1136, which probably did have AI assistence.


<!-- Describe what changes you made and why -->

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

No changelog needed.

- [ ] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing `` Add custom backend support - by :user:`yourname`  ``

## Checklist

- [ ] Tests pass locally (`tox`)
- [x] Code follows project style (`tox -e fix`)
- [ ] Type checks pass (`tox -e type`)
- [ ] Documentation builds (`tox -e docs`)
