### PR TITLE
🔧 build(type): run mypy, ty, pyrefly, pyright and gate type coverage

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,5 +14,5 @@
 
 - [ ] Tests pass locally (`tox`)
 - [ ] Code follows project style (`tox -e fix`)
-- [ ] Type checks pass (`tox -e type`)
+- [ ] Type checks pass (`tox -m type`)
 - [ ] Documentation builds (`tox -e docs`)

--- a/.github/workflows/reusable-type.yml
+++ b/.github/workflows/reusable-type.yml
@@ -4,11 +4,22 @@ on:
 permissions: {}
 jobs:
   type:
-    name: Type check
+    name: Type check with ${{ matrix.checker }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - checker: mypy
+            env: type
+          - checker: ty
+            env: ty
+          - checker: pyrefly
+            env: pyrefly
     env:
       PY_COLORS: 1
       TOX_PARALLEL_NO_SPINNER: 1
+      TOX_ENV: ${{ matrix.env }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -20,6 +31,6 @@ jobs:
       - name: Install tox
         run: python -m pip install tox
       - name: Setup run environment
-        run: tox -vv --notest -e type
+        run: tox -vv --notest -e "$TOX_ENV"
       - name: Run check for type
-        run: tox -e type --skip-pkg-install
+        run: tox -e "$TOX_ENV" --skip-pkg-install

--- a/.github/workflows/reusable-type.yml
+++ b/.github/workflows/reusable-type.yml
@@ -16,6 +16,8 @@ jobs:
             env: ty
           - checker: pyrefly
             env: pyrefly
+          - checker: pyright
+            env: pyright
     env:
       PY_COLORS: 1
       TOX_PARALLEL_NO_SPINNER: 1

--- a/docs/changelog/1159.misc.rst
+++ b/docs/changelog/1159.misc.rst
@@ -1,2 +1,2 @@
-Type check with ``ty``, ``pyrefly`` and ``pyright`` alongside ``mypy``, and verify the public API is fully typed with
-``pyrefly coverage check`` and ``pyright --verifytypes`` - by :user:`gaborbernat`.
+Type check with ``ty``, ``pyrefly`` and ``pyright`` alongside ``mypy``, require full type coverage with ``pyrefly
+coverage check`` and verify the public API is complete with ``pyright --verifytypes`` - by :user:`gaborbernat`.

--- a/docs/changelog/1159.misc.rst
+++ b/docs/changelog/1159.misc.rst
@@ -1,0 +1,1 @@
+Type check with ``pyrefly`` and ``ty`` alongside ``mypy``.

--- a/docs/changelog/1159.misc.rst
+++ b/docs/changelog/1159.misc.rst
@@ -1,1 +1,2 @@
-Type check with ``pyrefly`` and ``ty`` alongside ``mypy``.
+Type check with ``ty``, ``pyrefly`` and ``pyright`` alongside ``mypy``, and verify the public API is fully typed with
+``pyrefly coverage check`` and ``pyright --verifytypes`` - by :user:`gaborbernat`.

--- a/docs/development/contributing.rst
+++ b/docs/development/contributing.rst
@@ -45,7 +45,7 @@ Due to its nature, ``build`` has a somewhat complex test suite with two sets of 
 Unit tests verify the actual code implementation, while integration tests run build on real world projects as a sanity
 check. To run tests we use ``tox``.
 
-Some example commands for this project include running type checking with ``tox -e type``, running only unit tests
+Some example commands for this project include running type checking with ``tox -m type``, running only unit tests
 against Python 3.14 with ``tox run -e 3.14``, running both unit and integration tests with ``tox run --
 --run-integration``, running only integration tests with ``tox run -- --only-integration``, or running only integration
 tests with parallel tasks using ``tox run -- -n auto --only-integration``.
@@ -76,7 +76,7 @@ minimum versions of dependencies. For type checking,
 
 .. code-block:: console
 
-    tox -e type
+    tox -m type
 
 Code coverage is tracked to ensure all code paths are tested. Aim for complete coverage of any new code you add. The CI
 system will report coverage metrics on your pull request and runs the test suite across all supported operating systems.

--- a/docs/development/contributing.rst
+++ b/docs/development/contributing.rst
@@ -73,8 +73,8 @@ and with the module being invoked directly from path, sdist install, or wheel in
 
 Additionally, there are environments for type checking and documentation building, plus extras like checking code with
 minimum versions of dependencies. Type checking runs ``mypy``, ``ty``, ``pyrefly`` and ``pyright`` so the annotations
-hold up under whichever checker a downstream project uses; ``pyrefly`` and ``pyright`` also verify that every symbol in
-the public API is fully typed. To run them all,
+hold up under whichever checker a downstream project uses; ``pyrefly`` also requires every symbol in the package to be
+fully typed and ``pyright`` verifies the public API is complete. To run them all,
 
 .. code-block:: console
 

--- a/docs/development/contributing.rst
+++ b/docs/development/contributing.rst
@@ -72,11 +72,15 @@ and with the module being invoked directly from path, sdist install, or wheel in
 and with the module being invoked directly from path, sdist install, or wheel install.
 
 Additionally, there are environments for type checking and documentation building, plus extras like checking code with
-minimum versions of dependencies. For type checking,
+minimum versions of dependencies. Type checking runs ``mypy``, ``ty``, ``pyrefly`` and ``pyright`` so the annotations
+hold up under whichever checker a downstream project uses; ``pyrefly`` and ``pyright`` also verify that every symbol in
+the public API is fully typed. To run them all,
 
 .. code-block:: console
 
     tox -m type
+
+or a single one, for example ``tox -e pyright``.
 
 Code coverage is tracked to ensure all code paths are tested. Aim for complete coverage of any new code you add. The CI
 system will report coverage metrics on your pull request and runs the test suite across all supported operating systems.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,6 +251,10 @@ ignore-missing-imports = ["virtualenv"]  # optional dependency
 [tool.pyrefly.errors]
 # `@override` needs typing_extensions before 3.12; build takes no runtime deps for typing
 missing-override-decorator = false
+# warnings under the strict preset; promoted so an unhandled `Literal` member or an unguarded `NotRequired` key
+# fails the run (https://github.com/pypa/build/pull/1159#issuecomment-5294522232)
+non-exhaustive-match = true
+not-required-key-access = true
 
 [tool.pyright]
 include = ["src", "tests", "tasks", "docs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,14 @@ mypy = [
   "mypy ~= 2.3.0",
   { include-group = "typing" },
 ]
+pyrefly = [
+  "pyrefly >= 1.2",
+  { include-group = "typing" },
+]
+ty = [
+  "ty >= 0.0.69",
+  { include-group = "typing" },
+]
 release = [
   "docstrfmt == 2.2.0", # keep in sync with the docstrfmt rev in .pre-commit-config.yaml
   "gitpython >= 3.1.44",
@@ -131,6 +139,8 @@ dev = [
   "flit-core",
   { include-group = "test" },
   { include-group = "mypy" },
+  { include-group = "pyrefly" },
+  { include-group = "ty" },
 ]
 
 [tool.flit.sdist]
@@ -224,6 +234,29 @@ module = [
   "virtualenv", # Optional dependency
 ]
 ignore_missing_imports = true
+
+[tool.pyrefly]
+project-includes = ["src", "tests", "tasks", "docs"]
+project-excludes = ["**/tests/packages*"]
+search-path = ["src", "tests"]
+python-version = "3.10"
+preset = "strict"
+ignore-missing-imports = ["virtualenv"]  # optional dependency
+
+[tool.pyrefly.errors]
+# `@override` needs typing_extensions before 3.12; build takes no runtime deps for typing
+missing-override-decorator = false
+
+[tool.ty]
+environment.python-version = "3.10"
+
+[tool.ty.src]
+exclude = ["tests/packages"]
+
+[tool.ty.rules]
+all = "error"
+# `@override` needs typing_extensions before 3.12; build takes no runtime deps for typing
+missing-override-decorator = "ignore"
 
 [tool.ruff]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,10 @@ pyrefly = [
   "pyrefly >= 1.2",
   { include-group = "typing" },
 ]
+pyright = [
+  "pyright >= 1.1.408",
+  { include-group = "typing" },
+]
 ty = [
   "ty >= 0.0.69",
   { include-group = "typing" },
@@ -140,6 +144,7 @@ dev = [
   { include-group = "test" },
   { include-group = "mypy" },
   { include-group = "pyrefly" },
+  { include-group = "pyright" },
   { include-group = "ty" },
 ]
 
@@ -246,6 +251,12 @@ ignore-missing-imports = ["virtualenv"]  # optional dependency
 [tool.pyrefly.errors]
 # `@override` needs typing_extensions before 3.12; build takes no runtime deps for typing
 missing-override-decorator = false
+
+[tool.pyright]
+include = ["src", "tests", "tasks", "docs"]
+exclude = ["tests/packages"]
+pythonVersion = "3.10"
+reportMissingModuleSource = false # optional dependencies without stubs
 
 [tool.ty]
 environment.python-version = "3.10"

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 
 
 __lazy_modules__ = [
-    f'{__spec__.parent}._builder',
-    f'{__spec__.parent}._exceptions',
-    f'{__spec__.parent}._types',
-    f'{__spec__.parent}._util',
+    f'{__spec__.parent}._builder',  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017
+    f'{__spec__.parent}._exceptions',  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017
+    f'{__spec__.parent}._types',  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017
+    f'{__spec__.parent}._util',  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017
 ]
 
 from ._builder import ProjectBuilder

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -5,7 +5,7 @@ build - A simple, correct Python build frontend
 from __future__ import annotations
 
 
-__lazy_modules__ = [
+__lazy_modules__: list[str] = [
     f'{__spec__.parent}._builder',  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017
     f'{__spec__.parent}._exceptions',  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017
     f'{__spec__.parent}._types',  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -174,7 +174,7 @@ def _make_logger() -> _ctx.Logger:
 
 
 def _setup_cli(*, verbosity: int) -> None:
-    warnings.showwarning = _showwarning
+    warnings.showwarning = _showwarning  # ty: ignore[invalid-assignment]  # https://github.com/astral-sh/ty/issues/3962
 
     if platform.system() == 'Windows':
         try:
@@ -186,7 +186,7 @@ def _setup_cli(*, verbosity: int) -> None:
 
     _init_colors()
 
-    _ctx.LOGGER.set(_make_logger())
+    _ctx.LOGGER.set(_make_logger())  # ty: ignore[invalid-argument-type]  # https://github.com/astral-sh/ty/issues/4257
     _ctx.VERBOSITY.set(verbosity)
 
 
@@ -841,13 +841,17 @@ def _select_build(
             'pass --wheel to build a wheel from the sdist (see https://github.com/pypa/build/issues/311)'
         )
     if args.metadata:
-        return partial(_build_metadata, distributions=['wheel'])
+        return partial(_build_metadata, distributions=['wheel'])  # ty: ignore[invalid-argument-type]  # https://github.com/astral-sh/ty/issues/1536
     if sdist_input:
         distributions: list[Distribution] = args.distributions or ['wheel']
         return partial(build_package, distributions=distributions)
     if args.distributions:
         return partial(build_package, distributions=args.distributions)
-    return partial(build_package_via_sdist, distributions=['wheel'], sdist_extract_dir=args.sdist_extract_dir)
+    return partial(
+        build_package_via_sdist,
+        distributions=['wheel'],  # ty: ignore[invalid-argument-type]  # https://github.com/astral-sh/ty/issues/1536
+        sdist_extract_dir=args.sdist_extract_dir,
+    )
 
 
 def _validate_sdist_archive(archive: StrPath) -> str:

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-__lazy_modules__ = [
+__lazy_modules__: list[str] = [
     'argparse',
     'build._compat',
     'build._compat.tarfile',
@@ -186,7 +186,7 @@ def _setup_cli(*, verbosity: int) -> None:
 
     _init_colors()
 
-    _ctx.LOGGER.set(_make_logger())  # ty: ignore[invalid-argument-type]  # https://github.com/astral-sh/ty/issues/4257
+    _ctx.LOGGER.set(_make_logger())
     _ctx.VERBOSITY.set(verbosity)
 
 

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-__lazy_modules__ = [
+__lazy_modules__: list[str] = [
     'contextlib',
     'difflib',
     f'{__spec__.parent}._compat',  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 __lazy_modules__ = [
     'contextlib',
     'difflib',
-    f'{__spec__.parent}._compat',
-    f'{__spec__.parent}._exceptions',
-    f'{__spec__.parent}._util',
+    f'{__spec__.parent}._compat',  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017
+    f'{__spec__.parent}._exceptions',  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017
+    f'{__spec__.parent}._util',  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017
     'os',
     'pyproject_hooks',
     'subprocess',

--- a/src/build/_compat/tarfile.py
+++ b/src/build/_compat/tarfile.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 
-__lazy_modules__ = [
+__lazy_modules__: list[str] = [
     'pathlib',
     'tarfile',
 ]

--- a/src/build/_compat/tomllib.py
+++ b/src/build/_compat/tomllib.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 
-__lazy_modules__ = ['tomli', 'tomllib']
+__lazy_modules__: list[str] = ['tomli', 'tomllib']
 
 import sys
 

--- a/src/build/_ctx.py
+++ b/src/build/_ctx.py
@@ -21,7 +21,7 @@ class Logger(typing.Protocol):  # pragma: no cover
     def __call__(self, message: str, *, kind: tuple[str, ...] | None = None) -> None: ...
 
 
-_package_name = __spec__.parent
+_package_name = __spec__.parent  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017
 _default_logger = logging.getLogger(_package_name)
 
 

--- a/src/build/_ctx.py
+++ b/src/build/_ctx.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 
-__lazy_modules__ = ['subprocess']
+__lazy_modules__: list[str] = ['subprocess']
 
 import contextvars
 import logging
@@ -30,8 +30,8 @@ def _log_default(message: str, *, kind: tuple[str, ...] | None = None) -> None: 
     _default_logger.log(logging.INFO, message, stacklevel=2)
 
 
-LOGGER = contextvars.ContextVar('LOGGER', default=_log_default)
-VERBOSITY = contextvars.ContextVar('VERBOSITY', default=0)
+LOGGER: contextvars.ContextVar[Logger] = contextvars.ContextVar('LOGGER', default=_log_default)
+VERBOSITY: contextvars.ContextVar[int] = contextvars.ContextVar('VERBOSITY', default=0)
 
 
 def log_subprocess_error(error: subprocess.CalledProcessError) -> None:

--- a/src/build/_exceptions.py
+++ b/src/build/_exceptions.py
@@ -7,6 +7,8 @@ if TYPE_CHECKING:
     import subprocess
     import types
 
+    ExcInfo = tuple[type[BaseException], BaseException, types.TracebackType] | tuple[None, None, None]
+
 
 class BuildException(Exception):
     """
@@ -23,15 +25,11 @@ class BuildBackendException(Exception):
         self,
         exception: Exception,
         description: str | None = None,
-        exc_info: tuple[type[BaseException], BaseException, types.TracebackType] | tuple[None, None, None] = (
-            None,
-            None,
-            None,
-        ),
+        exc_info: ExcInfo = (None, None, None),
     ) -> None:
         super().__init__()
-        self.exception = exception
-        self.exc_info = exc_info
+        self.exception: Exception = exception
+        self.exc_info: ExcInfo = exc_info
         self._description = description
 
     def __str__(self) -> str:
@@ -56,7 +54,7 @@ class FailedProcessError(Exception):
 
     def __init__(self, exception: subprocess.CalledProcessError, description: str) -> None:
         super().__init__()
-        self.exception = exception
+        self.exception: subprocess.CalledProcessError = exception
         self._description = description
 
     def __str__(self) -> str:

--- a/src/build/_types.py
+++ b/src/build/_types.py
@@ -15,11 +15,13 @@ StrPath = str | os.PathLike[str]
 
 # A decoded JSON value, as produced by ``json.load``. Uses the covariant ``Sequence``/``Mapping``
 # so concrete literals (e.g. ``str | list[str]``) are also assignable to it.
-JSONValue = str | int | float | bool | None | collections.abc.Sequence['JSONValue'] | collections.abc.Mapping[str, 'JSONValue']
+JSONValue: typing.TypeAlias = (
+    str | int | float | bool | collections.abc.Sequence['JSONValue'] | collections.abc.Mapping[str, 'JSONValue'] | None
+)
 
 # A value as produced by ``tomllib`` when parsing ``pyproject.toml``. Uses the covariant
 # ``Sequence``/``Mapping`` so concrete literals (e.g. ``dict[str, list[str]]``) are assignable.
-TOMLValue = (
+TOMLValue: typing.TypeAlias = (
     str
     | int
     | float

--- a/src/build/_util.py
+++ b/src/build/_util.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 
-__lazy_modules__ = [
+__lazy_modules__: list[str] = [
     f'{__spec__.parent}._compat',  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017
     'packaging',
     'packaging.requirements',

--- a/src/build/_util.py
+++ b/src/build/_util.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 
 __lazy_modules__ = [
-    f'{__spec__.parent}._compat',
+    f'{__spec__.parent}._compat',  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017
     'packaging',
     'packaging.requirements',
 ]

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 
-__lazy_modules__ = [
+__lazy_modules__: list[str] = [
     'abc',
     'contextlib',
     f'{__spec__.parent}._compat.importlib',  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017
@@ -60,7 +60,7 @@ if TYPE_CHECKING:
 
 Installer = typing.Literal['pip', 'uv']
 
-INSTALLERS = typing.get_args(Installer)
+INSTALLERS: tuple[Installer, ...] = typing.get_args(Installer)
 
 
 class IsolatedEnv(typing.Protocol):

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 __lazy_modules__ = [
     'abc',
     'contextlib',
-    f'{__spec__.parent}._compat.importlib',
-    f'{__spec__.parent}._ctx',
-    f'{__spec__.parent}._exceptions',
-    f'{__spec__.parent}._util',
+    f'{__spec__.parent}._compat.importlib',  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017
+    f'{__spec__.parent}._ctx',  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017
+    f'{__spec__.parent}._exceptions',  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017
+    f'{__spec__.parent}._util',  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017
     'importlib',
     'importlib.util',
     'os',

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 
-__lazy_modules__ = [f'{__spec__.parent}._compat', f'{__spec__.parent}.env', 'pathlib', 'tempfile']
+__lazy_modules__ = [
+    f'{__spec__.parent}._compat',  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017
+    f'{__spec__.parent}.env',  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017
+    'pathlib',
+    'tempfile',
+]
 
 import pathlib
 import tempfile
@@ -23,7 +28,9 @@ if TYPE_CHECKING:
 def _project_wheel_metadata(builder: ProjectBuilder) -> importlib.metadata.PackageMetadata:
     with tempfile.TemporaryDirectory() as tmpdir:
         path = pathlib.Path(builder.metadata_path(tmpdir))
-        metadata = importlib.metadata.PathDistribution(path).metadata
+        metadata = importlib.metadata.PathDistribution(
+            path,  # ty: ignore[invalid-argument-type]  # pyrefly: ignore[bad-argument-type]  # https://github.com/python/importlib_metadata/issues/542
+        ).metadata
         assert metadata is not None
         return metadata
 

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-__lazy_modules__ = [
+__lazy_modules__: list[str] = [
     f'{__spec__.parent}._compat',  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017
     f'{__spec__.parent}.env',  # ty: ignore[unresolved-attribute]  # https://github.com/astral-sh/ty/issues/4017
     'pathlib',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
         elif config.getoption('--only-integration'):  # pragma: no cover
             item.add_marker(skip_other)
     # run integration tests after unit tests
-    items.sort(key=lambda i: 1 if is_integration(i) else 0)
+    items.sort(key=is_integration)
 
 
 def _xfail_isolated_strict(item: pytest.Item, *, is_integration_file: bool) -> bool:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -44,7 +44,8 @@ def test_make_extra_environ_overrides_pythonpath() -> None:
 
 def test_installed_versions(mocker: pytest_mock.MockerFixture) -> None:
     env = build.env.DefaultIsolatedEnv()
-    env._env_backend = SimpleNamespace(purelib='/purelib')
+    # _env_backend is created lazily in __enter__, so it is absent on a fresh env
+    mocker.patch.object(env, '_env_backend', SimpleNamespace(purelib='/purelib'), create=True)
     distributions = mocker.patch(
         'build._compat.importlib.metadata.distributions',
         return_value=[

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -925,7 +925,8 @@ def test_log_dependency_versions(mocker: pytest_mock.MockerFixture) -> None:
 
 def test_log_dependency_versions_none(mocker: pytest_mock.MockerFixture) -> None:
     env = mocker.create_autospec(build.env.DefaultIsolatedEnv, instance=True)
-    env.installed_versions.return_value = {}
+    installed: dict[str, str] = {}
+    env.installed_versions.return_value = installed
     log = mocker.patch('build.__main__._ctx.log')
 
     build.__main__._log_dependency_versions(env, set())

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -313,7 +313,7 @@ def test_check_dependencies(
 
     builder = build.ProjectBuilder(package_test_flit)
 
-    side_effects = [
+    side_effects: list[list[str] | type[pyproject_hooks.BackendUnavailable]] = [
         [],
         ['something'],
         pyproject_hooks.BackendUnavailable,
@@ -576,7 +576,7 @@ def test_metadata_path_no_prepare(tmp_dir: str, package_test_no_prepare: str) ->
     builder = build.ProjectBuilder(package_test_no_prepare)
 
     metadata = _importlib.metadata.PathDistribution(
-        pathlib.Path(builder.metadata_path(tmp_dir)),
+        pathlib.Path(builder.metadata_path(tmp_dir)),  # ty: ignore[invalid-argument-type]  # pyrefly: ignore[bad-argument-type]  # https://github.com/python/importlib_metadata/issues/542
     ).metadata
     assert metadata is not None
 
@@ -588,7 +588,7 @@ def test_metadata_path_with_prepare(tmp_dir: str, package_test_setuptools: str) 
     builder = build.ProjectBuilder(package_test_setuptools)
 
     metadata = _importlib.metadata.PathDistribution(
-        pathlib.Path(builder.metadata_path(tmp_dir)),
+        pathlib.Path(builder.metadata_path(tmp_dir)),  # ty: ignore[invalid-argument-type]  # pyrefly: ignore[bad-argument-type]  # https://github.com/python/importlib_metadata/issues/542
     ).metadata
     assert metadata is not None
 
@@ -601,7 +601,7 @@ def test_metadata_path_legacy(tmp_dir: str, package_legacy: str) -> None:
     builder = build.ProjectBuilder(package_legacy)
 
     metadata = _importlib.metadata.PathDistribution(
-        pathlib.Path(builder.metadata_path(tmp_dir)),
+        pathlib.Path(builder.metadata_path(tmp_dir)),  # ty: ignore[invalid-argument-type]  # pyrefly: ignore[bad-argument-type]  # https://github.com/python/importlib_metadata/issues/542
     ).metadata
     assert metadata is not None
 
@@ -760,11 +760,19 @@ def test_parse_invalid_build_system_table_type(pyproject_toml: Mapping[str, TOML
         build._builder._parse_build_system_table(pyproject_toml)
 
 
+def _no_backend_path(_tmp_path: pathlib.Path) -> None:
+    return None
+
+
+def _backend_path_as_file(tmp_path: pathlib.Path) -> None:
+    (tmp_path / 'bad').write_text('', encoding='utf-8')
+
+
 @pytest.mark.parametrize(
     'setup',
     [
-        pytest.param(lambda _tmp_path: None, id='nonexistent'),
-        pytest.param(lambda tmp_path: (tmp_path / 'bad').write_text('', encoding='utf-8'), id='file-not-dir'),
+        pytest.param(_no_backend_path, id='nonexistent'),
+        pytest.param(_backend_path_as_file, id='file-not-dir'),
     ],
 )
 def test_backend_path_invalid_directory(tmp_path: pathlib.Path, setup: Callable[[pathlib.Path], None]) -> None:

--- a/tox.toml
+++ b/tox.toml
@@ -72,7 +72,7 @@ description = "run pyrefly type checks and public API type coverage"
 set_env = { PYTHONWARNDEFAULTENCODING = "" }
 commands = [
     ["pyrefly", "check", { replace = "posargs", extend = true }],
-    ["pyrefly", "coverage", "check", "--public-only", "--strict", "src/build"],
+    ["pyrefly", "coverage", "check", "--strict", "--fail-under", "100", "src/build"],
 ]
 dependency_groups = ["pyrefly"]
 

--- a/tox.toml
+++ b/tox.toml
@@ -2,6 +2,8 @@ requires = ["tox-uv>=1.28"]
 env_list = [
     "fix",
     "type",
+    "ty",
+    "pyrefly",
     "docs",
     "path",
     { product = [{ prefix = "3.", start = 10, stop = 15 }]},
@@ -10,6 +12,9 @@ env_list = [
     { product = [{ prefix = "min-pypy3.", start = 10, stop = 11 }]},
 ]
 skip_missing_interpreters = true
+
+[labels]
+type = ["type", "ty", "pyrefly"]
 
 [env_run_base]
 description = "run test suite with {basepython}"
@@ -47,11 +52,25 @@ commands = [
 ]
 dependency_groups = ["lint"]
 
+[env.ty]
+description = "run ty type checks"
+set_env = { PYTHONWARNDEFAULTENCODING = "" }
+commands = [
+    ["ty", "check", "--output-format", "concise", "--error-on-warning", { replace = "posargs", default = ["."], extend = true }],
+]
+dependency_groups = ["ty"]
+
 [env.type]
-description = "run type check on code base"
+description = "run mypy type checks"
 set_env = { PYTHONWARNDEFAULTENCODING = "" }
 commands = [["mypy", { replace = "posargs", extend = true }]]
 dependency_groups = ["mypy"]
+
+[env.pyrefly]
+description = "run pyrefly type checks"
+set_env = { PYTHONWARNDEFAULTENCODING = "" }
+commands = [["pyrefly", "check", { replace = "posargs", extend = true }]]
+dependency_groups = ["pyrefly"]
 
 [env.docs]
 description = "build documentations"

--- a/tox.toml
+++ b/tox.toml
@@ -4,6 +4,7 @@ env_list = [
     "type",
     "ty",
     "pyrefly",
+    "pyright",
     "docs",
     "path",
     { product = [{ prefix = "3.", start = 10, stop = 15 }]},
@@ -14,7 +15,7 @@ env_list = [
 skip_missing_interpreters = true
 
 [labels]
-type = ["type", "ty", "pyrefly"]
+type = ["type", "ty", "pyrefly", "pyright"]
 
 [env_run_base]
 description = "run test suite with {basepython}"
@@ -67,10 +68,22 @@ commands = [["mypy", { replace = "posargs", extend = true }]]
 dependency_groups = ["mypy"]
 
 [env.pyrefly]
-description = "run pyrefly type checks"
+description = "run pyrefly type checks and public API type coverage"
 set_env = { PYTHONWARNDEFAULTENCODING = "" }
-commands = [["pyrefly", "check", { replace = "posargs", extend = true }]]
+commands = [
+    ["pyrefly", "check", { replace = "posargs", extend = true }],
+    ["pyrefly", "coverage", "check", "--public-only", "--strict", "src/build"],
+]
 dependency_groups = ["pyrefly"]
+
+[env.pyright]
+description = "run pyright type checks and public API type completeness"
+set_env = { PYTHONWARNDEFAULTENCODING = "" }
+commands = [
+    ["pyright", { replace = "posargs", extend = true }],
+    ["pyright", "--verifytypes", "build", "--ignoreexternal"],
+]
+dependency_groups = ["pyright"]
 
 [env.docs]
 description = "build documentations"


### PR DESCRIPTION
Supersedes #1135 and #1136, per the review discussion there. mypy stays and ty, pyrefly and pyright join it. 🔧 Each checker accepts annotations the others reject, users run each of them against build's public API (pyright most of all, through Pylance), and in the two closed PRs each caught defects the others missed, so checking with all four keeps the annotations correct for each audience.

The review here made a second point. Downstream users need a fully typed public API, and which internal annotations each checker tolerates matters less. 🔍 Two gates enforce that. `pyright --verifytypes build --ignoreexternal` runs against the installed package and fails when an exported symbol has an unknown or ambiguous type, and `pyrefly coverage check --strict --fail-under 100 src/build` requires an annotation on each symbol in the package. On `main` both report gaps (`__lazy_modules__`, the `_ctx` context variables, `env.INSTALLERS` and the exception attributes are unannotated); the annotations that fix them also make one ty suppression unnecessary.

Each checker gets its own tox environment and CI job. mypy keeps the historical `type` environment, `ty`, `pyrefly` and `pyright` are new, and the `type` label (`tox -m type`) runs all four. The mypy setup carries over unchanged and pyright passes in standard mode with no suppressions. Where ty has an open defect the code carries an inline suppression linking the upstream issue instead of a runtime workaround, which drops the `__spec__` guards the #1135 review objected to: [`__spec__` narrowing](https://github.com/astral-sh/ty/issues/4017), [callable-attribute assignment](https://github.com/astral-sh/ty/issues/3962) and [`functools.partial` support](https://github.com/astral-sh/ty/issues/1536), filed while writing this. Reading wheel metadata trips [python/importlib_metadata#542](https://github.com/python/importlib_metadata/issues/542) under both ty and pyrefly. pyrefly runs its `strict` preset because since 1.2 the `all` preset reports around 300 findings here, in bulk unused call results and implicit bool conversions that ruff polices.
