### PR TITLE
chore: clean up unused casts in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,7 +233,7 @@ ignore = [
   "PLR2004", # Magic values
   "PTH",     # Too many change for now
   "Q",       # Using formatter for quotes
-  "S101",    # Assert is used by mypy and pytest
+  "S101",    # Assert is used by the type checker and pytest
   "SLF001",  # Private members are okay to access
 ]
 
@@ -261,8 +261,8 @@ ignore = [
   "W005",  # We _are_ build
 ]
 
-[tool.repo-review]
-ignore = ["PC140"]  # mypy in tox
+[tool.repo-review.ignore]
+PC140 =  "type checker in tox"
 
 
 [tool.towncrier]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,7 @@ def _xfail_isolated_strict(item: pytest.Item, *, is_integration_file: bool) -> b
 
 def is_integration(item: pytest.Item) -> bool:
     # item.location is typically a (path, lineno) tuple; cast to str for typing
-    return os.path.basename(str(item.location[0])) == 'test_integration.py'
+    return os.path.basename(item.location[0]) == 'test_integration.py'
 
 
 def pytest_runtest_call(item: pytest.Item) -> None:

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -295,7 +295,7 @@ def test_build_missing_backend(
     builder = build.ProjectBuilder(bad_backend_path)
 
     with pytest.raises(build.BuildBackendException):
-        builder.build(distribution, str(tmpdir))
+        builder.build(distribution, tmpdir)
 
 
 def _nothing_installed(name: str) -> NoReturn:
@@ -429,7 +429,7 @@ def demo_pkg_inline(tmp_path_factory: pytest.TempPathFactory) -> pathlib.Path:
     tmp_path = tmp_path_factory.mktemp('demo-pkg-inline')
     builder = build.ProjectBuilder(source_dir=os.path.join(os.path.dirname(__file__), 'packages', 'inline'))
     out = tmp_path / 'dist'
-    builder.build('wheel', str(out))
+    builder.build('wheel', out)
     return next(out.iterdir())
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -52,7 +52,7 @@ def test_with_get_requires(package_test_metadata: str) -> None:
 
     # Setuptools < v69.0.3 (https://github.com/pypa/setuptools/pull/4159) normalized this to dashes
     assert metadata['name'].replace('-', '_') == 'test_metadata'
-    assert str(metadata['version']) == '1.0.0'
+    assert metadata['version'] == '1.0.0'
     assert metadata['summary'] == 'hello!'
     assert isinstance(metadata.json, dict)
 


### PR DESCRIPTION
## Description

This was casting strings to strings. Also generalized text refering to mypy

<!-- Describe what changes you made and why -->

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

Not needed

- [ ] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing `` Add custom backend support - by :user:`yourname`  ``

## Checklist

- [ ] Tests pass locally (`tox`)
- [x] Code follows project style (`tox -e fix`)
- [x] Type checks pass (`tox -e type`)
- [ ] Documentation builds (`tox -e docs`)
