### PR TITLE
fix: honor _fresh installs with the uv installer

### DIFF
--- a/docs/changelog/1179.bugfix.rst
+++ b/docs/changelog/1179.bugfix.rst
@@ -1,0 +1,1 @@
+Honor ``_fresh`` isolated installs when using the uv installer - by :user:`r3wretrhy`

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -473,7 +473,12 @@ class _UvBackend(_EnvBackend):
         if (verbosity := _ctx.verbosity) > 1:
             cmd += [f'-{"v" * min(2, verbosity - 1)}']
 
-        cmd += ['install', *requirements, '--python', self.python_executable]
+        cmd += ['install']
+        if _fresh:
+            # Match pip's ``--ignore-installed`` so CLI / project_wheel_metadata
+            # ``_fresh=True`` (preset PYTHONPATH) actually reinstalls into the env.
+            cmd += ['--reinstall']
+        cmd += [*requirements, '--python', self.python_executable]
 
         if constraints_txt_path:
             cmd += ['-c', str(constraints_txt_path)]

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -298,6 +298,7 @@ def test_uv_impl_install_cmd_well_formed(  # pragma: no cover -- uv tests are sk
                 'pip',
                 *(['-vv' if verbosity > 2 else '-v'] if verbosity > 1 else []),
                 'install',
+                *(['--reinstall'] if fresh else []),
                 'some',
                 'requirements',
                 '--python',


### PR DESCRIPTION
## Description

`--installer uv` ignored `_fresh=True`. Pip maps that flag to `--ignore-installed` so the CLI and `project_wheel_metadata` reinstall build requirements when `PYTHONPATH` is preset. The uv backend accepted `_fresh` but never forwarded it.

Pass `uv pip install --reinstall` in that case, matching pip's behavior.

## Changelog

- [x] Added changelog fragment: `docs/changelog/1179.bugfix.rst`

## Checklist

- [x] Tests pass locally (`uv run pytest tests/test_env.py::test_uv_impl_install_cmd_well_formed tests/test_env.py::test_default_impl_install_cmd_well_formed` — 24 passed)
- [x] Code follows project style (`ruff check` / `ruff format --check`)
