### PR TITLE
ci: support releases from v* branches

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - v*
   push:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -21,7 +21,7 @@ jobs:
   pre-release:
     name: Pre-release
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/v')
     environment: release
     permissions:
       contents: read # to checkout
@@ -31,7 +31,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-          ref: main
+          ref: ${{ github.ref }}
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
@@ -65,6 +65,7 @@ jobs:
         run: |
           gh auth setup-git
           tag=$(git describe --tags --exact-match HEAD)
-          git push --atomic origin HEAD:main "refs/tags/${tag}"
+          git push --atomic origin "HEAD:${BRANCH}" "refs/tags/${tag}"
         env:
           GH_TOKEN: ${{ steps.release-token.outputs.token }}
+          BRANCH: ${{ github.ref_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - main
+      - v*
   pull_request:
     branches:
       - main
+      - v*
   schedule:
     - cron: "0 8 * * 1"
   workflow_dispatch:

--- a/docs/changelog/1178.misc.rst
+++ b/docs/changelog/1178.misc.rst
@@ -1,0 +1,1 @@
+The release workflows now support ``v*`` maintenance branches in addition to ``main``.

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -31,7 +31,7 @@ def main(version_str: str, *, push: bool) -> None:
     tag = tag_release_commit(release_commit, repo, version)
     if push:
         print('push release commit')
-        repo.git.push(remote.name, 'HEAD:main')
+        repo.git.push(remote.name, f'HEAD:{repo.active_branch.name}')
         print('push release tag')
         repo.git.push(remote.name, tag)
     print('All done! ✨ 🍰 ✨')


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The pre-release workflow, the local release script, and the test workflow only accepted `main`. This lets them also run on `v*` maintenance branches:

- `pre-release.yml`: run on `main` or `v*`, check out the dispatched ref, push back to the dispatched branch.
- `tasks/release.py`: push to the current branch instead of `main`.
- `test.yml` and `cd.yml`: trigger on pushes and PRs for `v*` branches.

The `release` and `pypi` GitHub environments need `v*` added to their branch rules before a release from a `v1` branch can run.
