### PR TITLE
chore: faster mypy, fix merge error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ typing = [
   { include-group = "extra" },
 ]
 mypy = [
-  "mypy ~= 2.1.0",
+  "mypy ~= 2.3.0",
   { include-group = "typing" },
 ]
 release = [
@@ -196,6 +196,7 @@ filterwarnings = [
 files = ["src", "tests", "tasks", "docs"]
 exclude = ["tests/packages"]
 python_version = "3.10"
+native_parser = true
 strict = true
 disallow_any_explicit = true
 disallow_any_decorated = true

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -47,6 +47,9 @@ def resolve_version(version_str: str, repo: Repo) -> Version:
             parts = [parts[0], parts[1] + 1, 0]
         case 'patch':
             parts[2] += 1
+        case bt:
+            msg = f'Invalid bump type {bt!r}'
+            raise AssertionError(msg)
     return Version('.'.join(str(p) for p in parts))
 
 


### PR DESCRIPTION
## Description

* Fix merge error - #1151 and #1153 together without a rebase cause a finding in the scripts. Which was an issue, an unrecongised bump type fell through instead of erroring.
* Bump mypy
* Use the faster new parser, since it's becoming the default soon (and is 29% faster for us uncached)

<!-- Describe what changes you made and why -->

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

None needed.

- [ ] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing `` Add custom backend support - by :user:`yourname`  ``

## Checklist

- [ ] Tests pass locally (`tox`)
- [x] Code follows project style (`tox -e fix`)
- [x] Type checks pass (`tox -e type`)
- [ ] Documentation builds (`tox -e docs`)
