### PR TITLE
Drop redundant `exc_info` parameter from backend exception wrapper

### DIFF
--- a/docs/changelog/1161.removal.rst
+++ b/docs/changelog/1161.removal.rst
@@ -1,0 +1,1 @@
+Remove ``exc_info`` parameter and attribute from ``BuildBackendException``. - by :user:`layday`

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -297,11 +297,11 @@ def _handle_build_error(*, env_dir: str | None, sdist_extract_dir: StrPath | Non
             _cprint('{yellow}TIP{reset} {}', hint, file=sys.stderr)
             _error(str(e))
 
-        if e.exc_info[0] is not None:
-            tb_lines = traceback.format_exception(e.exc_info[0], e.exc_info[1], e.exc_info[2], limit=-1)
-            tb = ''.join(tb_lines)
-        else:  # pragma: no cover
-            tb = traceback.format_exc(limit=-1)
+        inner_exception = e.exception
+        tb_lines = traceback.format_exception(
+            inner_exception.__class__, inner_exception, inner_exception.__traceback__, limit=-1
+        )
+        tb = ''.join(tb_lines)
         _cprint('\n{dim}{}{reset}\n', tb.strip('\n'))
         _cprint('{yellow}TIP{reset} {}', hint, file=sys.stderr)
         _error(str(e))

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -298,9 +298,7 @@ def _handle_build_error(*, env_dir: str | None, sdist_extract_dir: StrPath | Non
             _error(str(e))
 
         inner_exception = e.exception
-        tb_lines = traceback.format_exception(
-            inner_exception.__class__, inner_exception, inner_exception.__traceback__, limit=-1
-        )
+        tb_lines = traceback.format_exception(inner_exception, limit=-1)
         tb = ''.join(tb_lines)
         _cprint('\n{dim}{}{reset}\n', tb.strip('\n'))
         _cprint('{yellow}TIP{reset} {}', hint, file=sys.stderr)

--- a/src/build/_builder.py
+++ b/src/build/_builder.py
@@ -409,12 +409,8 @@ class ProjectBuilder:
         try:
             yield
         except pyproject_hooks.BackendUnavailable as exception:
-            raise BuildBackendException(
-                exception,
-                f"Backend '{self._backend}' is not available.",
-                sys.exc_info(),
-            ) from None
+            raise BuildBackendException(exception, f"Backend '{self._backend}' is not available.") from None
         except subprocess.CalledProcessError as exception:
             raise BuildBackendException(exception, f'Backend subprocess exited when trying to invoke {hook}') from None
         except Exception as exception:
-            raise BuildBackendException(exception, exc_info=sys.exc_info()) from None
+            raise BuildBackendException(exception) from None

--- a/src/build/_exceptions.py
+++ b/src/build/_exceptions.py
@@ -5,7 +5,6 @@ TYPE_CHECKING = False
 
 if TYPE_CHECKING:
     import subprocess
-    import types
 
 
 class BuildException(Exception):
@@ -23,15 +22,9 @@ class BuildBackendException(Exception):
         self,
         exception: Exception,
         description: str | None = None,
-        exc_info: tuple[type[BaseException], BaseException, types.TracebackType] | tuple[None, None, None] = (
-            None,
-            None,
-            None,
-        ),
     ) -> None:
         super().__init__()
         self.exception = exception
-        self.exc_info = exc_info
         self._description = description
 
     def __str__(self) -> str:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -866,10 +866,10 @@ def test_handle_build_error_build_backend_exception(mocker: pytest_mock.MockerFi
     try:
         raise exc
     except ValueError:
-        exc_info = sys.exc_info()
+        pass
 
     with pytest.raises(SystemExit), build.__main__._handle_build_error(env_dir=None, sdist_extract_dir=None):
-        raise build.BuildBackendException(exc, exc_info=exc_info)
+        raise build.BuildBackendException(exc)
 
 
 def test_handle_build_error_prints_debug_tip_on_subprocess_failure(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -862,14 +862,10 @@ def test_entrypoint(mocker: pytest_mock.MockerFixture) -> None:
 def test_handle_build_error_build_backend_exception(mocker: pytest_mock.MockerFixture) -> None:
     mocker.patch('build.__main__._error', side_effect=SystemExit(1))
 
-    exc = ValueError('test error')
-    try:
-        raise exc
-    except ValueError:
-        pass
-
     with pytest.raises(SystemExit), build.__main__._handle_build_error(env_dir=None, sdist_extract_dir=None):
-        raise build.BuildBackendException(exc)
+        raise build.BuildBackendException(
+            ValueError('test error'),
+        )
 
 
 def test_handle_build_error_prints_debug_tip_on_subprocess_failure(


### PR DESCRIPTION
## Description

Drops the `exc_info` parameter from the backend exception wrapper.  I don't recall why we had this originally - possibly for Python 2 compat?

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

- [x] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing `` Add custom backend support - by :user:`yourname`  ``

## Checklist

- [x] Tests pass locally (`tox`)
- [x] Code follows project style (`tox -e fix`)
- [x] Type checks pass (`tox -e type`)
- [x] Documentation builds (`tox -e docs`)
