### PR TITLE
Use stdlib `importlib.metadata` for typing

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,8 +85,6 @@ html_css_files = ['custom.css']
 autoclass_content = 'both'
 
 nitpick_ignore = [
-    # https://github.com/python/importlib_metadata/issues/316
-    ('py:class', 'importlib.metadata._meta.PackageMetadata'),
     ('py:data', 'typing.Union'),
 ]
 

--- a/src/build/_compat/importlib.py
+++ b/src/build/_compat/importlib.py
@@ -6,7 +6,7 @@ import sys
 TYPE_CHECKING = False
 
 if TYPE_CHECKING:
-    import importlib_metadata as metadata
+    from importlib import metadata
 elif sys.version_info >= (3, 10, 2):
     from importlib import metadata  # pragma: no cover
 else:  # pragma: no cover

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -52,10 +52,15 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Collection, Mapping
 
+    from typing_extensions import Unpack
+
     if sys.version_info < (3, 11):
         from typing_extensions import Self
     else:
         from typing import Self
+
+    class _DistArgs(typing.TypedDict, total=False):
+        path: list[str]
 
 
 Installer = typing.Literal['pip', 'uv']
@@ -77,7 +82,7 @@ class IsolatedEnv(typing.Protocol):
 
 
 def _has_dependency(
-    name: str, minimum_version_str: str | None = None, /, **distargs: object
+    name: str, minimum_version_str: str | None = None, /, **distargs: Unpack[_DistArgs]
 ) -> importlib_metadata.Distribution | None:
     """
     Given a distribution name, see if it is present and return the distribution

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -27,6 +27,8 @@ from build._compat import importlib as _importlib
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+    from typing_extensions import Never
+
     from build._builder import BuildSystemTable
     from build._types import TOMLValue
 
@@ -43,7 +45,7 @@ DEFAULT_BACKEND = {
 class MockDistribution(_importlib.metadata.Distribution):
     _metadata: str = ''
 
-    def locate_file(self, path: str | os.PathLike[str]) -> _importlib.metadata.SimplePath:  # pragma: no cover
+    def locate_file(self, path: str | os.PathLike[str]) -> Never:  # pragma: no cover
         raise NotImplementedError
 
     def read_text(self, filename: str) -> str:


### PR DESCRIPTION
## Description

`importlib.metadata` has better types than the PyPI package.

`SimplePath` is not exported before Python 3.15 and is only used in a test fixture.

I don't think a changelog entry is necessary for this.

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

- [ ] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing `` Add custom backend support - by :user:`yourname`  ``

## Checklist

- [x] Tests pass locally (`tox`)
- [x] Code follows project style (`tox -e fix`)
- [x] Type checks pass (`tox -e type`)
- [x] Documentation builds (`tox -e docs`)
