### PR TITLE
docs: fix changelog page heading levels and sidebar

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,8 @@ repos:
       - id: docstrfmt
         args: ["-l", "120"]
         additional_dependencies: ["sphinx>=9.1"]
+        # title must outrank the included CHANGELOG.rst headings
+        exclude: ^docs/changelog\.rst$
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: aab412d509121cb5f7533134b7e67f9fab59c682 # frozen: v0.16.4
     hooks:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,1 +1,5 @@
+===========
+ Changelog
+===========
+
 .. include:: ../CHANGELOG.rst


### PR DESCRIPTION
## Description

Fix up the display of the changelog; now just a normal entry, the ToC is now nested properly (first entry was raised a level before due to docstrfmt rewriting it). 

<!-- Describe what changes you made and why -->

## Changelog

<!-- All PRs should include a changelog fragment in docs/changelog/ -->

None needed.

- [ ] Added changelog fragment: `docs/changelog/<pr_number>.<type>.rst`
  - Types: `feature`, `bugfix`, `doc`, `removal`, `misc`
  - Example: `123.feature.rst` containing `` Add custom backend support - by :user:`yourname`  ``

## Checklist

- [ ] Tests pass locally (`tox`)
- [ ] Code follows project style (`tox -e fix`)
- [ ] Type checks pass (`tox -e type`)
- [x] Documentation builds (`tox -e docs`)
