### PR TITLE
fix: always use copies for the isolated venv on Windows

### DIFF
--- a/docs/changelog/1175.bugfix.rst
+++ b/docs/changelog/1175.bugfix.rst
@@ -1,0 +1,1 @@
+Avoid trying to detect symlinks on Windows, regression in 1.6.0 - by :user:`henryiii` (:issue:`1175`)

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -66,6 +66,9 @@ Installer = typing.Literal['pip', 'uv']
 
 INSTALLERS: tuple[Installer, ...] = typing.get_args(Installer)
 
+# Match the ``venv`` CLI default. Symlinked interpreters on Windows can fail, see #1175.
+_USE_SYMLINKS = os.name != 'nt'
+
 
 class IsolatedEnv(typing.Protocol):
     """Isolated build environment ABC."""
@@ -361,7 +364,7 @@ class _PipBackend(_EnvBackend):
             with_pip = not self._has_valid_outer_pip
 
             try:
-                venv.EnvBuilder(symlinks=_fs_supports_symlink(), with_pip=with_pip).create(path)
+                venv.EnvBuilder(symlinks=_USE_SYMLINKS, with_pip=with_pip).create(path)
             except subprocess.CalledProcessError as exc:
                 _ctx.log_subprocess_error(exc)
                 raise FailedProcessError(exc, 'Failed to create venv. Maybe try installing virtualenv.') from None
@@ -455,7 +458,7 @@ class _UvBackend(_EnvBackend):
             _ctx.log(f'Using external uv from {uv_bin}')
             self._uv_bin = uv_bin
 
-        venv.EnvBuilder(symlinks=_fs_supports_symlink(), with_pip=False).create(self._env_path)
+        venv.EnvBuilder(symlinks=_USE_SYMLINKS, with_pip=False).create(self._env_path)
         self.python_executable, self.scripts_dir, self.purelib = _find_executable_and_scripts(self._env_path)
 
     def install_dependencies(  # pragma: no cover -- uv tests are skipped on PyPy, covered on CPython
@@ -484,24 +487,6 @@ class _UvBackend(_EnvBackend):
     @property
     def display_name(self) -> str:
         return 'venv+uv'
-
-
-@functools.cache
-def _fs_supports_symlink() -> bool:
-    """Return True if symlinks are supported"""
-    # Using definition used by venv.main()
-    if os.name != 'nt':
-        return True  # pragma: win32 no cover
-
-    # Windows may support symlinks (setting in Windows 10)
-    with tempfile.NamedTemporaryFile(prefix='build-symlink-') as tmp_file:  # pragma: win32 cover
-        dest = f'{tmp_file.name}-b'
-        try:
-            os.symlink(tmp_file.name, dest)
-            os.unlink(dest)
-        except (OSError, NotImplementedError, AttributeError):
-            return False
-        return True
 
 
 def _find_executable_and_scripts(path: str) -> tuple[str, str, str]:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -212,62 +212,6 @@ def test_pip_needs_upgrade_mac_os_11(
             )
 
 
-@pytest.mark.parametrize('has_symlink', [True, False] if sys.platform.startswith('win') else [True])
-def test_venv_symlink(
-    mocker: pytest_mock.MockerFixture,
-    has_symlink: bool,
-) -> None:
-    if has_symlink:
-        mocker.patch('os.symlink')
-        mocker.patch('os.unlink')
-    else:  # pragma: win32 cover
-        mocker.patch('os.symlink', side_effect=OSError())
-
-    # Cache must be cleared to rerun
-    build.env._fs_supports_symlink.cache_clear()
-    supports_symlink = build.env._fs_supports_symlink()
-    build.env._fs_supports_symlink.cache_clear()
-
-    assert supports_symlink is has_symlink
-
-
-def test_fs_supports_symlink_windows_dest_is_tmp_file_path(
-    mocker: pytest_mock.MockerFixture,
-) -> None:
-    """Regression test for the Windows-only branch of ``_fs_supports_symlink``.
-
-    ``dest`` must be built from ``tmp_file.name``, not from the ``NamedTemporaryFile`` object itself: interpolating the
-    object yields its repr (containing ``<`` and ``>``, which are invalid in Windows filenames), so ``os.symlink`` would
-    always fail and the function would always report symlinks as unsupported, even when Windows Developer Mode enables
-    them.
-
-    """
-    mocker.patch('os.name', 'nt')
-
-    # Avoid exercising the real tempfile module: on some platforms tempfile's own
-    # internals branch on os.name, which we're patching to 'nt' above.
-    fake_tmp_file = mocker.MagicMock()
-    fake_tmp_file.name = r'C:\Users\test\AppData\Local\Temp\build-symlink-abc123'
-    fake_tmp_file.__enter__.return_value = fake_tmp_file
-    fake_tmp_file.__exit__.return_value = False
-    mocker.patch('build.env.tempfile.NamedTemporaryFile', return_value=fake_tmp_file)
-
-    recorded_dest = {}
-
-    def fake_symlink(_src: str, dst: str) -> None:
-        recorded_dest['dst'] = dst
-
-    mocker.patch('os.symlink', side_effect=fake_symlink)
-    mocker.patch('os.unlink')
-
-    build.env._fs_supports_symlink.cache_clear()
-    supports_symlink = build.env._fs_supports_symlink()
-    build.env._fs_supports_symlink.cache_clear()
-
-    assert supports_symlink is True
-    assert recorded_dest['dst'] == f'{fake_tmp_file.name}-b'
-
-
 def test_install_short_circuits(
     mocker: pytest_mock.MockerFixture,
 ) -> None:


### PR DESCRIPTION
The broken probe fixed in #1118 (1.6.0, broken previously) wasn't actually supposed to be there; `python -m venv` doesn't check for symlink support. Even if symlinks are supported, python don't always work symlinked on Windows. This PR removes the check.

Fixes #1175.

:robot: _AI text below_ :robot:



Version 1.6.0 fixed the symlink probe in #1118. Before that fix the probe always failed on Windows, so every isolated environment was built from copies. After the fix, GitHub Windows runners report symlink support, and `venv` started to symlink `python.exe`. A symlinked interpreter cannot find the DLLs of some Python builds, most visibly conda, and pip fails with `DLL load failed while importing _ssl` / `_ctypes`. Projects such as xgboost, LightGBM, and partcad have pinned `build<1.6` to work around this.

This change removes the probe and hardcodes `symlinks=os.name != 'nt'`, which is the `venv` CLI default and the behavior all releases before 1.6.0 had in practice. The two tests for the probe are removed with it.
