### PR TITLE
Add parsed wheel metadata utility

### DIFF
--- a/docs/changelog/1131.feature.rst
+++ b/docs/changelog/1131.feature.rst
@@ -1,0 +1,1 @@
+Add ``build.util.wheel_metadata`` for programmatic access to parsed wheel metadata - by :user:`GruffElixir`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -86,6 +86,7 @@ autoclass_content = 'both'
 
 nitpick_ignore = [
     ('py:data', 'typing.Union'),
+    ('py:class', 'packaging.metadata.RawMetadata'),
 ]
 
 

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -83,6 +83,15 @@ Getting package metadata without building:
         metadata_dir = builder.metadata_path(tmpdir)
         # Read METADATA file from metadata_dir to extract package info
 
+Getting parsed wheel metadata:
+
+.. code-block:: python
+
+    from build.util import wheel_metadata
+
+    metadata = wheel_metadata("path/to/project")
+    print(metadata["name"], metadata["version"])
+
 Accessing build dependencies:
 
 .. code-block:: python

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 
 __lazy_modules__ = {
+    'packaging.metadata',
     'pathlib',
     'tempfile',
     f'{__spec__.parent}._compat',
@@ -13,6 +14,7 @@ __lazy_modules__ = {
 import pathlib
 import tempfile
 
+import packaging.metadata
 import pyproject_hooks
 
 from . import ProjectBuilder
@@ -31,6 +33,52 @@ def _project_wheel_metadata(builder: ProjectBuilder) -> importlib.metadata.Packa
         metadata = importlib.metadata.PathDistribution(path).metadata
         assert metadata is not None
         return metadata
+
+
+def _wheel_metadata(builder: ProjectBuilder) -> packaging.metadata.RawMetadata:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        metadata_path = pathlib.Path(builder.metadata_path(tmpdir), 'METADATA')
+        raw_metadata = metadata_path.read_bytes()
+
+    metadata, _ = packaging.metadata.parse_email(raw_metadata)
+    return metadata
+
+
+def wheel_metadata(
+    source_dir: StrPath,
+    isolated: bool = True,
+    *,
+    runner: SubprocessRunner = pyproject_hooks.quiet_subprocess_runner,
+) -> packaging.metadata.RawMetadata:
+    """
+    Return a project's wheel metadata as a parsed, JSON-serialisable mapping.
+
+    Uses the ``prepare_metadata_for_build_wheel`` hook if available,
+    otherwise ``build_wheel``, and parses the resulting ``METADATA`` file.
+
+    :param source_dir: Project source directory
+    :param isolated: Whether or not to invoke the backend in the current
+                     environment or to create an isolated one and invoke it
+                     there.
+    :param runner: An alternative runner for backend subprocesses
+    """
+
+    if isolated:
+        with DefaultIsolatedEnv() as env:
+            builder = ProjectBuilder.from_isolated_env(
+                env,
+                source_dir,
+                runner=runner,
+            )
+            env.install(builder.build_system_requires, _fresh=True)
+            env.install(builder.get_requires_for_build('wheel'))
+            return _wheel_metadata(builder)
+    else:
+        builder = ProjectBuilder(
+            source_dir,
+            runner=runner,
+        )
+        return _wheel_metadata(builder)
 
 
 def project_wheel_metadata(
@@ -72,4 +120,5 @@ def project_wheel_metadata(
 
 __all__ = [
     'project_wheel_metadata',
+    'wheel_metadata',
 ]

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 
 __lazy_modules__ = {
+    'packaging',
     'packaging.metadata',
     'pathlib',
     'tempfile',

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import pathlib
 import re
 import unittest.mock
 
@@ -14,12 +15,12 @@ import build.util
 
 @pytest.mark.parametrize('isolated', [False, pytest.param(True, marks=[pytest.mark.network, pytest.mark.isolated])])
 def test_wheel_metadata(package_test_setuptools: str, isolated: bool) -> None:
-    metadata = build.util.project_wheel_metadata(package_test_setuptools, isolated)
+    metadata = build.util.wheel_metadata(package_test_setuptools, isolated)
 
     # Setuptools < v69.0.3 (https://github.com/pypa/setuptools/pull/4159) normalized this to dashes
     assert metadata['name'].replace('-', '_') == 'test_setuptools'
     assert metadata['version'] == '1.0.0'
-    assert isinstance(metadata.json, dict)
+    assert isinstance(metadata, dict)
 
 
 @pytest.mark.network
@@ -27,28 +28,28 @@ def test_wheel_metadata_isolation(package_test_flit: str) -> None:
     if importlib.util.find_spec('flit_core'):
         pytest.xfail('flit_core is available -- we want it missing!')  # pragma: no cover
 
-    metadata = build.util.project_wheel_metadata(package_test_flit)
+    metadata = build.util.wheel_metadata(package_test_flit)
 
     assert metadata['name'] == 'test_flit'
     assert metadata['version'] == '1.0.0'
-    assert isinstance(metadata.json, dict)
+    assert isinstance(metadata, dict)
 
     with pytest.raises(
         build.BuildBackendException,
         match=re.escape("Backend 'flit_core.buildapi' is not available."),
     ):
-        build.util.project_wheel_metadata(package_test_flit, isolated=False)
+        build.util.wheel_metadata(package_test_flit, isolated=False)
 
 
 @pytest.mark.network
 def test_with_get_requires(package_test_metadata: str) -> None:
-    metadata = build.util.project_wheel_metadata(package_test_metadata)
+    metadata = build.util.wheel_metadata(package_test_metadata)
 
     # Setuptools < v69.0.3 (https://github.com/pypa/setuptools/pull/4159) normalized this to dashes
     assert metadata['name'].replace('-', '_') == 'test_metadata'
     assert metadata['version'] == '1.0.0'
     assert metadata['summary'] == 'hello!'
-    assert isinstance(metadata.json, dict)
+    assert isinstance(metadata, dict)
 
 
 def test_project_wheel_metadata_installs_build_requires_fresh(mocker: pytest_mock.MockerFixture) -> None:
@@ -71,3 +72,17 @@ def test_project_wheel_metadata_installs_build_requires_fresh(mocker: pytest_moc
         mocker.call({'dep1'}, _fresh=True),
         mocker.call({'dep2'}),
     ]
+
+
+def test_wheel_metadata_reads_parsed_metadata(tmp_path: pathlib.Path, mocker: pytest_mock.MockerFixture) -> None:
+    builder = mocker.MagicMock()
+    metadata_dir = tmp_path / 'demo-1.0.dist-info'
+    metadata_dir.mkdir()
+    (metadata_dir / 'METADATA').write_bytes(b'Metadata-Version: 2.1\nName: demo\nVersion: 1.0\n')
+    mocker.patch('build.util.ProjectBuilder', return_value=builder)
+    builder.metadata_path.return_value = str(metadata_dir)
+
+    metadata = build.util.wheel_metadata(tmp_path / 'project', isolated=False)
+
+    assert metadata['name'] == 'demo'
+    assert metadata['version'] == '1.0'

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -18,8 +18,8 @@ def test_wheel_metadata(package_test_setuptools: str, isolated: bool) -> None:
     metadata = build.util.wheel_metadata(package_test_setuptools, isolated)
 
     # Setuptools < v69.0.3 (https://github.com/pypa/setuptools/pull/4159) normalized this to dashes
-    assert metadata['name'].replace('-', '_') == 'test_setuptools'
-    assert metadata['version'] == '1.0.0'
+    assert metadata.get('name', '').replace('-', '_') == 'test_setuptools'
+    assert metadata.get('version') == '1.0.0'
     assert isinstance(metadata, dict)
 
 
@@ -30,8 +30,8 @@ def test_wheel_metadata_isolation(package_test_flit: str) -> None:
 
     metadata = build.util.wheel_metadata(package_test_flit)
 
-    assert metadata['name'] == 'test_flit'
-    assert metadata['version'] == '1.0.0'
+    assert metadata.get('name') == 'test_flit'
+    assert metadata.get('version') == '1.0.0'
     assert isinstance(metadata, dict)
 
     with pytest.raises(
@@ -46,9 +46,9 @@ def test_with_get_requires(package_test_metadata: str) -> None:
     metadata = build.util.wheel_metadata(package_test_metadata)
 
     # Setuptools < v69.0.3 (https://github.com/pypa/setuptools/pull/4159) normalized this to dashes
-    assert metadata['name'].replace('-', '_') == 'test_metadata'
-    assert metadata['version'] == '1.0.0'
-    assert metadata['summary'] == 'hello!'
+    assert metadata.get('name', '').replace('-', '_') == 'test_metadata'
+    assert metadata.get('version') == '1.0.0'
+    assert metadata.get('summary') == 'hello!'
     assert isinstance(metadata, dict)
 
 
@@ -74,6 +74,15 @@ def test_project_wheel_metadata_installs_build_requires_fresh(mocker: pytest_moc
     ]
 
 
+def test_project_wheel_metadata_non_isolated(mocker: pytest_mock.MockerFixture) -> None:
+    builder = mocker.MagicMock()
+    metadata = unittest.mock.sentinel.metadata
+    mocker.patch('build.util.ProjectBuilder', return_value=builder)
+    mocker.patch('build.util._project_wheel_metadata', return_value=metadata)
+
+    assert build.util.project_wheel_metadata('/tmp/project', isolated=False) is metadata
+
+
 def test_wheel_metadata_reads_parsed_metadata(tmp_path: pathlib.Path, mocker: pytest_mock.MockerFixture) -> None:
     builder = mocker.MagicMock()
     metadata_dir = tmp_path / 'demo-1.0.dist-info'
@@ -84,5 +93,9 @@ def test_wheel_metadata_reads_parsed_metadata(tmp_path: pathlib.Path, mocker: py
 
     metadata = build.util.wheel_metadata(tmp_path / 'project', isolated=False)
 
-    assert metadata['name'] == 'demo'
-    assert metadata['version'] == '1.0'
+    assert metadata.get('name') == 'demo'
+    assert metadata.get('version') == '1.0'
+
+    legacy_metadata = build.util._project_wheel_metadata(builder)
+    assert legacy_metadata['Name'] == 'demo'
+    assert legacy_metadata['Version'] == '1.0'


### PR DESCRIPTION
## Description

Add `build.util.wheel_metadata` to expose parsed wheel metadata to Python callers while preserving the existing `project_wheel_metadata` helper.

The new utility follows the existing isolated-build path, reads the generated `METADATA` file, and returns the `packaging.metadata.RawMetadata` mapping used by the metadata CLI.

Fixes #1131.

## Changelog

- [x] Added changelog fragment: `docs/changelog/1131.feature.rst`

## Checklist

- [x] Tests pass locally (`python -m pytest -o addopts='' -q tests/test_util.py tests/test_main.py -k metadata`)
- [x] Code follows project style (`python -m ruff check src/build/util.py tests/test_util.py`)
- [x] Formatting checked (`python -m ruff format --check src/build/util.py tests/test_util.py`)
- [x] Diff checked (`git diff --check`)
- [ ] Type checks pass (`tox -e type`)
- [ ] Documentation builds (`tox -e docs`)
