### PR TITLE
chore: turn up strictness on mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,8 +197,25 @@ exclude = ["tests/packages"]
 python_version = "3.10"
 strict = true
 disallow_any_explicit = true
-enable_error_code = ["ignore-without-code", "truthy-bool", "redundant-expr"]
+disallow_any_decorated = true
+disallow_any_unimported = true
+disallow_untyped_globals = true
+disallow_redefinition = true
+warn_unused_configs = true
 warn_unreachable = true
+enable_error_code = [
+  "deprecated",
+  "exhaustive-match",
+  "ignore-without-code",
+  "mutable-override",
+  "possibly-undefined",
+  "redundant-expr",
+  "redundant-self",
+  "truthy-bool",
+  "truthy-iterable",
+  "unimported-reveal",
+  "unused-awaitable",
+]
 
 [[tool.mypy.overrides]]
 module = [

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -161,6 +161,8 @@ def _parse_build_system_table(pyproject_toml: Mapping[str, TOMLValue]) -> BuildS
         case {'backend-path': _}:
             msg = '`backend-path` must be an array of strings'
             raise BuildSystemTableValidationError(msg)
+        case _:
+            pass
 
     unknown_props = build_system.keys() - {'requires', 'build-backend', 'backend-path'}
     if unknown_props:


### PR DESCRIPTION
## Description

This enables all the easy settings that are not part of strict=true according to --help. Three were skipped, as they flagged intentional design patterns.

Assisted-by: ClaudeCode:claude-opus-5
(used to compare `--help`'s strict listing with the fully list from `--help`)

<!-- Describe what changes you made and why -->

## Changelog

None needed.

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

- [ ] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing `` Add custom backend support - by :user:`yourname`  ``

## Checklist

- [ ] Tests pass locally (`tox`)
- [ ] Code follows project style (`tox -e fix`)
- [ ] Type checks pass (`tox -e type`)
- [ ] Documentation builds (`tox -e docs`)
