### PR TITLE
refactor(typing): apply review feedback from #1093

### DIFF
--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -70,13 +70,9 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping, Sequence
 
-    from build._types import ConfigSettings, Distribution, StrPath, SubprocessRunner
+    from build._types import ConfigSettings, Distribution, JSONValue, StrPath, SubprocessRunner
 
-    # A decoded JSON value, as produced by ``--config-json``. Uses the covariant ``Sequence``/``Mapping``
-    # so the ``str | list[str]`` settings from ``--config-setting`` are also assignable to it.
-    JSONValue = str | int | float | bool | None | Sequence['JSONValue'] | Mapping[str, 'JSONValue']
-
-    class _Args(argparse.Namespace):
+    class _CliArgs(argparse.Namespace):
         """The arguments :func:`main_parser` produces, typed for the rest of the module."""
 
         srcdir: str
@@ -725,7 +721,7 @@ def main(cli_args: Sequence[str], prog: str | None = None) -> None:
     parser = main_parser()
     if prog:
         parser.prog = prog
-    args = cast('_Args', parser.parse_args(cli_args))
+    args = cast('_CliArgs', parser.parse_args(cli_args))
 
     if args.env_dir is not None and args.no_isolation:
         parser.error('--env-dir: not allowed with --no-isolation')
@@ -815,7 +811,7 @@ def _describe_artifact(path: str, name: str) -> _ArtifactReport:
     }
 
 
-def _resolve_config_settings(args: _Args) -> Mapping[str, JSONValue]:
+def _resolve_config_settings(args: _CliArgs) -> Mapping[str, JSONValue]:
     if args.config_json:
         try:
             config_settings = json.loads(args.config_json)
@@ -829,7 +825,9 @@ def _resolve_config_settings(args: _Args) -> Mapping[str, JSONValue]:
     return {}
 
 
-def _select_build(parser: argparse.ArgumentParser, args: _Args, *, sdist_input: bool, wheel_input: bool) -> partial[list[str]]:
+def _select_build(
+    parser: argparse.ArgumentParser, args: _CliArgs, *, sdist_input: bool, wheel_input: bool
+) -> partial[list[str]]:
     if args.report is not None and args.metadata:
         parser.error('--report: not allowed with --metadata')
     if wheel_input and not args.metadata:

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -48,7 +48,7 @@ import zipfile
 from functools import partial
 from tarfile import TarError
 from tarfile import open as tar_open
-from typing import NoReturn, TextIO, TypedDict, cast
+from typing import NoReturn, TextIO, TypedDict
 
 import pyproject_hooks
 
@@ -72,23 +72,24 @@ if TYPE_CHECKING:
 
     from build._types import ConfigSettings, Distribution, JSONValue, StrPath, SubprocessRunner
 
-    class _CliArgs(argparse.Namespace):
-        """The arguments :func:`main_parser` produces, typed for the rest of the module."""
 
-        srcdir: str
-        verbosity: int
-        outdir: str | None
-        distributions: list[Distribution] | None
-        metadata: bool
-        config_settings: list[str] | None
-        config_json: str | None
-        installer: _env.Installer
-        no_isolation: bool
-        dependency_constraints_txt: str | None
-        skip_dependency_check: bool
-        sdist_extract_dir: str | None
-        env_dir: str | None
-        report: str | None
+class _CliArgs:
+    """The arguments :func:`main_parser` produces, typed for the rest of the module."""
+
+    srcdir: str
+    verbosity: int
+    outdir: str | None
+    distributions: list[Distribution] | None
+    metadata: bool
+    config_settings: list[str] | None
+    config_json: str | None
+    installer: _env.Installer
+    no_isolation: bool
+    dependency_constraints_txt: str | None
+    skip_dependency_check: bool
+    sdist_extract_dir: str | None
+    env_dir: str | None
+    report: str | None
 
 
 _COLORS = {
@@ -721,7 +722,7 @@ def main(cli_args: Sequence[str], prog: str | None = None) -> None:
     parser = main_parser()
     if prog:
         parser.prog = prog
-    args = cast('_CliArgs', parser.parse_args(cli_args))
+    args = parser.parse_args(cli_args, _CliArgs())
 
     if args.env_dir is not None and args.no_isolation:
         parser.error('--env-dir: not allowed with --no-isolation')

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -41,31 +41,12 @@ from ._util import check_dependency
 TYPE_CHECKING = False
 
 if TYPE_CHECKING:
-    import datetime
-
     from collections.abc import Iterable, Iterator, Mapping, Sequence
-    from typing import TypedDict
+    from typing import TypedDict, TypeGuard
 
-    if sys.version_info < (3, 11):
-        from typing_extensions import NotRequired, Self
-    else:
-        from typing import NotRequired, Self
+    from typing_extensions import NotRequired, Self
 
-    from ._types import ConfigSettings, Distribution, StrPath, SubprocessRunner
-
-    # A value as produced by ``tomllib`` when parsing ``pyproject.toml``. Uses the covariant
-    # ``Sequence``/``Mapping`` so concrete literals (e.g. ``dict[str, list[str]]``) are assignable.
-    TOMLValue = (
-        str
-        | int
-        | float
-        | bool
-        | datetime.datetime
-        | datetime.date
-        | datetime.time
-        | Sequence['TOMLValue']
-        | Mapping[str, 'TOMLValue']
-    )
+    from ._types import ConfigSettings, Distribution, StrPath, SubprocessRunner, TOMLValue
 
     # The validated ``[build-system]`` table.
     BuildSystemTable = TypedDict(
@@ -78,6 +59,10 @@ _DEFAULT_BACKEND: BuildSystemTable = {
     'build-backend': 'setuptools.build_meta:__legacy__',
     'requires': ['setuptools >= 40.8.0'],
 }
+
+
+def _is_list_of_str(value: object) -> TypeGuard[list[str]]:
+    return isinstance(value, list) and all(isinstance(item, str) for item in value)
 
 
 def _find_typo(dictionary: Iterable[str], expected: str) -> None:
@@ -135,7 +120,7 @@ def _parse_build_system_table(pyproject_toml: Mapping[str, TOMLValue]) -> BuildS
         msg = '`requires` is a required property'
         raise BuildSystemTableValidationError(msg)
     requires = build_system['requires']
-    if not isinstance(requires, list) or not all(isinstance(i, str) for i in requires):
+    if not _is_list_of_str(requires):
         msg = '`requires` must be an array of strings'
         raise BuildSystemTableValidationError(msg)
 
@@ -156,7 +141,7 @@ def _parse_build_system_table(pyproject_toml: Mapping[str, TOMLValue]) -> BuildS
             _find_typo(build_system, 'build-backend')
 
     match build_system:
-        case {'backend-path': list() as backend_path} if all(isinstance(i, str) for i in backend_path):
+        case {'backend-path': backend_path} if _is_list_of_str(backend_path):
             table['backend-path'] = backend_path
         case {'backend-path': _}:
             msg = '`backend-path` must be an array of strings'

--- a/src/build/_types.py
+++ b/src/build/_types.py
@@ -1,16 +1,35 @@
 from __future__ import annotations
 
 import collections.abc
+import datetime
 import os
 import typing
 
 
-__all__ = ['ConfigSettings', 'Distribution', 'StrPath', 'SubprocessRunner']
+__all__ = ['ConfigSettings', 'Distribution', 'JSONValue', 'StrPath', 'SubprocessRunner', 'TOMLValue']
 
 ConfigSettings = collections.abc.Mapping[str, str | collections.abc.Sequence[str]]
 Distribution = typing.Literal['sdist', 'wheel', 'editable']
 
 StrPath = str | os.PathLike[str]
+
+# A decoded JSON value, as produced by ``json.load``. Uses the covariant ``Sequence``/``Mapping``
+# so concrete literals (e.g. ``str | list[str]``) are also assignable to it.
+JSONValue = str | int | float | bool | None | collections.abc.Sequence['JSONValue'] | collections.abc.Mapping[str, 'JSONValue']
+
+# A value as produced by ``tomllib`` when parsing ``pyproject.toml``. Uses the covariant
+# ``Sequence``/``Mapping`` so concrete literals (e.g. ``dict[str, list[str]]``) are assignable.
+TOMLValue = (
+    str
+    | int
+    | float
+    | bool
+    | datetime.datetime
+    | datetime.date
+    | datetime.time
+    | collections.abc.Sequence['TOMLValue']
+    | collections.abc.Mapping[str, 'TOMLValue']
+)
 
 TYPE_CHECKING = False
 

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -77,7 +77,7 @@ class IsolatedEnv(typing.Protocol):
 
 
 def _has_dependency(
-    name: str, minimum_version_str: str | None = None, /, **distargs: list[str]
+    name: str, minimum_version_str: str | None = None, /, **distargs: object
 ) -> importlib_metadata.Distribution | None:
     """
     Given a distribution name, see if it is present and return the distribution

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,7 +16,7 @@ import unittest.mock
 import venv
 import zipfile
 
-from collections.abc import Callable, Iterator, Mapping, Sequence
+from collections.abc import Callable, Iterator
 from typing import TYPE_CHECKING, Protocol, TypedDict
 
 import pytest
@@ -33,9 +33,7 @@ from build._compat import importlib as _importlib
 if TYPE_CHECKING:
     from conftest import SubTests
 
-
-class CapturedRunner(Protocol):
-    def __call__(self, cmd: Sequence[str], cwd: str | None = ..., extra_environ: Mapping[str, str] | None = ...) -> None: ...
+    from build._types import SubprocessRunner
 
 
 pytestmark = pytest.mark.contextvars
@@ -1003,10 +1001,10 @@ def test_build_metadata_runner_without_extra_environ(
     tmp_path: pathlib.Path,
     package_test_setuptools: str,
 ) -> None:
-    captured_runners: list[CapturedRunner] = []
+    captured_runners: list[SubprocessRunner] = []
 
     @contextlib.contextmanager
-    def fake_bootstrap(*_args: object, runner: CapturedRunner, **_kwargs: object) -> Iterator[unittest.mock.MagicMock]:
+    def fake_bootstrap(*_args: object, runner: SubprocessRunner, **_kwargs: object) -> Iterator[unittest.mock.MagicMock]:
         captured_runners.append(runner)
         builder = mocker.MagicMock()
         metadata_dir = tmp_path / 'metadata'

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -27,7 +27,8 @@ from build._compat import importlib as _importlib
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from build._builder import BuildSystemTable, TOMLValue
+    from build._builder import BuildSystemTable
+    from build._types import TOMLValue
 
 
 build_open_owner = 'builtins'


### PR DESCRIPTION
Since @layday asked for an agent to address comments, here's an agent addressing the comments. :)

(and a handwritten followup comment with an improvement)

:robot: _AI text below_ :robot:

Applies the unresolved review comments from #1093 (merged before they were addressed):

- Move the `JSONValue` and `TOMLValue` aliases into `build._types`.
- Rename `_Args` to `_CliArgs`.
- Collapse the versioned `typing_extensions`/`typing` import in `_builder.py` into a single `typing_extensions` import (the block is only seen by type checkers).
- Loosen `**distargs` in `env.py` from `list[str]` to `object`.
- Reuse the `SubprocessRunner` type in `tests/test_main.py` instead of the duplicate `CapturedRunner` protocol.
- Add a `_is_list_of_str` `TypeGuard` helper so the `requires`/`backend-path` validation both raises and narrows with one shared check.