### PR TITLE
🔧 chore: batch dependency updates weekly on Tuesday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "tuesday"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Every project I maintain now checks for dependency updates on the same day, so the batched pull requests arrive together instead of scattered across the week. 🔁

Bumps already land grouped here; this moves the run to weekly on Tuesday.
