### PR TITLE
Revert "⚠️ feat(util): deprecate project_wheel_metadata"

### DIFF
--- a/src/build/util.py
+++ b/src/build/util.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 
-__lazy_modules__ = [f'{__spec__.parent}._compat', f'{__spec__.parent}.env', 'pathlib', 'tempfile', 'warnings']
+__lazy_modules__ = [f'{__spec__.parent}._compat', f'{__spec__.parent}.env', 'pathlib', 'tempfile']
 
 import pathlib
 import tempfile
-import warnings
 
 import pyproject_hooks
 
@@ -41,20 +40,13 @@ def project_wheel_metadata(
     Uses the ``prepare_metadata_for_build_wheel`` hook if available,
     otherwise ``build_wheel``.
 
-    .. deprecated:: 1.5.0
-       Generate metadata with the ``python -m build --metadata`` command instead.
-
     :param source_dir: Project source directory
     :param isolated: Whether or not to run invoke the backend in the current
                      environment or to create an isolated one and invoke it
                      there.
     :param runner: An alternative runner for backend subprocesses
     """
-    warnings.warn(
-        'project_wheel_metadata is deprecated; generate metadata with the `python -m build --metadata` command instead',
-        DeprecationWarning,
-        stacklevel=2,
-    )
+
     if isolated:
         with DefaultIsolatedEnv() as env:
             builder = ProjectBuilder.from_isolated_env(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -12,9 +12,6 @@ import pytest_mock
 import build.util
 
 
-pytestmark = pytest.mark.filterwarnings('ignore:project_wheel_metadata is deprecated:DeprecationWarning')
-
-
 @pytest.mark.pypy3323bug
 @pytest.mark.parametrize('isolated', [False, pytest.param(True, marks=[pytest.mark.network, pytest.mark.isolated])])
 def test_wheel_metadata(package_test_setuptools: str, isolated: bool) -> None:
@@ -77,11 +74,3 @@ def test_project_wheel_metadata_installs_build_requires_fresh(mocker: pytest_moc
         mocker.call({'dep1'}, _fresh=True),
         mocker.call({'dep2'}),
     ]
-
-
-def test_project_wheel_metadata_is_deprecated(mocker: pytest_mock.MockerFixture) -> None:
-    result = mocker.patch('build.util._project_wheel_metadata')
-    mocker.patch('build.util.ProjectBuilder')
-
-    with pytest.warns(DeprecationWarning, match=r'python -m build --metadata'):
-        assert build.util.project_wheel_metadata('/tmp/project', isolated=False) is result.return_value


### PR DESCRIPTION
Reverts pypa/build#1084. Per the plan in #1131, my idea is:

* Revert this (undeprecate) in 1.6.0
* Add a replacement in 1.6.0 (or later)
* Reapply this in a later release so there's a released way to avoid it.

People are depending on this, and we need to be sure the replacement is usable.
